### PR TITLE
Fixed typo

### DIFF
--- a/Midas/valec.py
+++ b/Midas/valec.py
@@ -285,7 +285,7 @@ class ValeCompiler:
                 print(proc.stdout + "\n" + proc.stderr)
                 sys.exit(22)
             else:
-                print(f"Internal error while running {valestrom_files}:\n" + proc.stdout + "\n" + proc.stderr)
+                print(f"Internal error while running {user_valestrom_files}:\n" + proc.stdout + "\n" + proc.stderr)
                 sys.exit(proc.returncode)
 
         elif args[0] == "build":


### PR DESCRIPTION
Fixed typo in valec.py that would cause a crash.