### PR TITLE
Docker Support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+build-linux.sh
+LICENSE
+Dockerfile
+
+.*
+**/*.idea
+**/*.md
+**/*.bat
+**/.gitignore
+**/.git
+**/.DS_Store

--- a/DockerRuntime/.dockerignore
+++ b/DockerRuntime/.dockerignore
@@ -1,0 +1,11 @@
+build-linux.sh
+LICENSE
+Dockerfile
+
+.*
+**/*.idea
+**/*.md
+**/*.bat
+**/.gitignore
+**/.git
+**/.DS_Store

--- a/DockerRuntime/Dockerfile
+++ b/DockerRuntime/Dockerfile
@@ -18,6 +18,6 @@ RUN rm -r BenchmarkRL samples README.txt
 
 COPY entrypoint.sh .
 # Copy user's source code into the docker image
-COPY src/*.vale src/
+COPY src/*.vale src
 
 ENTRYPOINT [ "sh", "entrypoint.sh"]

--- a/DockerRuntime/Dockerfile
+++ b/DockerRuntime/Dockerfile
@@ -18,6 +18,7 @@ RUN rm -r BenchmarkRL samples README.txt
 
 COPY entrypoint.sh .
 # Copy user's source code into the docker image
-COPY src/*.vale src
+# COPY src/*.vale src/
+RUN mkdir src
 
 ENTRYPOINT [ "sh", "entrypoint.sh"]

--- a/DockerRuntime/Dockerfile
+++ b/DockerRuntime/Dockerfile
@@ -8,13 +8,16 @@ RUN apt-get -y upgrade
 RUN apt-get -y install wget unzip
 RUN apt-get -y install python3
 RUN apt-get -y install default-jre
+RUN apt-get -y install clang
 
 # Download/extract Vale Compiler
 RUN wget https://vale.dev/releases/ValeCompiler-0.1.2.2-Linux.zip
 RUN unzip ValeCompiler-0.1.2.2-Linux.zip -d . && rm ValeCompiler-0.1.2.2-Linux.zip
-
 # Remove unneeded files
 RUN rm -r BenchmarkRL samples README.txt 
 
-ENTRYPOINT [ "python3", "/vale/valec.py", "build" ]
-# todo: log output to /var/log/vale/run.log
+COPY entrypoint.sh .
+# Copy user's source code into the docker image
+COPY src/*.vale src/
+
+ENTRYPOINT [ "sh", "entrypoint.sh"]

--- a/DockerRuntime/Dockerfile
+++ b/DockerRuntime/Dockerfile
@@ -1,0 +1,20 @@
+# This docker image is a quick adaptaion of the Vale build-linux.sh script
+FROM ubuntu:20.10
+
+WORKDIR /vale
+
+RUN apt-get update
+RUN apt-get -y upgrade
+RUN apt-get -y install wget unzip
+RUN apt-get -y install python3
+RUN apt-get -y install default-jre
+
+# Download/extract Vale Compiler
+RUN wget https://vale.dev/releases/ValeCompiler-0.1.2.2-Linux.zip
+RUN unzip ValeCompiler-0.1.2.2-Linux.zip -d . && rm ValeCompiler-0.1.2.2-Linux.zip
+
+# Remove unneeded files
+RUN rm -r BenchmarkRL samples README.txt 
+
+ENTRYPOINT [ "python3", "/vale/valec.py", "build" ]
+# todo: log output to /var/log/vale/run.log

--- a/DockerRuntime/Makefile
+++ b/DockerRuntime/Makefile
@@ -6,11 +6,8 @@ build:
 run:
 	@echo Running Vale docker image...
 	@docker stop testVale > /dev/null 2>&1 && docker rm testVale > /dev/null 2>&1 || true
-	@docker run --name testVale -it vale:latest < hello.vale
-
-# If the container exits with an error - copy/cat the log file out. Otherwise just stream the output of the log file to stdout
-# @docker exec testVale tail -f /var/log/vale/run.log 2> /dev/null || docker cp testVale:/var/log/vale/run.log /tmp/vale_run.log && cat /tmp/vale_run.log && rm /tmp/vale_run.log
-
+	@docker run --name testVale -it vale:latest
+	@docker exec testVale tail -f /var/log/vale/run.log 2> /dev/null || docker cp testVale:/var/log/vale/run.log /tmp/vale_run.log && cat /tmp/vale_run.log && rm /tmp/vale_run.log
 
 # Explore a docker container (running or not) - this is useful for debuggin when docker image hits the fan...
 # 1. create image (snapshot) from container filesystem

--- a/DockerRuntime/Makefile
+++ b/DockerRuntime/Makefile
@@ -1,5 +1,6 @@
 build:
 	@echo Building Vale docker image...
+	@docker rm testVale || true
 	@docker rmi vale:latest vale:1.0.0 || true
 	@docker build -t vale:latest -t vale:1.0.0 .
 

--- a/DockerRuntime/Makefile
+++ b/DockerRuntime/Makefile
@@ -3,7 +3,7 @@ build:
 	@docker rmi vale:latest vale:1.0.0 || true
 	@docker build -t vale:latest -t vale:1.0.0 .
 
-run:
+run: build
 	@echo Running Vale docker image...
 	@docker stop testVale > /dev/null 2>&1 && docker rm testVale > /dev/null 2>&1 || true
 	@docker run --name testVale -it vale:latest

--- a/DockerRuntime/Makefile
+++ b/DockerRuntime/Makefile
@@ -4,10 +4,10 @@ build:
 	@docker rmi vale:latest vale:1.0.0 || true
 	@docker build -t vale:latest -t vale:1.0.0 .
 
-run: build
+run:
 	@echo Running Vale docker image...
 	@docker stop testVale > /dev/null 2>&1 && docker rm testVale > /dev/null 2>&1 || true
-	@docker run --name testVale -it vale:latest
+	@docker run --name testVale -v `pwd`/src:/vale/src -it vale:latest
 	@docker exec testVale tail -f /var/log/vale/run.log 2> /dev/null || docker cp testVale:/var/log/vale/run.log /tmp/vale_run.log && cat /tmp/vale_run.log && rm /tmp/vale_run.log
 
 # Explore a docker container (running or not) - this is useful for debuggin when docker image hits the fan...

--- a/DockerRuntime/Makefile
+++ b/DockerRuntime/Makefile
@@ -1,0 +1,23 @@
+build:
+	@echo Building Vale docker image...
+	@docker rmi vale:latest vale:1.0.0 || true
+	@docker build -t vale:latest -t vale:1.0.0 .
+
+run:
+	@echo Running Vale docker image...
+	@docker stop testVale > /dev/null 2>&1 && docker rm testVale > /dev/null 2>&1 || true
+	@docker run --name testVale -it vale:latest < hello.vale
+
+# If the container exits with an error - copy/cat the log file out. Otherwise just stream the output of the log file to stdout
+# @docker exec testVale tail -f /var/log/vale/run.log 2> /dev/null || docker cp testVale:/var/log/vale/run.log /tmp/vale_run.log && cat /tmp/vale_run.log && rm /tmp/vale_run.log
+
+
+# Explore a docker container (running or not) - this is useful for debuggin when docker image hits the fan...
+# 1. create image (snapshot) from container filesystem
+# 2. explore this filesystem using bash (for example)
+# 3. cleanup
+explore:
+	@docker rmi test_vale_snapshot > /dev/null 2>&1 | true
+	@docker commit testVale test_vale_snapshot > /dev/null
+	@docker run --rm -it --entrypoint=/bin/bash test_vale_snapshot
+# @docker run -it --rm test_vale_snapshot && docker rmi test_vale_snapshot

--- a/DockerRuntime/entrypoint.sh
+++ b/DockerRuntime/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Compile Vale
+python3 /vale/valec.py build src/*.vale
+mkdir -p /var/log/vale
+echo "Running code..."
+/vale/a.out > /var/log/vale/run.log 2>/var/log/vale/err.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# This docker image is a quick adaptaion of the Vale build-linux.sh script
+FROM ubuntu:20.10 AS builder
+
+WORKDIR /build
+
+RUN apt-get update
+RUN apt-get -y upgrade
+
+RUN apt-get -y install software-properties-common
+RUN apt-get -y install git gnupg2 cmake curl
+RUN apt-get -y install clang-11
+RUN apt-get -y install zlib1g-dev
+
+# Needed for multiprocessing unit tests later
+RUN apt-get -y install python3-pip
+
+# Add Java repository
+RUN bash -c "curl -s https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -"
+RUN add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+
+# Add SBT repository
+RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
+RUN curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add
+
+RUN apt-get update
+RUN apt-get install -y adoptopenjdk-11-hotspot
+RUN apt-get install -y sbt
+
+# Copy all of the source into the docker image (except for files mentioned in .dockerignore)
+COPY Valestrom ./Valestrom
+RUN bash -c "cd Valestrom && sbt assembly"
+
+# Install LLVM 11
+# from https://github.com/llvm/llvm-project/releases/tag/llvmorg-11.0.1
+RUN curl -SL https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-20.10.tar.xz \
+ | tar -xJC . && \
+ mv clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-20.10 llvm11
+
+ENV PATH=/build/llvm11/bin:${PATH}’
+ENV LD_LIBRARY_PATH=/build/llvm11/lib:${LD_LIBRARY_PATH}’
+ENV LDFLAGS="-L~/llvm11/lib -Wl,-rpath,~/llvm11/lib"
+ENV CPPFLAGS="-I~/llvm11/include"
+ENV PATH="~/llvm11/bin:${PATH}"
+
+# Copy needed-files from host into docker image
+COPY Midas ./Midas
+COPY scripts/package-unix.sh scripts/
+RUN bash -c "cd Midas && cmake -D CMAKE_CXX_COMPILER=clang++-11 -B build"
+RUN bash -c "cd Midas/build && make"
+RUN bash -c "cd Midas && python3 -m unittest -f -k assist"
+RUN bash -c "cd scripts && ./package-unix.sh"
+# RUN bash -c "cd release-unix && zip -r ValeCompiler.zip *"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+build-linux:
+	@echo Building Vale Compiler for Linux...
+	sh ./build-linux.sh
+
+build-mac:
+	@echo Building Vale Compiler for Mac...
+	sh ./build-mac.sh
+
+build-windows:
+	@echo Building Vale Compiler for Windows...
+	@echo Please read build-windows.md for more information
+
+build-docker:
+	@echo Building Vale Compiler docker image...
+	@docker rmi vale_compilerlatest vale_compiler1.0.0 || true
+	@docker build -t vale_compiler:latest -t vale_compiler1.0.0 .
+
+run-docker:
+	@echo Running Vale docker image...
+	@docker stop testValeCompiler > /dev/null 2>&1 && docker rm testValeCompiler > /dev/null 2>&1 || true
+	@docker run --name testValeCompiler -it vale_compilerlatest
+
+# Explore a docker container (running or not) - this is useful for debuggin when docker image hits the fan...
+# 1. create image (snapshot) from container filesystem
+# 2. explore this filesystem using bash (for example)
+# 3. cleanup
+explore-docker:
+	@docker rmi test_vale_snapshot > /dev/null 2>&1 | true
+	@docker commit testValeCompiler test_vale_snapshot > /dev/null
+	@docker run -it --rm test_vale_snapshot && docker rmi test_vale_snapshot

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ build-windows:
 
 build-docker:
 	@echo Building Vale Compiler docker image...
-	@docker rmi vale_compilerlatest vale_compiler1.0.0 || true
-	@docker build -t vale_compiler:latest -t vale_compiler1.0.0 .
+	@docker rmi vale_compiler:latest vale_compiler:1.0.0 || true
+	@docker build -t vale_compiler:latest -t vale_compiler:1.0.0 .
 
 run-docker:
 	@echo Running Vale docker image...
 	@docker stop testValeCompiler > /dev/null 2>&1 && docker rm testValeCompiler > /dev/null 2>&1 || true
-	@docker run --name testValeCompiler -it vale_compilerlatest
+	@docker run --name testValeCompiler -it vale_compiler:latest
 
 # Explore a docker container (running or not) - this is useful for debuggin when docker image hits the fan...
 # 1. create image (snapshot) from container filesystem


### PR DESCRIPTION
I've added two separate docker files for use with Vale. One for aiding in Vale compiler development, and another useful for experimenting with the Vale language.

Ultimately these docker images are running Ubuntu 20.10 under the hood.

### Dockerfile for Vale compiler development
This is located in the root of the git directory. It'd be nice to organize this differently, but due to file scoping issues (the docker file needs to be in the same directory or above Valestrom/Midas...etc) it has to be in root.

This dockerfile is based on Ubuntu 20.10 - as of right now it completely builds the Vale compiler from scratch (basically runs  build-linux.sh).

Example mac/linux usage (assuming you have docker installed)
```
git clone https://github.com/ValeLang/Vale.git
cd Vale
make build-docker
make run-docker
```
This will then bring you to a console inside the docker, that you can then do as you please. Besides dependencies installed on the OS, everything is located in `/build`.
The compiled compiler is located at `/build/release-unix`.
Typing `exit` will get you out of the docker terminal (and stop the instance).

**Note:** for now this just builds the compiler and leaves it in the docker image...if you want to get the build out of the image, you'll need to use something like `docker cp testValeCompiler:/build/release-unix .` or [mount a volume](https://docs.docker.com/storage/volumes/). This needs to be done from your host machine.

### Dockerfile for experimenting with Valelang
This is located in the `DockerRuntime` folder. Place your `<filename>.vale` files into the `DockerRuntime/src` directory and then use the make file to build/run the docker file. As soon as your vale code is done executing, the docker container is stopped - this is so you can easily inspect the stopped containers file system if needed. If you run `make run` again, it will re-pull the vale files from the host and compile/run them in the container.

In the future I hope this dockerfile can evolve to be used to facilitate a web based Vale playground.

Example Usage
```
git clone https://github.com/ValeLang/Vale.git
cd Vale/DockerRuntime
make build
cd src
# Place your code in this directory
curl -O https://raw.githubusercontent.com/Ivo-Balbaert/Vale_Examples/main/hello_world.vale
cd ..
make run


# Make some code changes to your vale files
make run
```