### PR TITLE
Separated .vast by package, prefixed externs/exports with project name

### DIFF
--- a/Midas/CMakeLists.txt
+++ b/Midas/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4.3)
 project(valec)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -std=c++17")
 
 find_package(LLVM 11.1 REQUIRED CONFIG)
 add_definitions(${LLVM_DEFINITIONS})

--- a/Midas/src/c-compiler/function/expressions/block.cpp
+++ b/Midas/src/c-compiler/function/expressions/block.cpp
@@ -19,7 +19,7 @@ Ref translateBlock(
   auto resultLE =
       translateExpression(globalState, functionState, &childBlockState, builder, block->inner);
 
-  if (block->innerType->referend != globalState->metalCache->never) {
+  if (block->innerType->kind != globalState->metalCache->never) {
     childBlockState.checkAllIntroducedLocalsWereUnstackified();
 
     auto childUnstackifiedParentLocalIds =

--- a/Midas/src/c-compiler/function/expressions/constructunknownsizearray.cpp
+++ b/Midas/src/c-compiler/function/expressions/constructunknownsizearray.cpp
@@ -19,13 +19,13 @@ Ref translateConstructRuntimeSizedArray(
 
   auto generatorType = constructRuntimeSizedArray->generatorType;
   auto generatorExpr = constructRuntimeSizedArray->generatorExpr;
-  auto sizeReferend = constructRuntimeSizedArray->sizeReferend;
+  auto sizeKind = constructRuntimeSizedArray->sizeKind;
   auto sizeExpr = constructRuntimeSizedArray->sizeExpr;
   auto sizeType = constructRuntimeSizedArray->sizeType;
   auto elementType = constructRuntimeSizedArray->elementType;
   auto arrayRefType = constructRuntimeSizedArray->arrayRefType;
 
-  auto runtimeSizedArrayMT = dynamic_cast<RuntimeSizedArrayT*>(constructRuntimeSizedArray->arrayRefType->referend);
+  auto runtimeSizedArrayMT = dynamic_cast<RuntimeSizedArrayT*>(constructRuntimeSizedArray->arrayRefType->kind);
 
   auto sizeRef = translateExpression(globalState, functionState, blockState, builder, sizeExpr);
 

--- a/Midas/src/c-compiler/function/expressions/destructure.cpp
+++ b/Midas/src/c-compiler/function/expressions/destructure.cpp
@@ -25,11 +25,11 @@ Ref translateDestructure(
 
   buildFlare(FL(), globalState, functionState, builder);
 
-  auto structReferend =
-      dynamic_cast<StructReferend *>(destructureM->structType->referend);
-  assert(structReferend);
+  auto structKind =
+      dynamic_cast<StructKind *>(destructureM->structType->kind);
+  assert(structKind);
 
-  auto structM = globalState->program->getStruct(structReferend->fullName);
+  auto structM = globalState->program->getStruct(structKind);
 
   for (int i = 0; i < structM->members.size(); i++) {
     buildFlare(FL(), globalState, functionState, builder);

--- a/Midas/src/c-compiler/function/expressions/discard.cpp
+++ b/Midas/src/c-compiler/function/expressions/discard.cpp
@@ -28,7 +28,7 @@ Ref translateDiscard(
   buildFlare(FL(), globalState, functionState, builder, "discarding!");
   globalState->getRegion(sourceResultType)
       ->dealias(
-          AFL(std::string("Discard ") + std::to_string((int)discardM->sourceResultType->ownership) + " " + typeid(*discardM->sourceResultType->referend).name() + " from " + typeid(*sourceExpr).name()),
+          AFL(std::string("Discard ") + std::to_string((int)discardM->sourceResultType->ownership) + " " + typeid(*discardM->sourceResultType->kind).name() + " from " + typeid(*sourceExpr).name()),
           functionState,
           builder,
           sourceResultType,

--- a/Midas/src/c-compiler/function/expressions/externs.cpp
+++ b/Midas/src/c-compiler/function/expressions/externs.cpp
@@ -217,7 +217,7 @@ Ref buildExternCall(
 
     buildFlare(FL(), globalState, functionState, builder);
 
-    if (prototype->returnType->referend == globalState->metalCache->never) {
+    if (prototype->returnType->kind == globalState->metalCache->never) {
       buildFlare(FL(), globalState, functionState, builder, "Done calling function ", prototype->name->name);
       buildFlare(FL(), globalState, functionState, builder, "Resuming function ", functionState->containingFuncName);
       LLVMBuildRet(builder, LLVMGetUndef(functionState->returnTypeL));

--- a/Midas/src/c-compiler/function/expressions/if.cpp
+++ b/Midas/src/c-compiler/function/expressions/if.cpp
@@ -45,8 +45,8 @@ Ref translateIf(
           FL(), functionState, builder, iff->commonSupertype, resultLE);
 
 
-  bool thenContinues = iff->thenResultType->referend != globalState->metalCache->never;
-  bool elseContinues = iff->elseResultType->referend != globalState->metalCache->never;
+  bool thenContinues = iff->thenResultType->kind != globalState->metalCache->never;
+  bool elseContinues = iff->elseResultType->kind != globalState->metalCache->never;
 
   auto thenUnstackifiedParentLocalIds = thenBlockState.getParentLocalIdsThatSelfUnstackified();
   auto elseUnstackifiedParentLocalIds = elseBlockState.getParentLocalIdsThatSelfUnstackified();

--- a/Midas/src/c-compiler/function/expressions/interfacecall.cpp
+++ b/Midas/src/c-compiler/function/expressions/interfacecall.cpp
@@ -49,7 +49,7 @@ Ref translateInterfaceCall(
   globalState->getRegion(call->functionType->returnType)
       ->checkValidReference(FL(), functionState, builder, call->functionType->returnType, resultLE);
 
-  if (call->functionType->returnType->referend == globalState->metalCache->never) {
+  if (call->functionType->returnType->kind == globalState->metalCache->never) {
     return wrap(
         globalState->getRegion(globalState->metalCache->neverRef),
         globalState->metalCache->neverRef,

--- a/Midas/src/c-compiler/function/expressions/localload.cpp
+++ b/Midas/src/c-compiler/function/expressions/localload.cpp
@@ -22,7 +22,7 @@ Ref translateLocalLoad(
   auto targetLocation = targetOwnership == Ownership::SHARE ? localType->location : Location::YONDER;
   auto resultType =
       globalState->metalCache->getReference(
-          targetOwnership, targetLocation, localType->referend);
+          targetOwnership, targetLocation, localType->kind);
 
   auto localAddr = blockState->getLocalAddr(localId);
 

--- a/Midas/src/c-compiler/function/expressions/newarrayfromvalues.cpp
+++ b/Midas/src/c-compiler/function/expressions/newarrayfromvalues.cpp
@@ -20,18 +20,18 @@ Ref translateNewArrayFromValues(
   auto elementsLE =
       translateExpressions(
           globalState, functionState, blockState, builder, newArrayFromValues->sourceExprs);
-  auto ssaDefM = globalState->program->getStaticSizedArray(newArrayFromValues->arrayReferend->name);
+  auto ssaDefM = globalState->program->getStaticSizedArray(newArrayFromValues->arrayKind);
   for (auto elementLE : elementsLE) {
     globalState->getRegion(ssaDefM->rawArray->elementType)
         ->checkValidReference(
             FL(), functionState, builder, ssaDefM->rawArray->elementType, elementLE);
   }
 
-  auto staticSizedArrayMT = dynamic_cast<StaticSizedArrayT*>(newArrayFromValues->arrayRefType->referend);
+  auto staticSizedArrayMT = dynamic_cast<StaticSizedArrayT*>(newArrayFromValues->arrayRefType->kind);
 
   if (newArrayFromValues->arrayRefType->location == Location::INLINE) {
 //        auto valStructL =
-//            globalState->getInnerStruct(structReferend->fullName);
+//            globalState->getInnerStruct(structKind->fullName);
 //        return constructInnerStruct(
 //            builder, structM, valStructL, membersLE);
     assert(false);
@@ -43,7 +43,7 @@ Ref translateNewArrayFromValues(
             functionState,
             builder,
             newArrayFromValues->arrayRefType,
-            newArrayFromValues->arrayReferend);
+            newArrayFromValues->arrayKind);
     fillStaticSizedArray(
         globalState,
         functionState,

--- a/Midas/src/c-compiler/function/expressions/shared/ref.h
+++ b/Midas/src/c-compiler/function/expressions/shared/ref.h
@@ -21,12 +21,12 @@ struct WrapperPtrLE {
 
 
 struct ControlBlockPtrLE {
-  Referend* const referendM;
+  Kind* const kindM;
   // TODO rename to ptrLE
   LLVMValueRef const refLE;
 
-  ControlBlockPtrLE(Referend* refM_, LLVMValueRef refLE_)
-    : referendM(refM_), refLE(refLE_) { }
+  ControlBlockPtrLE(Kind* refM_, LLVMValueRef refLE_)
+    : kindM(refM_), refLE(refLE_) { }
 };
 
 

--- a/Midas/src/c-compiler/function/expressions/shared/shared.cpp
+++ b/Midas/src/c-compiler/function/expressions/shared/shared.cpp
@@ -58,7 +58,7 @@ LLVMValueRef adjustStrongRc(
     AreaAndFileAndLine from,
     GlobalState* globalState,
     FunctionState* functionState,
-    IReferendStructsSource* referendStructsSource,
+    IKindStructsSource* kindStructsSource,
     LLVMBuilderRef builder,
     Ref exprRef,
     Reference* refM,
@@ -78,8 +78,8 @@ LLVMValueRef adjustStrongRc(
   }
 
   auto controlBlockPtrLE =
-      referendStructsSource->getControlBlockPtr(from, functionState, builder, exprRef, refM);
-  auto rcPtrLE = referendStructsSource->getStrongRcPtrFromControlBlockPtr(builder, refM, controlBlockPtrLE);
+      kindStructsSource->getControlBlockPtr(from, functionState, builder, exprRef, refM);
+  auto rcPtrLE = kindStructsSource->getStrongRcPtrFromControlBlockPtr(builder, refM, controlBlockPtrLE);
 //  auto oldRc = LLVMBuildLoad(builder, rcPtrLE, "oldRc");
   auto newRc = adjustCounter(globalState, builder, rcPtrLE, amount);
 //  flareAdjustStrongRc(from, globalState, functionState, builder, refM, controlBlockPtrLE, oldRc, newRc);
@@ -88,7 +88,7 @@ LLVMValueRef adjustStrongRc(
 
 LLVMValueRef strongRcIsZero(
     GlobalState* globalState,
-    IReferendStructsSource* structs,
+    IKindStructsSource* structs,
     LLVMBuilderRef builder,
     Reference* refM,
     ControlBlockPtrLE controlBlockPtrLE) {
@@ -218,9 +218,9 @@ Ref buildInterfaceCall(
     int virtualParamIndex) {
   auto virtualParamMT = prototype->params[virtualParamIndex];
 
-  auto interfaceReferendM = dynamic_cast<InterfaceReferend*>(virtualParamMT->referend);
-  assert(interfaceReferendM);
-//  int indexInEdge = globalState->getInterfaceMethod(interfaceReferendM, prototype);
+  auto interfaceKindM = dynamic_cast<InterfaceKind*>(virtualParamMT->kind);
+  assert(interfaceKindM);
+//  int indexInEdge = globalState->getInterfaceMethod(interfaceKindM, prototype);
 
   auto virtualArgRef = argRefs[virtualParamIndex];
 
@@ -243,7 +243,7 @@ Ref buildInterfaceCall(
   }
   argsLE[virtualParamIndex] = newVirtualArgLE;
 
-  buildFlare(FL(), globalState, functionState, builder, interfaceReferendM->fullName->name, " ", ptrToIntLE(globalState, builder, methodFunctionPtrLE));
+  buildFlare(FL(), globalState, functionState, builder, interfaceKindM->fullName->name, " ", ptrToIntLE(globalState, builder, methodFunctionPtrLE));
 
 //  assert(LLVMGetTypeKind(LLVMTypeOf(itablePtrLE)) == LLVMPointerTypeKind);
 //  auto funcPtrPtrLE =
@@ -337,7 +337,7 @@ Ref buildCall(
   auto resultRef = wrap(globalState->getRegion(prototype->returnType), prototype->returnType, resultLE);
   globalState->getRegion(prototype->returnType)->checkValidReference(FL(), functionState, builder, prototype->returnType, resultRef);
 
-  if (prototype->returnType->referend == globalState->metalCache->never) {
+  if (prototype->returnType->kind == globalState->metalCache->never) {
     buildFlare(FL(), globalState, functionState, builder, "Done calling function ", prototype->name->name);
     buildFlare(FL(), globalState, functionState, builder, "Resuming function ", functionState->containingFuncName);
     LLVMBuildRet(builder, LLVMGetUndef(functionState->returnTypeL));

--- a/Midas/src/c-compiler/function/expressions/shared/shared.h
+++ b/Midas/src/c-compiler/function/expressions/shared/shared.h
@@ -41,7 +41,7 @@ LLVMValueRef adjustStrongRc(
     AreaAndFileAndLine from,
     GlobalState* globalState,
     FunctionState* functionState,
-    IReferendStructsSource* referendStructsSource,
+    IKindStructsSource* kindStructsSource,
     LLVMBuilderRef builder,
     Ref exprLE,
     Reference* refM,
@@ -49,7 +49,7 @@ LLVMValueRef adjustStrongRc(
 
 LLVMValueRef strongRcIsZero(
     GlobalState* globalState,
-    IReferendStructsSource* structs,
+    IKindStructsSource* structs,
     LLVMBuilderRef builder,
     Reference* refM,
     ControlBlockPtrLE exprLE);

--- a/Midas/src/c-compiler/function/expressions/staticarrayfromcallable.cpp
+++ b/Midas/src/c-compiler/function/expressions/staticarrayfromcallable.cpp
@@ -21,9 +21,9 @@ Ref translateStaticArrayFromCallable(
   auto generatorExpr = staticArrayFromCallable->generatorExpr;
   auto elementType = staticArrayFromCallable->elementType;
   auto arrayRefType = staticArrayFromCallable->arrayRefType;
-  auto staticSizedArrayMT = dynamic_cast<StaticSizedArrayT*>(staticArrayFromCallable->arrayRefType->referend);
+  auto staticSizedArrayMT = dynamic_cast<StaticSizedArrayT*>(staticArrayFromCallable->arrayRefType->kind);
 
-  auto ssaDefMT = globalState->program->getStaticSizedArray(staticSizedArrayMT->name);
+  auto ssaDefMT = globalState->program->getStaticSizedArray(staticSizedArrayMT);
   auto sizeRef = globalState->constI64(ssaDefMT->size);
 
   auto generatorRef = translateExpression(globalState, functionState, blockState, builder, generatorExpr);
@@ -33,7 +33,7 @@ Ref translateStaticArrayFromCallable(
   std::unique_ptr<Ref> result;
   if (staticArrayFromCallable->arrayRefType->location == Location::INLINE) {
 //        auto valStructL =
-//            globalState->getInnerStruct(structReferend->fullName);
+//            globalState->getInnerStruct(structKind->fullName);
 //        return constructInnerStruct(
 //            builder, structM, valStructL, membersLE);
     assert(false);

--- a/Midas/src/c-compiler/function/function.cpp
+++ b/Midas/src/c-compiler/function/function.cpp
@@ -10,8 +10,7 @@
 
 LLVMValueRef declareFunction(
     GlobalState* globalState,
-    Function* functionM,
-    bool skipExporting) {
+    Function* functionM) {
 
   auto valeParamTypesL = translateTypes(globalState, functionM->prototype->params);
   auto valeReturnTypeL =
@@ -27,79 +26,78 @@ LLVMValueRef declareFunction(
   assert(globalState->functions.count(functionM->prototype->name->name) == 0);
   globalState->functions.emplace(functionM->prototype->name->name, valeFunctionL);
 
-  if (!skipExporting && globalState->program->isExported(functionM->prototype->name)) {
-    std::vector<LLVMTypeRef> exportParamTypesL;
-    for (auto valeRefMT : functionM->prototype->params) {
-      auto hostRefMT = globalState->getRegion(valeRefMT)->getExternalType(valeRefMT);
-      exportParamTypesL.push_back(globalState->getRegion(hostRefMT)->translateType(hostRefMT));
-    }
-    auto hostReturnRefMT =
-        globalState->getRegion(functionM->prototype->returnType)
-            ->getExternalType(functionM->prototype->returnType);
-    LLVMTypeRef exportReturnTypeL =
-        globalState->getRegion(hostReturnRefMT)->translateType(hostReturnRefMT);
-
-    LLVMTypeRef exportFunctionTypeL =
-        LLVMFunctionType(exportReturnTypeL, exportParamTypesL.data(), exportParamTypesL.size(), 0);
-
-    for (auto exportName : globalState->program->getExportedNames(functionM->prototype->name)) {
-      // The full name should end in _0, _1, etc. The exported name shouldnt.
-      assert(exportName != functionM->prototype->name->name);
-      // This is a thunk function that correctly aliases the objects that come in from the
-      // outside world, and dealiases the object that we're returning to the outside world.
-      LLVMValueRef exportFunctionL = LLVMAddFunction(globalState->mod, exportName.c_str(), exportFunctionTypeL);
-
-      LLVMBasicBlockRef block = LLVMAppendBasicBlockInContext(globalState->context, exportFunctionL, "entry");
-      LLVMBuilderRef builder = LLVMCreateBuilderInContext(globalState->context);
-      LLVMPositionBuilderAtEnd(builder, block);
-      // This is unusual because normally we have a separate localsBuilder which points to a separate
-      // block at the beginning. This is a simple function which should require no locals, so this
-      // should be fine.
-      LLVMBuilderRef localsBuilder = builder;
-
-      FunctionState functionState(exportName, exportFunctionL, exportReturnTypeL, localsBuilder);
-      BlockState initialBlockState(globalState->addressNumberer, nullptr);
-
-      std::vector<Ref> argsToActualFunction;
-
-      for (int i = 0; i < functionM->prototype->params.size(); i++) {
-        auto valeParamMT = functionM->prototype->params[i];
-        auto hostParamMT =
-            (valeParamMT->ownership == Ownership::SHARE ?
-                globalState->linearRegion->linearizeReference(valeParamMT) :
-                valeParamMT);
-        auto hostArgRefLE = LLVMGetParam(exportFunctionL, i);
-
-        auto valeRef =
-            sendHostObjectIntoVale(
-                globalState, &functionState, builder, hostParamMT, valeParamMT, hostArgRefLE);
-
-        argsToActualFunction.push_back(valeRef);
-      }
-
-      auto valeReturnRefOrVoid = buildCall(globalState, &functionState, builder, functionM->prototype, argsToActualFunction);
-      auto valeReturnRef =
-          (functionM->prototype->returnType == globalState->metalCache->emptyTupleStructRef ?
-              makeEmptyTupleRef(globalState) :
-              valeReturnRefOrVoid);
-
-      auto valeReturnMT = functionM->prototype->returnType;
-      auto hostReturnMT =
-          (valeReturnMT->ownership == Ownership::SHARE ?
-              globalState->linearRegion->linearizeReference(valeReturnMT) :
-              valeReturnMT);
-
-      auto hostReturnRefLE =
-          sendValeObjectIntoHost(
-              globalState, &functionState, builder, valeReturnMT, hostReturnMT, valeReturnRef);
-      LLVMBuildRet(builder, hostReturnRefLE);
-
-      LLVMDisposeBuilder(builder);
-    }
-  }
-
   return valeFunctionL;
 }
+
+void exportFunction(GlobalState* globalState, Package* package, Function* functionM, std::string exportName) {
+  std::vector<LLVMTypeRef> exportParamTypesL;
+  for (auto valeRefMT : functionM->prototype->params) {
+    auto hostRefMT = globalState->getRegion(valeRefMT)->getExternalType(valeRefMT);
+    exportParamTypesL.push_back(globalState->getRegion(hostRefMT)->translateType(hostRefMT));
+  }
+  auto hostReturnRefMT =
+      globalState->getRegion(functionM->prototype->returnType)
+          ->getExternalType(functionM->prototype->returnType);
+  LLVMTypeRef exportReturnTypeL =
+      globalState->getRegion(hostReturnRefMT)->translateType(hostReturnRefMT);
+
+  LLVMTypeRef exportFunctionTypeL =
+      LLVMFunctionType(exportReturnTypeL, exportParamTypesL.data(), exportParamTypesL.size(), 0);
+
+  // The full name should end in _0, _1, etc. The exported name shouldnt.
+  assert(exportName != functionM->prototype->name->name);
+  // This is a thunk function that correctly aliases the objects that come in from the
+  // outside world, and dealiases the object that we're returning to the outside world.
+  LLVMValueRef exportFunctionL = LLVMAddFunction(globalState->mod, exportName.c_str(), exportFunctionTypeL);
+
+  LLVMBasicBlockRef block = LLVMAppendBasicBlockInContext(globalState->context, exportFunctionL, "entry");
+  LLVMBuilderRef builder = LLVMCreateBuilderInContext(globalState->context);
+  LLVMPositionBuilderAtEnd(builder, block);
+  // This is unusual because normally we have a separate localsBuilder which points to a separate
+  // block at the beginning. This is a simple function which should require no locals, so this
+  // should be fine.
+  LLVMBuilderRef localsBuilder = builder;
+
+  FunctionState functionState(exportName, exportFunctionL, exportReturnTypeL, localsBuilder);
+  BlockState initialBlockState(globalState->addressNumberer, nullptr);
+
+  std::vector<Ref> argsToActualFunction;
+
+  for (int i = 0; i < functionM->prototype->params.size(); i++) {
+    auto valeParamMT = functionM->prototype->params[i];
+    auto hostParamMT =
+        (valeParamMT->ownership == Ownership::SHARE ?
+         globalState->linearRegion->linearizeReference(valeParamMT) :
+         valeParamMT);
+    auto hostArgRefLE = LLVMGetParam(exportFunctionL, i);
+
+    auto valeRef =
+        sendHostObjectIntoVale(
+            globalState, &functionState, builder, hostParamMT, valeParamMT, hostArgRefLE);
+
+    argsToActualFunction.push_back(valeRef);
+  }
+
+  auto valeReturnRefOrVoid = buildCall(globalState, &functionState, builder, functionM->prototype, argsToActualFunction);
+  auto valeReturnRef =
+      (functionM->prototype->returnType == globalState->metalCache->emptyTupleStructRef ?
+       makeEmptyTupleRef(globalState) :
+       valeReturnRefOrVoid);
+
+  auto valeReturnMT = functionM->prototype->returnType;
+  auto hostReturnMT =
+      (valeReturnMT->ownership == Ownership::SHARE ?
+       globalState->linearRegion->linearizeReference(valeReturnMT) :
+       valeReturnMT);
+
+  auto hostReturnRefLE =
+      sendValeObjectIntoHost(
+          globalState, &functionState, builder, valeReturnMT, hostReturnMT, valeReturnRef);
+  LLVMBuildRet(builder, hostReturnRefLE);
+
+  LLVMDisposeBuilder(builder);
+}
+
 
 //LLVMTypeRef translateExternType(GlobalState* globalState, Reference* reference) {
 //  if (reference == globalState->metalCache->intRef) {
@@ -114,9 +112,9 @@ LLVMValueRef declareFunction(
 //    return LLVMVoidTypeInContext(globalState->context);
 //  } else if (reference == globalState->metalCache->emptyTupleStructRef) {
 //    return LLVMVoidTypeInContext(globalState->context);
-//  } else if (auto structReferend = dynamic_cast<StructReferend*>(reference->referend)) {
+//  } else if (auto structKind = dynamic_cast<StructKind*>(reference->kind)) {
 //    if (reference->location == Location::INLINE) {
-//      return globalState->getRegion(refHere)->getReferendStructsSource()->getInnerStruct(structReferend);
+//      return globalState->getRegion(refHere)->getKindStructsSource()->getInnerStruct(structKind);
 //    } else {
 //      std::cerr << "Can only pass inline imm structs between C and Vale currently." << std::endl;
 //      assert(false);
@@ -228,7 +226,7 @@ void translateFunction(
 //  // we'll never reach this statement.
 //  // In .ll we can call a noreturn function and then put an unreachable block,
 //  // but I can't figure out how to specify noreturn with the LLVM C API.
-//  if (dynamic_cast<Never*>(functionM->prototype->returnType->referend)) {
+//  if (dynamic_cast<Never*>(functionM->prototype->returnType->kind)) {
 //    LLVMBuildRet(bodyTopLevelBuilder, LLVMGetUndef(region->translateType(functionM->prototype->returnType)));
 //  }
 

--- a/Midas/src/c-compiler/function/function.cpp
+++ b/Midas/src/c-compiler/function/function.cpp
@@ -29,7 +29,7 @@ LLVMValueRef declareFunction(
   return valeFunctionL;
 }
 
-void exportFunction(GlobalState* globalState, Package* package, Function* functionM, std::string exportName) {
+void exportFunction(GlobalState* globalState, Package* package, Function* functionM) {
   std::vector<LLVMTypeRef> exportParamTypesL;
   for (auto valeRefMT : functionM->prototype->params) {
     auto hostRefMT = globalState->getRegion(valeRefMT)->getExternalType(valeRefMT);
@@ -44,6 +44,7 @@ void exportFunction(GlobalState* globalState, Package* package, Function* functi
   LLVMTypeRef exportFunctionTypeL =
       LLVMFunctionType(exportReturnTypeL, exportParamTypesL.data(), exportParamTypesL.size(), 0);
 
+  auto exportName = package->getFunctionExportName(functionM->prototype);
   // The full name should end in _0, _1, etc. The exported name shouldnt.
   assert(exportName != functionM->prototype->name->name);
   // This is a thunk function that correctly aliases the objects that come in from the
@@ -127,6 +128,7 @@ void exportFunction(GlobalState* globalState, Package* package, Function* functi
 
 LLVMValueRef declareExternFunction(
     GlobalState* globalState,
+    Package* package,
     Prototype* prototypeM) {
   std::vector<LLVMTypeRef> paramTypesL;
   for (auto valeParamRefMT : prototypeM->params) {
@@ -145,7 +147,7 @@ LLVMValueRef declareExternFunction(
     returnTypeL = globalState->getRegion(hostRetRefMT)->translateType(hostRetRefMT);
   }
 
-  auto nameL = prototypeM->name->name;
+  auto nameL = package->getFunctionExternName(prototypeM);
 
   LLVMTypeRef functionTypeL =
       LLVMFunctionType(returnTypeL, paramTypesL.data(), paramTypesL.size(), 0);

--- a/Midas/src/c-compiler/function/function.h
+++ b/Midas/src/c-compiler/function/function.h
@@ -151,10 +151,11 @@ LLVMValueRef declareFunction(
     GlobalState* globalState,
     Function* functionM);
 
-void exportFunction(GlobalState* globalState, Package* package, Function* functionM, std::string exportName);
+void exportFunction(GlobalState* globalState, Package* package, Function* functionM);
 
 LLVMValueRef declareExternFunction(
     GlobalState* globalState,
+    Package* package,
     Prototype* prototypeM);
 
 //LLVMTypeRef translateExternType(GlobalState* globalState, Reference* reference);

--- a/Midas/src/c-compiler/function/function.h
+++ b/Midas/src/c-compiler/function/function.h
@@ -149,8 +149,9 @@ void translateFunction(
 
 LLVMValueRef declareFunction(
     GlobalState* globalState,
-    Function* functionM,
-    bool skipExporting);
+    Function* functionM);
+
+void exportFunction(GlobalState* globalState, Package* package, Function* functionM, std::string exportName);
 
 LLVMValueRef declareExternFunction(
     GlobalState* globalState,

--- a/Midas/src/c-compiler/globalstate.cpp
+++ b/Midas/src/c-compiler/globalstate.cpp
@@ -9,24 +9,23 @@
 GlobalState::GlobalState(AddressNumberer* addressNumberer_) :
     addressNumberer(addressNumberer_),
     interfaceTablePtrs(0, addressNumberer->makeHasher<Edge*>()),
-    interfaceExtraMethods(0, addressNumberer->makeHasher<InterfaceReferend*>()),
-    overridesBySubstructByInterface(0, addressNumberer->makeHasher<InterfaceReferend*>()),
+    interfaceExtraMethods(0, addressNumberer->makeHasher<InterfaceKind*>()),
+    overridesBySubstructByInterface(0, addressNumberer->makeHasher<InterfaceKind*>()),
     extraFunctions(0, addressNumberer->makeHasher<Prototype*>()),
     regions(0, addressNumberer->makeHasher<RegionId*>()),
-    regionIdByReferend(0, addressNumberer->makeHasher<Referend*>())
+    regionIdByKind(0, addressNumberer->makeHasher<Kind*>())
 {}
 
-std::vector<LLVMTypeRef> GlobalState::getInterfaceFunctionTypes(InterfaceReferend* referend) {
-  auto interfaceDefMIter = program->interfaces.find(referend->fullName->name);
+std::vector<LLVMTypeRef> GlobalState::getInterfaceFunctionTypes(InterfaceKind* kind) {
   std::vector<LLVMTypeRef> interfaceFunctionsLT;
-  if (interfaceDefMIter != program->interfaces.end()) {
-    auto interfaceDefM = interfaceDefMIter->second;
+  if (auto maybeInterfaceDefM = program->getMaybeInterface(kind)) {
+    auto interfaceDefM = *maybeInterfaceDefM;
     for (auto method : interfaceDefM->methods) {
       auto interfaceFunctionLT = translateInterfaceMethodToFunctionType(this, method);
       interfaceFunctionsLT.push_back(LLVMPointerType(interfaceFunctionLT, 0));
     }
   }
-  for (auto interfaceExtraMethod : interfaceExtraMethods[referend]) {
+  for (auto interfaceExtraMethod : interfaceExtraMethods[kind]) {
     auto interfaceFunctionLT =
         translateInterfaceMethodToFunctionType(this, interfaceExtraMethod);
     interfaceFunctionsLT.push_back(LLVMPointerType(interfaceFunctionLT, 0));
@@ -36,7 +35,7 @@ std::vector<LLVMTypeRef> GlobalState::getInterfaceFunctionTypes(InterfaceReferen
 }
 
 std::vector<LLVMValueRef> GlobalState::getEdgeFunctions(Edge* edge) {
-  auto interfaceM = program->getInterface(edge->interfaceName->fullName);
+  auto interfaceM = program->getInterface(edge->interfaceName);
 
   assert(edge->structPrototypesByInterfaceMethod.size() == interfaceM->methods.size());
 
@@ -85,23 +84,23 @@ std::vector<LLVMValueRef> GlobalState::getEdgeFunctions(Edge* edge) {
 }
 
 IRegion* GlobalState::getRegion(Reference* referenceM) {
-  return getRegion(referenceM->referend);
+  return getRegion(referenceM->kind);
 }
 
-IRegion* GlobalState::getRegion(Referend* referendM) {
-  if (auto innt = dynamic_cast<Int*>(referendM)) {
+IRegion* GlobalState::getRegion(Kind* kindM) {
+  if (auto innt = dynamic_cast<Int*>(kindM)) {
     return getRegion(innt->regionId);
-  } else if (auto boool = dynamic_cast<Bool*>(referendM)) {
+  } else if (auto boool = dynamic_cast<Bool*>(kindM)) {
     return getRegion(boool->regionId);
-  } else if (auto flooat = dynamic_cast<Float*>(referendM)) {
+  } else if (auto flooat = dynamic_cast<Float*>(kindM)) {
     return getRegion(flooat->regionId);
-  } else if (auto never = dynamic_cast<Never*>(referendM)) {
+  } else if (auto never = dynamic_cast<Never*>(kindM)) {
     return getRegion(never->regionId);
-  } else if (auto str = dynamic_cast<Str*>(referendM)) {
+  } else if (auto str = dynamic_cast<Str*>(kindM)) {
     return getRegion(str->regionId);
   } else {
-    auto iter = regionIdByReferend.find(referendM);
-    assert(iter != regionIdByReferend.end());
+    auto iter = regionIdByKind.find(kindM);
+    assert(iter != regionIdByKind.end());
     auto regionId = iter->second;
     return getRegion(regionId);
   }
@@ -162,39 +161,39 @@ Ref GlobalState::constI1(bool b) {
 }
 Ref GlobalState::buildAdd(FunctionState* functionState, LLVMBuilderRef builder, Ref a, Ref b) {
   auto intMT = metalCache->intRef;
-  auto addPrototype = metalCache->getPrototype(metalCache->getName("__addIntInt"), intMT, {intMT, intMT});
+  auto addPrototype = metalCache->getPrototype(metalCache->getName(metalCache->builtinPackageCoord, "__addIntInt"), intMT, {intMT, intMT});
   return buildExternCall(this, functionState, builder, addPrototype, { a, b });
 }
 Ref GlobalState::buildMod(FunctionState* functionState, LLVMBuilderRef builder, Ref a, Ref b) {
   auto intMT = metalCache->intRef;
-  auto addPrototype = metalCache->getPrototype(metalCache->getName("__mod"), intMT, {intMT, intMT});
+  auto addPrototype = metalCache->getPrototype(metalCache->getName(metalCache->builtinPackageCoord, "__mod"), intMT, {intMT, intMT});
   return buildExternCall(this, functionState, builder, addPrototype, { a, b });
 }
 Ref GlobalState::buildDivide(FunctionState* functionState, LLVMBuilderRef builder, Ref a, Ref b) {
   auto intMT = metalCache->intRef;
-  auto addPrototype = metalCache->getPrototype(metalCache->getName("__divideIntInt"), intMT, {intMT, intMT});
+  auto addPrototype = metalCache->getPrototype(metalCache->getName(metalCache->builtinPackageCoord, "__divideIntInt"), intMT, {intMT, intMT});
   return buildExternCall(this, functionState, builder, addPrototype, { a, b });
 }
 
 Ref GlobalState::buildMultiply(FunctionState* functionState, LLVMBuilderRef builder, Ref a, Ref b) {
   auto intMT = metalCache->intRef;
-  auto addPrototype = metalCache->getPrototype(metalCache->getName("__multiplyIntInt"), intMT, {intMT, intMT});
+  auto addPrototype = metalCache->getPrototype(metalCache->getName(metalCache->builtinPackageCoord, "__multiplyIntInt"), intMT, {intMT, intMT});
   return buildExternCall(this, functionState, builder, addPrototype, { a, b });
 }
 
-Name* GlobalState::getReferendName(Referend* referend) {
-  if (auto structReferend = dynamic_cast<StructReferend*>(referend)) {
-    return structReferend->fullName;
-  } else if (auto interfaceReferend = dynamic_cast<InterfaceReferend*>(referend)) {
-    return interfaceReferend->fullName;
-  } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(referend)) {
+Name* GlobalState::getKindName(Kind* kind) {
+  if (auto structKind = dynamic_cast<StructKind*>(kind)) {
+    return structKind->fullName;
+  } else if (auto interfaceKind = dynamic_cast<InterfaceKind*>(kind)) {
+    return interfaceKind->fullName;
+  } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(kind)) {
     return ssaMT->name;
-  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(referend)) {
+  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(kind)) {
     return rsaMT->name;
   } else assert(false);
   return nullptr;
 }
 
-Weakability GlobalState::getReferendWeakability(Referend* referend) {
-  return getRegion(referend)->getReferendWeakability(referend);
+Weakability GlobalState::getKindWeakability(Kind* kind) {
+  return getRegion(kind)->getKindWeakability(kind);
 }

--- a/Midas/src/c-compiler/globalstate.h
+++ b/Midas/src/c-compiler/globalstate.h
@@ -14,7 +14,7 @@
 #include "externs.h"
 
 class IRegion;
-class IReferendStructsSource;
+class IKindStructsSource;
 class IWeakRefStructsSource;
 class ControlBlock;
 class Linear;
@@ -87,38 +87,38 @@ public:
   std::unordered_map<std::string, LLVMValueRef> functions;
   std::unordered_map<std::string, LLVMValueRef> externFunctions;
 
-  // This is temporary, Valestrom should soon embed mutability and region into the referend for us
+  // This is temporary, Valestrom should soon embed mutability and region into the kind for us
   // so we won't have to do this.
-  std::unordered_map<Referend*, RegionId*, AddressHasher<Referend*>> regionIdByReferend;
+  std::unordered_map<Kind*, RegionId*, AddressHasher<Kind*>> regionIdByKind;
 
   // These contain the extra interface methods that Midas adds to particular interfaces.
   // For example, for every immutable, Midas needs to add a serialize() method that
   // adds it to an outgoing linear buffer.
   std::unordered_map<Prototype*, LLVMValueRef, AddressHasher<Prototype*>> extraFunctions;
   std::unordered_map<
-      InterfaceReferend*,
+      InterfaceKind*,
       std::vector<InterfaceMethod*>,
-          AddressHasher<InterfaceReferend*>> interfaceExtraMethods;
+          AddressHasher<InterfaceKind*>> interfaceExtraMethods;
 
   using OverridesBySubstructMap =
       std::unordered_map<
-          StructReferend*,
+          StructKind*,
           std::vector<std::pair<InterfaceMethod*, Prototype*>>,
-          AddressHasher<StructReferend*>>;
+          AddressHasher<StructKind*>>;
   using OverridesBySubstructByInterfaceMap =
       std::unordered_map<
-          InterfaceReferend*,
+          InterfaceKind*,
           OverridesBySubstructMap,
-          AddressHasher<InterfaceReferend*>>;
+          AddressHasher<InterfaceKind*>>;
   OverridesBySubstructByInterfaceMap overridesBySubstructByInterface;
   // This keeps us from adding more edges or interfaces after we've already started compiling them.
   bool interfacesOpen = true;
 
-  void addInterfaceExtraMethod(InterfaceReferend* interfaceReferend, InterfaceMethod* method) {
+  void addInterfaceExtraMethod(InterfaceKind* interfaceKind, InterfaceMethod* method) {
     assert(interfacesOpen);
-    interfaceExtraMethods[interfaceReferend].push_back(method);
+    interfaceExtraMethods[interfaceKind].push_back(method);
   }
-  void addEdgeExtraMethod(InterfaceReferend* interfaceMT, StructReferend* structMT, InterfaceMethod* interfaceMethod, Prototype* function) {
+  void addEdgeExtraMethod(InterfaceKind* interfaceMT, StructKind* structMT, InterfaceMethod* interfaceMethod, Prototype* function) {
     auto interfaceExtraMethodsI = interfaceExtraMethods.find(interfaceMT);
     assert(interfaceExtraMethodsI != interfaceExtraMethods.end());
 
@@ -128,7 +128,7 @@ public:
       iter =
           overridesBySubstructByInterface.emplace(
               interfaceMT,
-              OverridesBySubstructMap{0, addressNumberer->makeHasher<StructReferend*>()})
+              OverridesBySubstructMap{0, addressNumberer->makeHasher<StructKind*>()})
               .first;
     }
     int index = iter->second[structMT].size();
@@ -140,20 +140,20 @@ public:
 //  std::unordered_map<Name*, StructDefinition*> extraStructs;
 //  std::unordered_map<Name*, InterfaceDefinition*> extraInterfaces;
 
-  StructDefinition* lookupStruct(Name* name) {
+  StructDefinition* lookupStruct(StructKind* structMT) {
 //    auto structI = extraStructs.find(name);
 //    if (structI != extraStructs.end()) {
 //      return structI->second;
 //    }
-    return program->getStruct(name);
+    return program->getStruct(structMT);
   }
 
-  InterfaceDefinition* lookupInterface(Name* name) {
+  InterfaceDefinition* lookupInterface(InterfaceKind* interfaceMT) {
 //    auto interfaceI = extraInterfaces.find(name);
 //    if (interfaceI != extraInterfaces.end()) {
 //      return interfaceI->second;
 //    }
-    return program->getInterface(name);
+    return program->getInterface(interfaceMT);
   }
 
   LLVMValueRef lookupFunction(Prototype* prototype) {
@@ -166,11 +166,10 @@ public:
     return funcIter->second;
   }
 
-  int getInterfaceMethodIndex(InterfaceReferend* interfaceReferendM, Prototype* prototype) {
+  int getInterfaceMethodIndex(InterfaceKind* interfaceKindM, Prototype* prototype) {
     int numMetalMethods = 0;
-    auto interfaceDefMIter = program->interfaces.find(interfaceReferendM->fullName->name);
-    if (interfaceDefMIter != program->interfaces.end()) {
-      auto interfaceDefM = interfaceDefMIter->second;
+    if (auto maybeInterfaceDefM = program->getMaybeInterface(interfaceKindM)) {
+      auto interfaceDefM = *maybeInterfaceDefM;
       for (int i = 0; i < interfaceDefM->methods.size(); i++) {
         if (interfaceDefM->methods[i]->prototype == prototype) {
           return i;
@@ -178,7 +177,7 @@ public:
       }
       numMetalMethods = interfaceDefM->methods.size();
     }
-    auto iter = interfaceExtraMethods.find(interfaceReferendM);
+    auto iter = interfaceExtraMethods.find(interfaceKindM);
     assert(iter != interfaceExtraMethods.end());
     auto extraMethods = iter->second;
     for (int i = 0; i < extraMethods.size(); i++) {
@@ -190,7 +189,7 @@ public:
   }
 
 
-  Weakability getReferendWeakability(Referend* referend);
+  Weakability getKindWeakability(Kind* kind);
 
   Ref constI64(int64_t x);
   Ref constI1(bool b);
@@ -199,7 +198,7 @@ public:
   Ref buildMultiply(FunctionState* functionState, LLVMBuilderRef builder, Ref a, Ref b);
   Ref buildDivide(FunctionState* functionState, LLVMBuilderRef builder, Ref a, Ref b);
 
-  Name* getReferendName(Referend* referend);
+  Name* getKindName(Kind* kind);
 
   template<typename T>
   AddressHasher<T> makeAddressHasher() {
@@ -224,11 +223,11 @@ public:
 
   std::vector<LLVMValueRef> getEdgeFunctions(Edge* edge);
 
-  std::vector<LLVMTypeRef> getInterfaceFunctionTypes(InterfaceReferend* referend);
+  std::vector<LLVMTypeRef> getInterfaceFunctionTypes(InterfaceKind* kind);
 
 
   IRegion* getRegion(Reference* referenceM);
-  IRegion* getRegion(Referend* referendM);
+  IRegion* getRegion(Kind* kindM);
   IRegion* getRegion(RegionId* regionId);
   LLVMValueRef getFunction(Name* name);
   LLVMValueRef getInterfaceTablePtr(Edge* edge);

--- a/Midas/src/c-compiler/mainFunction.cpp
+++ b/Midas/src/c-compiler/mainFunction.cpp
@@ -33,7 +33,7 @@ Prototype* makeValeMainFunction(
   auto voidPtrLT = LLVMPointerType(int8LT, 0);
   auto int8PtrLT = LLVMPointerType(int8LT, 0);
 
-  auto valeMainName = globalState->metalCache->getName("__Vale_Main");
+  auto valeMainName = globalState->metalCache->getName(globalState->metalCache->builtinPackageCoord, "__Vale_Main");
   auto valeMainProto =
       globalState->metalCache->getPrototype(valeMainName, globalState->metalCache->intRef, {});
   declareAndDefineExtraFunction(
@@ -117,13 +117,13 @@ Prototype* makeValeMainFunction(
         }
         buildFlare(FL(), globalState, functionState, entryBuilder);
 
-        if (userMainFunctionPrototype->returnType->referend == globalState->metalCache->emptyTupleStruct) {
+        if (userMainFunctionPrototype->returnType->kind == globalState->metalCache->emptyTupleStruct) {
           buildFlare(FL(), globalState, functionState, entryBuilder);
           LLVMBuildRet(entryBuilder, LLVMConstInt(LLVMInt64TypeInContext(globalState->context), 0, true));
-        } else if (userMainFunctionPrototype->returnType->referend == globalState->metalCache->innt) {
+        } else if (userMainFunctionPrototype->returnType->kind == globalState->metalCache->innt) {
           buildFlare(FL(), globalState, functionState, entryBuilder, userMainResultLE);
           LLVMBuildRet(entryBuilder, userMainResultLE);
-        } else if (userMainFunctionPrototype->returnType->referend == globalState->metalCache->never) {
+        } else if (userMainFunctionPrototype->returnType->kind == globalState->metalCache->never) {
           buildFlare(FL(), globalState, functionState, entryBuilder);
           LLVMBuildRet(entryBuilder, LLVMConstInt(LLVMInt64TypeInContext(globalState->context), 0, true));
         } else {

--- a/Midas/src/c-compiler/metal/ast.h
+++ b/Midas/src/c-compiler/metal/ast.h
@@ -37,6 +37,7 @@ class Name;
 
 class Package {
 public:
+  PackageCoordinate* packageCoordinate;
   std::unordered_map<std::string, InterfaceDefinition*> interfaces;
   std::unordered_map<std::string, StructDefinition*> structs;
   std::unordered_map<std::string, StaticSizedArrayDefinitionT*> staticSizedArrays;
@@ -62,6 +63,7 @@ public:
 
   Package(
     AddressNumberer* addressNumberer,
+    PackageCoordinate* packageCoordinate_,
     std::unordered_map<std::string, InterfaceDefinition*> interfaces_,
     std::unordered_map<std::string, StructDefinition*> structs_,
     std::unordered_map<std::string, StaticSizedArrayDefinitionT*> staticSizedArrays_,
@@ -74,6 +76,7 @@ public:
     std::unordered_map<std::string, Kind*> exportNameToKind_,
     std::unordered_map<std::string, Prototype*> externNameToFunction_,
     std::unordered_map<std::string, Kind*> externNameToKind_) :
+      packageCoordinate(packageCoordinate_),
       interfaces(std::move(interfaces_)),
       structs(std::move(structs_)),
       staticSizedArrays(std::move(staticSizedArrays_)),
@@ -181,7 +184,7 @@ public:
     return iter->second;
   }
 
-  std::string getKindExportName(Kind* kind) const {
+  std::string getKindExportName(Kind* kind, bool includeProjectName) const {
     if (dynamic_cast<Int *>(kind)) {
       return "int64_t";
     } else if (dynamic_cast<Bool *>(kind)) {
@@ -193,23 +196,23 @@ public:
     } else {
       auto iter = kindToExportName.find(kind);
       assert(iter != kindToExportName.end());
-      return iter->second;
+      return (includeProjectName ? packageCoordinate->projectName + "_" : "") + iter->second;
     }
   }
   std::string getFunctionExportName(Prototype* kind) const {
     auto iter = functionToExportName.find(kind);
     assert(iter != functionToExportName.end());
-    return iter->second;
+    return packageCoordinate->projectName + "_" + iter->second;
   }
   std::string getKindExternName(Kind* kind) const {
     auto iter = kindToExternName.find(kind);
     assert(iter != kindToExternName.end());
-    return iter->second;
+    return packageCoordinate->projectName + "_" + iter->second;
   }
   std::string getFunctionExternName(Prototype* kind) const {
     auto iter = functionToExternName.find(kind);
     assert(iter != functionToExternName.end());
-    return iter->second;
+    return packageCoordinate->projectName + "_" + iter->second;
   }
 //  bool isExported(Name* name) {
 //    auto exportedNameI = fullNameToExportName.find(name);

--- a/Midas/src/c-compiler/metal/ast.h
+++ b/Midas/src/c-compiler/metal/ast.h
@@ -196,23 +196,23 @@ public:
     } else {
       auto iter = kindToExportName.find(kind);
       assert(iter != kindToExportName.end());
-      return (includeProjectName ? packageCoordinate->projectName + "_" : "") + iter->second;
+      return (includeProjectName && !packageCoordinate->projectName.empty() ? packageCoordinate->projectName + "_" : "") + iter->second;
     }
   }
   std::string getFunctionExportName(Prototype* kind) const {
     auto iter = functionToExportName.find(kind);
     assert(iter != functionToExportName.end());
-    return packageCoordinate->projectName + "_" + iter->second;
+    return (!packageCoordinate->projectName.empty() ? packageCoordinate->projectName + "_" : "") + iter->second;
   }
   std::string getKindExternName(Kind* kind) const {
     auto iter = kindToExternName.find(kind);
     assert(iter != kindToExternName.end());
-    return packageCoordinate->projectName + "_" + iter->second;
+    return (!packageCoordinate->projectName.empty() ? packageCoordinate->projectName + "_" : "") + iter->second;
   }
   std::string getFunctionExternName(Prototype* kind) const {
     auto iter = functionToExternName.find(kind);
     assert(iter != functionToExternName.end());
-    return packageCoordinate->projectName + "_" + iter->second;
+    return (!packageCoordinate->projectName.empty() ? packageCoordinate->projectName + "_" : "") + iter->second;
   }
 //  bool isExported(Name* name) {
 //    auto exportedNameI = fullNameToExportName.find(name);

--- a/Midas/src/c-compiler/metal/ast.h
+++ b/Midas/src/c-compiler/metal/ast.h
@@ -43,68 +43,202 @@ public:
   std::unordered_map<std::string, RuntimeSizedArrayDefinitionT*> runtimeSizedArrays;
   // Get rid of this; since there's no IDs anymore we can have a stable
   // hardcoded NameH("__Pack", Some(List()), None, None).
-  StructReferend* emptyTupleStructRef;
-  std::unordered_map<std::string, Prototype*> externs;
+  StructKind* emptyTupleStructRef;
+//  std::unordered_map<std::string, Prototype*> externs;
   std::unordered_map<std::string, Function*> functions;
-  std::unordered_map<Referend*, Prototype*, AddressHasher<Referend*>> immDestructorsByKind;
+  std::unordered_map<Kind*, Prototype*, AddressHasher<Kind*>> immDestructorsByKind;
 
-  std::unordered_map<std::string, Name*> exportNameToFullName;
-  std::unordered_map<Name*, std::string, AddressHasher<Name*>> fullNameToExportName;
+  // This only contains exports defined in this package. Though, the things they're exporting can
+  // be defined somewhere else.
+  std::unordered_map<std::string, Prototype*> exportNameToFunction;
+  std::unordered_map<std::string, Kind*> exportNameToKind;
+  std::unordered_map<std::string, Prototype*> externNameToFunction;
+  std::unordered_map<std::string, Kind*> externNameToKind;
+  // These are inverses of the above maps
+  std::unordered_map<Prototype*, std::string, AddressHasher<Prototype*>> functionToExportName;
+  std::unordered_map<Kind*, std::string, AddressHasher<Kind*>> kindToExportName;
+  std::unordered_map<Prototype*, std::string, AddressHasher<Prototype*>> functionToExternName;
+  std::unordered_map<Kind*, std::string, AddressHasher<Kind*>> kindToExternName;
+
+  Package(
+    AddressNumberer* addressNumberer,
+    std::unordered_map<std::string, InterfaceDefinition*> interfaces_,
+    std::unordered_map<std::string, StructDefinition*> structs_,
+    std::unordered_map<std::string, StaticSizedArrayDefinitionT*> staticSizedArrays_,
+    std::unordered_map<std::string, RuntimeSizedArrayDefinitionT*> runtimeSizedArrays_,
+    StructKind* emptyTupleStructRef_,
+//    std::unordered_map<std::string, Prototype*> externs_,
+    std::unordered_map<std::string, Function*> functions_,
+    std::unordered_map<Kind*, Prototype*, AddressHasher<Kind*>> immDestructorsByKind_,
+    std::unordered_map<std::string, Prototype*> exportNameToFunction_,
+    std::unordered_map<std::string, Kind*> exportNameToKind_,
+    std::unordered_map<std::string, Prototype*> externNameToFunction_,
+    std::unordered_map<std::string, Kind*> externNameToKind_) :
+      interfaces(std::move(interfaces_)),
+      structs(std::move(structs_)),
+      staticSizedArrays(std::move(staticSizedArrays_)),
+      runtimeSizedArrays(std::move(runtimeSizedArrays_)),
+      emptyTupleStructRef(std::move(emptyTupleStructRef_)),
+//      externs(std::move(externs_)),
+      functions(std::move(functions_)),
+      immDestructorsByKind(std::move(immDestructorsByKind_)),
+      exportNameToFunction(std::move(exportNameToFunction_)),
+      exportNameToKind(std::move(exportNameToKind_)),
+      externNameToFunction(std::move(externNameToFunction_)),
+      externNameToKind(std::move(externNameToKind_)),
+      functionToExportName(0, addressNumberer->makeHasher<Prototype*>()),
+      kindToExportName(0, addressNumberer->makeHasher<Kind*>()),
+      functionToExternName(0, addressNumberer->makeHasher<Prototype*>()),
+      kindToExternName(0, addressNumberer->makeHasher<Kind*>()) {
+    for (auto [exportName, prototype] : exportNameToFunction) {
+      assert(functionToExportName.count(prototype) == 0);
+      functionToExportName[prototype] = exportName;
+    }
+    for (auto [exportName, kind] : exportNameToKind) {
+      assert(kindToExportName.count(kind) == 0);
+      kindToExportName[kind] = exportName;
+    }
+    for (auto [externName, prototype] : externNameToFunction) {
+      assert(functionToExternName.count(prototype) == 0);
+      functionToExternName[prototype] = externName;
+    }
+    for (auto [externName, kind] : externNameToKind) {
+      assert(kindToExternName.count(kind) == 0);
+      kindToExternName[kind] = externName;
+    }
+  }
 
 
-  StructDefinition* getStruct(Name* name) {
-    auto iter = structs.find(name->name);
-    if (iter == structs.end()) {
+  Function* getFunction(Name* name) {
+    auto iter = functions.find(name->name);
+    if (iter == functions.end()) {
       std::cerr << "Couldn't find struct: " << name->name << std::endl;
       exit(1);
     }
     return iter->second;
   }
-  InterfaceDefinition* getInterface(Name* name) {
-    auto iter = interfaces.find(name->name);
+  std::optional<Function*> getMaybeFunction(Name* name) {
+    auto iter = functions.find(name->name);
+    if (iter == functions.end()) {
+      return std::nullopt;
+    }
+    return std::optional(iter->second);
+  }
+  StructDefinition* getStruct(StructKind* structMT) {
+    auto iter = structs.find(structMT->fullName->name);
+    if (iter == structs.end()) {
+      std::cerr << "Couldn't find struct: " << structMT->fullName->name << std::endl;
+      exit(1);
+    }
+    return iter->second;
+  }
+  std::optional<StructDefinition*> getMaybeStruct(Name* name) {
+    auto iter = structs.find(name->name);
+    if (iter == structs.end()) {
+      return std::nullopt;
+    }
+    return std::optional(iter->second);
+  }
+  InterfaceDefinition* getInterface(InterfaceKind* interfaceMT) {
+    auto iter = interfaces.find(interfaceMT->fullName->name);
     assert(iter != interfaces.end());
     return iter->second;
   }
-  StaticSizedArrayDefinitionT* getStaticSizedArray(Name* name) {
-    auto iter = staticSizedArrays.find(name->name);
+  std::optional<InterfaceDefinition*> getMaybeInterface(InterfaceKind* interfaceMT) {
+    auto iter = interfaces.find(interfaceMT->fullName->name);
+    if (iter == interfaces.end()) {
+      return std::nullopt;
+    }
+    return std::optional(iter->second);
+  }
+  StaticSizedArrayDefinitionT* getStaticSizedArray(StaticSizedArrayT* ssaMT) {
+    auto iter = staticSizedArrays.find(ssaMT->name->name);
     assert(iter != staticSizedArrays.end());
     return iter->second;
   }
-  RuntimeSizedArrayDefinitionT* getRuntimeSizedArray(Name* name) {
-    auto iter = runtimeSizedArrays.find(name->name);
+  std::optional<StaticSizedArrayDefinitionT*> getMaybeStaticSizedArray(Name* name) {
+    auto iter = staticSizedArrays.find(name->name);
+    if (iter == staticSizedArrays.end()) {
+      return std::nullopt;
+    }
+    return std::optional(iter->second);
+  }
+  RuntimeSizedArrayDefinitionT* getRuntimeSizedArray(RuntimeSizedArrayT* rsaMT) {
+    auto iter = runtimeSizedArrays.find(rsaMT->name->name);
     assert(iter != runtimeSizedArrays.end());
     return iter->second;
   }
-  Prototype* getImmDestructor(Referend* referend) {
-    auto iter = immDestructorsByKind.find(referend);
+  std::optional<RuntimeSizedArrayDefinitionT*> getMaybeRuntimeSizedArray(Name* name) {
+    auto iter = runtimeSizedArrays.find(name->name);
+    if (iter == runtimeSizedArrays.end()) {
+      return std::nullopt;
+    }
+    return std::optional(iter->second);
+  }
+  Prototype* getImmDestructor(Kind* kind) {
+    auto iter = immDestructorsByKind.find(kind);
     assert(iter != immDestructorsByKind.end());
     return iter->second;
   }
-  bool isExported(Name* name) {
-    auto exportedNameI = fullNameToExportName.find(name);
-    return exportedNameI != fullNameToExportName.end();
-  }
-  std::string getExportedName(Name* name) {
-    auto exportedNameI = fullNameToExportName.find(name);
-    if (exportedNameI == fullNameToExportName.end()) {
-      std::cerr << "No exported name for " << name->name << std::endl;
-      assert(false);
-    }
-    return exportedNameI->second;
-  }
 
-  bool isExportedAs(Name* name, const std::string& exportName) {
-    auto exportedNamesI = fullNameToExportName.find(name);
-    if (exportedNamesI == fullNameToExportName.end()) {
-      return false;
+  std::string getKindExportName(Kind* kind) const {
+    if (dynamic_cast<Int *>(kind)) {
+      return "int64_t";
+    } else if (dynamic_cast<Bool *>(kind)) {
+      return "int8_t";
+    } else if (dynamic_cast<Float *>(kind)) {
+      return "double";
+    } else if (dynamic_cast<Str *>(kind)) {
+      return "ValeStr*";
+    } else {
+      auto iter = kindToExportName.find(kind);
+      assert(iter != kindToExportName.end());
+      return iter->second;
     }
-    return exportedNamesI->second == exportName;
   }
+  std::string getFunctionExportName(Prototype* kind) const {
+    auto iter = functionToExportName.find(kind);
+    assert(iter != functionToExportName.end());
+    return iter->second;
+  }
+  std::string getKindExternName(Kind* kind) const {
+    auto iter = kindToExternName.find(kind);
+    assert(iter != kindToExternName.end());
+    return iter->second;
+  }
+  std::string getFunctionExternName(Prototype* kind) const {
+    auto iter = functionToExternName.find(kind);
+    assert(iter != functionToExternName.end());
+    return iter->second;
+  }
+//  bool isExported(Name* name) {
+//    auto exportedNameI = fullNameToExportName.find(name);
+//    return exportedNameI != fullNameToExportName.end();
+//  }
+//  std::string getExportedName(Name* name) {
+//    auto exportedNameI = fullNameToExportName.find(name);
+//    if (exportedNameI == fullNameToExportName.end()) {
+//      std::cerr << "No exported name for " << name->name << std::endl;
+//      assert(false);
+//    }
+//    return exportedNameI->second;
+//  }
+//  bool isExportedAs(Name* name, const std::string& exportName) {
+//    auto exportedNamesI = fullNameToExportName.find(name);
+//    if (exportedNamesI == fullNameToExportName.end()) {
+//      return false;
+//    }
+//    return exportedNamesI->second == exportName;
+//  }
 };
 
 class Program {
 public:
-  std::unordered_map<PackageCoordinate*, Package*, PackageCoordinate::Hasher, PackageCoordinate::Equator> packages;
+  std::unordered_map<PackageCoordinate*, Package*, AddressHasher<PackageCoordinate*>, std::equal_to<PackageCoordinate*>> packages;
+
+  Program(
+      std::unordered_map<PackageCoordinate*, Package*, AddressHasher<PackageCoordinate*>, std::equal_to<PackageCoordinate*>> packages_) :
+      packages(std::move(packages_)) {}
 
   Package* getPackage(PackageCoordinate* packageCoord) {
     auto iter = packages.find(packageCoord);
@@ -112,24 +246,36 @@ public:
     return iter->second;
   }
 
-  StructDefinition* getStruct(Name* name) {
-    return getPackage(name->packageCoord)->getStruct(name);
+  Function* getFunction(Name* name) {
+    return getPackage(name->packageCoord)->getFunction(name);
   }
-  InterfaceDefinition* getInterface(Name* name) {
-    return getPackage(name->packageCoord)->getInterface(name);
+  std::optional<Function*> getMaybeFunction(Name* name) {
+    return getPackage(name->packageCoord)->getMaybeFunction(name);
   }
-  StaticSizedArrayDefinitionT* getStaticSizedArray(Name* name) {
-    return getPackage(name->packageCoord)->getStaticSizedArray(name);
+  StructDefinition* getStruct(StructKind* structMT) {
+    return getPackage(structMT->fullName->packageCoord)->getStruct(structMT);
   }
-  RuntimeSizedArrayDefinitionT* getRuntimeSizedArray(Name* name) {
-    return getPackage(name->packageCoord)->getRuntimeSizedArray(name);
+  std::optional<StructDefinition*> getMaybeStruct(StructKind* structMT) {
+    return getPackage(structMT->fullName->packageCoord)->getStruct(structMT);
   }
-  Prototype* getImmDestructor(Referend* referend) {
-    return getPackage(referend->getPackageCoordinate())->getImmDestructor(referend);
+  InterfaceDefinition* getInterface(InterfaceKind* interfaceMT) {
+    return getPackage(interfaceMT->fullName->packageCoord)->getInterface(interfaceMT);
   }
-  bool isExported(Name* name) {
-    return getPackage(name->packageCoord)->isExported(name);
+  std::optional<InterfaceDefinition*> getMaybeInterface(InterfaceKind* interfaceMT) {
+    return getPackage(interfaceMT->fullName->packageCoord)->getMaybeInterface(interfaceMT);
   }
+  StaticSizedArrayDefinitionT* getStaticSizedArray(StaticSizedArrayT* ssaMT) {
+    return getPackage(ssaMT->name->packageCoord)->getStaticSizedArray(ssaMT);
+  }
+  RuntimeSizedArrayDefinitionT* getRuntimeSizedArray(RuntimeSizedArrayT* rsaMT) {
+    return getPackage(rsaMT->name->packageCoord)->getRuntimeSizedArray(rsaMT);
+  }
+  Prototype* getImmDestructor(Kind* kind) {
+    return getPackage(kind->getPackageCoordinate())->getImmDestructor(kind);
+  }
+//  bool isExported(Name* name) {
+//    return getPackage(name->packageCoord)->isExported(name);
+//  }
 //  std::vector<std::string> getExportedNames(Name* name) {
 //    auto exportedNameI = fullNameToExportedNames.find(name);
 //    if (exportedNameI == fullNameToExportedNames.end()) {
@@ -138,10 +284,9 @@ public:
 //    }
 //    return exportedNameI->second;
 //  }
-
-  bool isExportedAs(Name* name, const std::string& exportName) {
-    return getPackage(name->packageCoord)->isExportedAs(name, exportName);
-  }
+//  bool isExportedAs(Name* name, const std::string& exportName) {
+//    return getPackage(name->packageCoord)->isExportedAs(name, exportName);
+//  }
 };
 
 class InterfaceMethod {
@@ -160,13 +305,13 @@ public:
 // Each edge has a vtable.
 class Edge {
 public:
-  StructReferend* structName;
-  InterfaceReferend* interfaceName;
+  StructKind* structName;
+  InterfaceKind* interfaceName;
   std::vector<std::pair<InterfaceMethod*, Prototype*>> structPrototypesByInterfaceMethod;
 
   Edge(
-      StructReferend* structName_,
-      InterfaceReferend* interfaceName_,
+      StructKind* structName_,
+      InterfaceKind* interfaceName_,
       std::vector<std::pair<InterfaceMethod*, Prototype*>> structPrototypesByInterfaceMethod_) :
       structName(structName_),
       interfaceName(interfaceName_),
@@ -176,7 +321,7 @@ public:
 class StructDefinition {
 public:
     Name* name;
-    StructReferend* referend;
+    StructKind* kind;
     RegionId* regionId;
     Mutability mutability;
     std::vector<Edge*> edges;
@@ -185,23 +330,23 @@ public:
 
     StructDefinition(
         Name* name_,
-        StructReferend* referend_,
+        StructKind* kind_,
         RegionId* regionId_,
         Mutability mutability_,
         std::vector<Edge*> edges_,
         std::vector<StructMember*> members_,
         Weakability weakable_) :
         name(name_),
-        referend(referend_),
+        kind(kind_),
         regionId(regionId_),
         mutability(mutability_),
         edges(edges_),
         members(members_),
         weakability(weakable_) {}
 
-    Edge* getEdgeForInterface(Name* interfaceName) {
+    Edge* getEdgeForInterface(InterfaceKind* interfaceMT) {
       for (auto e : edges) {
-        if (e->interfaceName->fullName == interfaceName)
+        if (e->interfaceName == interfaceMT)
           return e;
       }
       assert(false);
@@ -231,7 +376,7 @@ public:
 class InterfaceDefinition {
 public:
     Name* name;
-    InterfaceReferend* referend;
+    InterfaceKind* kind;
     RegionId* regionId;
     Mutability mutability;
     std::vector<Name*> superInterfaces;
@@ -240,21 +385,21 @@ public:
 
     InterfaceDefinition(
         Name* name_,
-        InterfaceReferend* referend_,
+        InterfaceKind* kind_,
         RegionId* regionId_,
         Mutability mutability_,
         const std::vector<Name*>& superInterfaces_,
         const std::vector<InterfaceMethod*>& methods_,
         Weakability weakable_) :
       name(name_),
-      referend(referend_),
+      kind(kind_),
       regionId(regionId_),
       mutability(mutability_),
       superInterfaces(superInterfaces_),
       methods(methods_),
       weakability(weakable_) {
       assert((uint64_t)name > 0x10000);
-      assert((uint64_t)referend > 0x10000);
+      assert((uint64_t)kind > 0x10000);
     }
 };
 

--- a/Midas/src/c-compiler/metal/instructions.h
+++ b/Midas/src/c-compiler/metal/instructions.h
@@ -133,27 +133,27 @@ class StructToInterfaceUpcast : public Expression {
 public:
   Expression* sourceExpr;
   Reference* sourceStructType;
-  StructReferend* sourceStructReferend;
+  StructKind* sourceStructKind;
   Reference* targetInterfaceType;
-  InterfaceReferend* targetInterfaceReferend;
+  InterfaceKind* targetInterfaceKind;
 
   StructToInterfaceUpcast(
       Expression* sourceExpr_,
       Reference* sourceStructType_,
-      StructReferend* sourceStructReferend_,
+      StructKind* sourceStructKind_,
       Reference* targetInterfaceType_,
-      InterfaceReferend* targetInterfaceReferend_) :
+      InterfaceKind* targetInterfaceKind_) :
       sourceExpr(sourceExpr_),
       sourceStructType(sourceStructType_),
-      sourceStructReferend(sourceStructReferend_),
+      sourceStructKind(sourceStructKind_),
       targetInterfaceType(targetInterfaceType_),
-      targetInterfaceReferend(targetInterfaceReferend_) {}
+      targetInterfaceKind(targetInterfaceKind_) {}
 };
 
 class InterfaceToInterfaceUpcast : public Expression {
 public:
   Expression* sourceExpr;
-  InterfaceReferend* targetInterfaceRef;
+  InterfaceKind* targetInterfaceRef;
 };
 
 class LocalStore : public Expression {
@@ -195,17 +195,17 @@ class WeakAlias : public Expression {
 public:
   Expression* sourceExpr;
   Reference* sourceType;
-  Referend* sourceReferend;
+  Kind* sourceKind;
   Reference* resultType;
 
   WeakAlias(
       Expression* sourceExpr_,
       Reference* sourceType_,
-      Referend* sourceReferend_,
+      Kind* sourceKind_,
       Reference* resultType_) :
     sourceExpr(sourceExpr_),
     sourceType(sourceType_),
-    sourceReferend(sourceReferend_),
+    sourceKind(sourceKind_),
     resultType(resultType_) {}
 };
 
@@ -250,7 +250,7 @@ public:
 class MemberLoad : public Expression {
 public:
   Expression* structExpr;
-  StructReferend* structId;
+  StructKind* structId;
   Reference* structType;
   bool structKnownLive;
   int memberIndex;
@@ -261,7 +261,7 @@ public:
 
   MemberLoad(
       Expression* structExpr_,
-      StructReferend* structId_,
+      StructKind* structId_,
       Reference* structType_,
       bool structKnownLive_,
       int memberIndex_,
@@ -285,15 +285,15 @@ class NewArrayFromValues : public Expression {
 public:
   std::vector<Expression*> sourceExprs;
   Reference* arrayRefType;
-  StaticSizedArrayT* arrayReferend;
+  StaticSizedArrayT* arrayKind;
 
   NewArrayFromValues(
       std::vector<Expression*> sourceExprs_,
       Reference* arrayRefType_,
-      StaticSizedArrayT* arrayReferend_) :
+      StaticSizedArrayT* arrayKind_) :
       sourceExprs(sourceExprs_),
       arrayRefType(arrayRefType_),
-      arrayReferend(arrayReferend_) {}
+      arrayKind(arrayKind_) {}
 };
 
 
@@ -309,36 +309,36 @@ class RuntimeSizedArrayStore : public Expression {
 public:
   Expression* arrayExpr;
   Reference* arrayType;
-  RuntimeSizedArrayT* arrayReferend;
+  RuntimeSizedArrayT* arrayKind;
   bool arrayKnownLive;
   Expression* indexExpr;
   Reference* indexType;
-  Referend* indexReferend;
+  Kind* indexKind;
   Expression* sourceExpr;
   Reference* sourceType;
-  Referend* sourceReferend;
+  Kind* sourceKind;
 
   RuntimeSizedArrayStore(
       Expression* arrayExpr_,
       Reference* arrayType_,
-      RuntimeSizedArrayT* arrayReferend_,
+      RuntimeSizedArrayT* arrayKind_,
       bool arrayKnownLive_,
       Expression* indexExpr_,
       Reference* indexType_,
-      Referend* indexReferend_,
+      Kind* indexKind_,
       Expression* sourceExpr_,
       Reference* sourceType_,
-      Referend* sourceReferend_) :
+      Kind* sourceKind_) :
     arrayExpr(arrayExpr_),
     arrayType(arrayType_),
-    arrayReferend(arrayReferend_),
+    arrayKind(arrayKind_),
     arrayKnownLive(arrayKnownLive_),
     indexExpr(indexExpr_),
     indexType(indexType_),
-    indexReferend(indexReferend_),
+    indexKind(indexKind_),
     sourceExpr(sourceExpr_),
     sourceType(sourceType_),
-    sourceReferend(sourceReferend_) {}
+    sourceKind(sourceKind_) {}
 };
 
 
@@ -346,11 +346,11 @@ class RuntimeSizedArrayLoad : public Expression {
 public:
   Expression* arrayExpr;
   Reference* arrayType;
-  RuntimeSizedArrayT* arrayReferend;
+  RuntimeSizedArrayT* arrayKind;
   bool arrayKnownLive;
   Expression* indexExpr;
   Reference* indexType;
-  Referend* indexReferend;
+  Kind* indexKind;
   Reference* resultType;
   Ownership targetOwnership;
   Reference* arrayElementType;
@@ -358,21 +358,21 @@ public:
   RuntimeSizedArrayLoad(
       Expression* arrayExpr_,
       Reference* arrayType_,
-      RuntimeSizedArrayT* arrayReferend_,
+      RuntimeSizedArrayT* arrayKind_,
       bool arrayKnownLive_,
       Expression* indexExpr_,
       Reference* indexType_,
-      Referend* indexReferend_,
+      Kind* indexKind_,
       Reference* resultType_,
       Ownership targetOwnership_,
       Reference* arrayElementType_) :
     arrayExpr(arrayExpr_),
     arrayType(arrayType_),
-    arrayReferend(arrayReferend_),
+    arrayKind(arrayKind_),
     arrayKnownLive(arrayKnownLive_),
     indexExpr(indexExpr_),
     indexType(indexType_),
-    indexReferend(indexReferend_),
+    indexKind(indexKind_),
     resultType(resultType_),
     targetOwnership(targetOwnership_),
     arrayElementType(arrayElementType_) {}
@@ -383,7 +383,7 @@ class StaticSizedArrayLoad : public Expression {
 public:
   Expression* arrayExpr;
   Reference* arrayType;
-  StaticSizedArrayT* arrayReferend;
+  StaticSizedArrayT* arrayKind;
   bool arrayKnownLive;
   Expression* indexExpr;
   Reference* resultType;
@@ -394,7 +394,7 @@ public:
   StaticSizedArrayLoad(
       Expression* arrayExpr_,
       Reference* arrayType_,
-      StaticSizedArrayT* arrayReferend_,
+      StaticSizedArrayT* arrayKind_,
       bool arrayKnownLive_,
       Expression* indexExpr_,
       Reference* resultType_,
@@ -403,7 +403,7 @@ public:
       int arraySize_) :
     arrayExpr(arrayExpr_),
     arrayType(arrayType_),
-    arrayReferend(arrayReferend_),
+    arrayKind(arrayKind_),
     arrayKnownLive(arrayKnownLive_),
     indexExpr(indexExpr_),
     resultType(resultType_),
@@ -445,14 +445,14 @@ class InterfaceCall : public Expression {
 public:
   std::vector<Expression*> argExprs;
   int virtualParamIndex;
-  InterfaceReferend* interfaceRef;
+  InterfaceKind* interfaceRef;
   int indexInEdge;
   Prototype* functionType;
 
   InterfaceCall(
       std::vector<Expression*> argExprs_,
       int virtualParamIndex_,
-      InterfaceReferend* interfaceRef_,
+      InterfaceKind* interfaceRef_,
       int indexInEdge_,
       Prototype* functionType_) :
     argExprs(argExprs_),
@@ -530,10 +530,10 @@ class ConstructRuntimeSizedArray : public Expression {
 public:
   Expression* sizeExpr;
   Reference* sizeType;
-  Referend* sizeReferend;
+  Kind* sizeKind;
   Expression* generatorExpr;
   Reference* generatorType;
-  Referend* generatorReferend;
+  Kind* generatorKind;
   Prototype* generatorMethod;
   bool generatorKnownLive;
   Reference* arrayRefType;
@@ -542,20 +542,20 @@ public:
   ConstructRuntimeSizedArray(
       Expression* sizeExpr_,
       Reference* sizeType_,
-      Referend* sizeReferend_,
+      Kind* sizeKind_,
       Expression* generatorExpr_,
       Reference* generatorType_,
-      Referend* generatorReferend_,
+      Kind* generatorKind_,
       Prototype* generatorMethod_,
       bool generatorKnownLive_,
       Reference* arrayRefType_,
       Reference* elementType_) :
     sizeExpr(sizeExpr_),
     sizeType(sizeType_),
-    sizeReferend(sizeReferend_),
+    sizeKind(sizeKind_),
     generatorExpr(generatorExpr_),
     generatorType(generatorType_),
-    generatorReferend(generatorReferend_),
+    generatorKind(generatorKind_),
     generatorMethod(generatorMethod_),
     generatorKnownLive(generatorKnownLive_),
     arrayRefType(arrayRefType_),
@@ -566,7 +566,7 @@ class StaticArrayFromCallable : public Expression {
 public:
   Expression* generatorExpr;
   Reference* generatorType;
-  Referend* generatorReferend;
+  Kind* generatorKind;
   Prototype* generatorMethod;
   bool generatorKnownLive;
   Reference* arrayRefType;
@@ -575,14 +575,14 @@ public:
   StaticArrayFromCallable(
       Expression* generatorExpr_,
       Reference* generatorType_,
-      Referend* generatorReferend_,
+      Kind* generatorKind_,
       Prototype* generatorMethod_,
       bool generatorKnownLive_,
       Reference* arrayRefType_,
       Reference* elementType_) :
       generatorExpr(generatorExpr_),
       generatorType(generatorType_),
-      generatorReferend(generatorReferend_),
+      generatorKind(generatorKind_),
       generatorMethod(generatorMethod_),
       generatorKnownLive(generatorKnownLive_),
       arrayRefType(arrayRefType_),
@@ -593,7 +593,7 @@ class DestroyStaticSizedArrayIntoFunction : public Expression {
 public:
   Expression* arrayExpr;
   Reference* arrayType;
-  StaticSizedArrayT* arrayReferend;
+  StaticSizedArrayT* arrayKind;
   Expression* consumerExpr;
   Reference* consumerType;
   Prototype* consumerMethod;
@@ -604,7 +604,7 @@ public:
   DestroyStaticSizedArrayIntoFunction(
       Expression* arrayExpr_,
       Reference* arrayType_,
-      StaticSizedArrayT* arrayReferend_,
+      StaticSizedArrayT* arrayKind_,
       Expression* consumerExpr_,
       Reference* consumerType_,
       Prototype* consumerMethod_,
@@ -613,7 +613,7 @@ public:
       int arraySize_) :
     arrayExpr(arrayExpr_),
     arrayType(arrayType_),
-    arrayReferend(arrayReferend_),
+    arrayKind(arrayKind_),
     consumerExpr(consumerExpr_),
     consumerType(consumerType_),
     consumerMethod(consumerMethod_),
@@ -632,28 +632,28 @@ class DestroyRuntimeSizedArray : public Expression {
 public:
   Expression* arrayExpr;
   Reference* arrayType;
-  RuntimeSizedArrayT* arrayReferend;
+  RuntimeSizedArrayT* arrayKind;
   Expression* consumerExpr;
   Reference* consumerType;
-  InterfaceReferend* consumerReferend;
+  InterfaceKind* consumerKind;
   Prototype* consumerMethod;
   bool consumerKnownLive;
 
   DestroyRuntimeSizedArray(
       Expression* arrayExpr_,
       Reference* arrayType_,
-      RuntimeSizedArrayT* arrayReferend_,
+      RuntimeSizedArrayT* arrayKind_,
       Expression* consumerExpr_,
       Reference* consumerType_,
-      InterfaceReferend* consumerReferend_,
+      InterfaceKind* consumerKind_,
       Prototype* consumerMethod_,
       bool consumerKnownLive_) :
     arrayExpr(arrayExpr_),
     arrayType(arrayType_),
-    arrayReferend(arrayReferend_),
+    arrayKind(arrayKind_),
     consumerExpr(consumerExpr_),
     consumerType(consumerType_),
-    consumerReferend(consumerReferend_),
+    consumerKind(consumerKind_),
     consumerMethod(consumerMethod_),
     consumerKnownLive(consumerKnownLive_) {}
 };
@@ -712,14 +712,14 @@ public:
 
   Prototype* someConstructor;
   Reference* someType;
-  StructReferend* someReferend;
+  StructKind* someKind;
 
   Prototype* noneConstructor;
   Reference* noneType;
-  StructReferend* noneReferend;
+  StructKind* noneKind;
 
   Reference* resultOptType;
-  InterfaceReferend* resultOptReferend;
+  InterfaceKind* resultOptKind;
 
   LockWeak(
       Expression* sourceExpr_,
@@ -727,23 +727,23 @@ public:
       bool sourceKnownLive_,
       Prototype* someConstructor_,
       Reference* someType_,
-      StructReferend* someReferend_,
+      StructKind* someKind_,
       Prototype* noneConstructor_,
       Reference* noneType_,
-      StructReferend* noneReferend_,
+      StructKind* noneKind_,
       Reference* resultOptType_,
-      InterfaceReferend* resultOptReferend_) :
+      InterfaceKind* resultOptKind_) :
     sourceExpr(sourceExpr_),
     sourceType(sourceType_),
     sourceKnownLive(sourceKnownLive_),
     someConstructor(someConstructor_),
     someType(someType_),
-    someReferend(someReferend_),
+    someKind(someKind_),
     noneConstructor(noneConstructor_),
     noneType(noneType_),
-    noneReferend(noneReferend_),
+    noneKind(noneKind_),
     resultOptType(resultOptType_),
-    resultOptReferend(resultOptReferend_) {}
+    resultOptKind(resultOptKind_) {}
 };
 
 class AsSubtype : public Expression {
@@ -752,44 +752,44 @@ public:
   Reference* sourceType;
   bool sourceKnownLive;
 
-  Referend* targetReferend;
+  Kind* targetKind;
 
   Prototype* okConstructor;
   Reference* okType;
-  StructReferend* okReferend;
+  StructKind* okKind;
 
   Prototype* errConstructor;
   Reference* errType;
-  StructReferend* errReferend;
+  StructKind* errKind;
 
   Reference* resultResultType;
-  InterfaceReferend* resultResultReferend;
+  InterfaceKind* resultResultKind;
 
   AsSubtype(
       Expression* sourceExpr_,
       Reference* sourceType_,
       bool sourceKnownLive_,
-      Referend* targetReferend_,
+      Kind* targetKind_,
       Prototype* okConstructor_,
       Reference* okType_,
-      StructReferend* okReferend_,
+      StructKind* okKind_,
       Prototype* errConstructor_,
       Reference* errType_,
-      StructReferend* errReferend_,
+      StructKind* errKind_,
       Reference* resultResultType_,
-      InterfaceReferend* resultResultReferend_) :
+      InterfaceKind* resultResultKind_) :
     sourceExpr(sourceExpr_),
     sourceType(sourceType_),
     sourceKnownLive(sourceKnownLive_),
-    targetReferend(targetReferend_),
+    targetKind(targetKind_),
     okConstructor(okConstructor_),
     okType(okType_),
-    okReferend(okReferend_),
+    okKind(okKind_),
     errConstructor(errConstructor_),
     errType(errType_),
-    errReferend(errReferend_),
+    errKind(errKind_),
     resultResultType(resultResultType_),
-    resultResultReferend(resultResultReferend_) {}
+    resultResultKind(resultResultKind_) {}
 };
 
 #endif

--- a/Midas/src/c-compiler/metal/name.h
+++ b/Midas/src/c-compiler/metal/name.h
@@ -1,0 +1,65 @@
+#ifndef METAL_NAME_H_
+#define METAL_NAME_H_
+
+#include <string>
+#include <vector>
+
+struct PackageCoordinate {
+  std::string moduleName;
+  std::vector<std::string> packageSteps;
+
+  PackageCoordinate(
+      const std::string& moduleName_,
+      const std::vector<std::string>& packageSteps_) :
+      moduleName(moduleName_),
+      packageSteps(packageSteps_)
+  {}
+
+  struct StringVectorHasher {
+    size_t operator()(const std::vector<std::string>& a) const {
+      size_t hash = 0;
+      for (int i = 0; i < a.size(); i++)
+        hash = hash * 37 + std::hash<std::string>()(a[i]);
+      return hash;
+    }
+  };
+  struct StringVectorEquator {
+    bool operator()(const std::vector<std::string>& a, const std::vector<std::string>& b) const {
+      if (a.size() != b.size())
+        return false;
+      for (int i = 0; i < a.size(); i++)
+        if (a[i] != b[i])
+          return false;
+      return true;
+    }
+  };
+
+  struct Hasher {
+    size_t operator()(const PackageCoordinate *a) const {
+      size_t hash = 0;
+      hash = hash * 37 + std::hash<std::string>()(a->moduleName);
+      hash = hash * 41 + StringVectorHasher()(a->packageSteps);
+      return hash;
+    }
+  };
+  struct Equator {
+    bool operator()(const PackageCoordinate* a, const PackageCoordinate* b) const {
+      if (a->moduleName != b->moduleName)
+        return false;
+      if (!StringVectorEquator()(a->packageSteps, b->packageSteps))
+        return false;
+      return true;
+    }
+  };
+};
+
+class Name {
+public:
+  PackageCoordinate* packageCoord;
+  std::string name;
+
+  Name(PackageCoordinate* packageCoord_, const std::string& name_) :
+      packageCoord(packageCoord_), name(name_) {}
+};
+
+#endif

--- a/Midas/src/c-compiler/metal/name.h
+++ b/Midas/src/c-compiler/metal/name.h
@@ -5,13 +5,13 @@
 #include <vector>
 
 struct PackageCoordinate {
-  std::string moduleName;
+  std::string projectName;
   std::vector<std::string> packageSteps;
 
   PackageCoordinate(
       const std::string& moduleName_,
       const std::vector<std::string>& packageSteps_) :
-      moduleName(moduleName_),
+      projectName(moduleName_),
       packageSteps(packageSteps_)
   {}
 
@@ -37,14 +37,14 @@ struct PackageCoordinate {
   struct Hasher {
     size_t operator()(const PackageCoordinate *a) const {
       size_t hash = 0;
-      hash = hash * 37 + std::hash<std::string>()(a->moduleName);
+      hash = hash * 37 + std::hash<std::string>()(a->projectName);
       hash = hash * 41 + StringVectorHasher()(a->packageSteps);
       return hash;
     }
   };
   struct Equator {
     bool operator()(const PackageCoordinate* a, const PackageCoordinate* b) const {
-      if (a->moduleName != b->moduleName)
+      if (a->projectName != b->projectName)
         return false;
       if (!StringVectorEquator()(a->packageSteps, b->packageSteps))
         return false;

--- a/Midas/src/c-compiler/metal/readjson.cpp
+++ b/Midas/src/c-compiler/metal/readjson.cpp
@@ -613,6 +613,7 @@ Package* readPackage(MetalCache* cache, const json& program) {
   assert(program["__type"] == "Package");
   return new Package(
       cache->addressNumberer,
+      readPackageCoordinate(cache, program["packageCoordinate"]),
       readArrayIntoMap<std::string, InterfaceDefinition*>(
           cache,
           std::hash<std::string>(),

--- a/Midas/src/c-compiler/metal/readjson.cpp
+++ b/Midas/src/c-compiler/metal/readjson.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <sstream>
 
 #include "readjson.h"
 #include "metal/instructions.h"
@@ -13,6 +14,7 @@ Ownership readUnconvertedOwnership(MetalCache* cache, const json& ownership);
 Location readLocation(MetalCache* cache, const json& location);
 Mutability readMutability(const json& mutability);
 Variability readVariability(const json& variability);
+Name* readName(MetalCache* cache, const json& name);
 
 //template<typename T>
 //concept ReturnsVec = requires(T a) {
@@ -30,10 +32,10 @@ std::vector<T> readArray(MetalCache* cache, const json& j, const F& f) {
   return vec;
 }
 // F should return pair<key, value>
-template<typename K, typename V, typename H, typename F>
-std::unordered_map<K, V, H> readArrayIntoMap(MetalCache* cache, H h, const json& j, const F& f) {
+template<typename K, typename V, typename H, typename E, typename F>
+std::unordered_map<K, V, H, E> readArrayIntoMap(MetalCache* cache, H h, E e, const json& j, const F& f) {
   assert(j.is_array());
-  std::unordered_map<K, V, H> map(0, move(h));
+  std::unordered_map<K, V, H, E> map(0, move(h), move(e));
   map.reserve(j.size());
   for (const auto& element : j) {
     std::pair<K, V> p = f(cache, element);
@@ -43,29 +45,50 @@ std::unordered_map<K, V, H> readArrayIntoMap(MetalCache* cache, H h, const json&
   return map;
 }
 
-Name* readName(MetalCache* cache, const json& name) {
+std::string readString(MetalCache* cache, const json& name) {
   assert(name.is_string());
   auto nameStr = name.get<std::string>();
-
-  return cache->getName(nameStr);
+  return nameStr;
 }
 
-StructReferend* readStructReferend(MetalCache* cache, const json& referend) {
-  assert(referend["__type"] == "StructId");
+PackageCoordinate* readPackageCoordinate(MetalCache* cache, const json& packageCoord) {
+  assert(packageCoord["__type"] == "PackageCoordinate");
+  auto moduleName = readString(cache, packageCoord["project"]);//.get<std::string>();
+  auto packageSteps = readArray(cache, packageCoord["packageSteps"], readString);
+  return cache->getPackageCoordinate(moduleName, packageSteps);
+}
 
-  auto structName = readName(cache, referend["name"]);
+Name* readName(MetalCache* cache, const json& name) {
+  assert(name.is_object());
+  auto packageCoord = readPackageCoordinate(cache, name["packageCoordinate"]);
+  auto readableName = readString(cache, name["readableName"]);
+  int id = name["id"];
+  auto parts = readArray(cache, name["parts"], readString);
 
-  auto result = cache->getStructReferend(structName);
+  std::stringstream nameStrBuilder;
+  nameStrBuilder << readableName;
+  if (id >= 0) {
+    nameStrBuilder << "_" << id;
+  }
+  return cache->getName(packageCoord, nameStrBuilder.str());
+}
+
+StructKind* readStructKind(MetalCache* cache, const json& kind) {
+  assert(kind["__type"] == "StructId");
+
+  auto structName = readName(cache, kind["name"]);
+
+  auto result = cache->getStructKind(structName);
 
   return result;
 }
 
-InterfaceReferend* readInterfaceReferend(MetalCache* cache, const json& referend) {
-  assert(referend["__type"] == "InterfaceId");
+InterfaceKind* readInterfaceKind(MetalCache* cache, const json& kind) {
+  assert(kind["__type"] == "InterfaceId");
 
-  auto interfaceName = readName(cache, referend["name"]);
+  auto interfaceName = readName(cache, kind["name"]);
 
-  return cache->getInterfaceReferend(interfaceName);
+  return cache->getInterfaceKind(interfaceName);
 }
 
 RawArrayT* readRawArray(MetalCache* cache, const json& rawArray) {
@@ -79,22 +102,22 @@ RawArrayT* readRawArray(MetalCache* cache, const json& rawArray) {
   return new RawArrayT(regionId, mutability, variability, elementType);
 }
 
-RuntimeSizedArrayT* readRuntimeSizedArray(MetalCache* cache, const json& referend) {
-  auto name = readName(cache, referend["name"]);
+RuntimeSizedArrayT* readRuntimeSizedArray(MetalCache* cache, const json& kind) {
+  auto name = readName(cache, kind["name"]);
 
   return cache->getRuntimeSizedArray(name);
 }
 
 RuntimeSizedArrayDefinitionT* readRuntimeSizedArrayDefinition(MetalCache* cache, const json& rsa) {
   auto name = readName(cache, rsa["name"]);
-  auto referend = readRuntimeSizedArray(cache, rsa["referend"]);
+  auto kind = readRuntimeSizedArray(cache, rsa["kind"]);
   auto rawArray = readRawArray(cache, rsa["array"]);
 
-  return new RuntimeSizedArrayDefinitionT(name, referend, rawArray);
+  return new RuntimeSizedArrayDefinitionT(name, kind, rawArray);
 }
 
-StaticSizedArrayT* readStaticSizedArray(MetalCache* cache, const json& referend) {
-  auto name = readName(cache, referend["name"]);
+StaticSizedArrayT* readStaticSizedArray(MetalCache* cache, const json& kind) {
+  auto name = readName(cache, kind["name"]);
 
   return makeIfNotPresent(
       &cache->staticSizedArrays,
@@ -104,35 +127,35 @@ StaticSizedArrayT* readStaticSizedArray(MetalCache* cache, const json& referend)
 
 StaticSizedArrayDefinitionT* readStaticSizedArrayDefinition(MetalCache* cache, const json& ssa) {
   auto name = readName(cache, ssa["name"]);
-  auto referend = readStaticSizedArray(cache, ssa["referend"]);
+  auto kind = readStaticSizedArray(cache, ssa["kind"]);
   auto rawArray = readRawArray(cache, ssa["array"]);
   auto size = ssa["size"].get<int>();
 
-  return new StaticSizedArrayDefinitionT(name, referend, size, rawArray);
+  return new StaticSizedArrayDefinitionT(name, kind, size, rawArray);
 }
 
-Referend* readReferend(MetalCache* cache, const json& referend) {
-  assert(referend.is_object());
-  if (referend["__type"] == "Int") {
+Kind* readKind(MetalCache* cache, const json& kind) {
+  assert(kind.is_object());
+  if (kind["__type"] == "Int") {
     return cache->innt;
-  } else if (referend["__type"] == "Bool") {
+  } else if (kind["__type"] == "Bool") {
     return cache->boool;
-  } else if (referend["__type"] == "Float") {
+  } else if (kind["__type"] == "Float") {
     return cache->flooat;
-  } else if (referend["__type"] == "Str") {
+  } else if (kind["__type"] == "Str") {
     return cache->str;
-  } else if (referend["__type"] == "StructId") {
-    return readStructReferend(cache, referend);
-  } else if (referend["__type"] == "Never") {
+  } else if (kind["__type"] == "StructId") {
+    return readStructKind(cache, kind);
+  } else if (kind["__type"] == "Never") {
     return cache->never;
-  } else if (referend["__type"] == "RuntimeSizedArray") {
-    return readRuntimeSizedArray(cache, referend);
-  } else if (referend["__type"] == "StaticSizedArray") {
-    return readStaticSizedArray(cache, referend);
-  } else if (referend["__type"] == "InterfaceId") {
-    return readInterfaceReferend(cache, referend);
+  } else if (kind["__type"] == "RuntimeSizedArray") {
+    return readRuntimeSizedArray(cache, kind);
+  } else if (kind["__type"] == "StaticSizedArray") {
+    return readStaticSizedArray(cache, kind);
+  } else if (kind["__type"] == "InterfaceId") {
+    return readInterfaceKind(cache, kind);
   } else {
-    std::cerr << "Unrecognized referend: " << referend["__type"] << std::endl;
+    std::cerr << "Unrecognized kind: " << kind["__type"] << std::endl;
     assert(false);
   }
 }
@@ -143,13 +166,13 @@ Reference* readReference(MetalCache* cache, const json& reference) {
 
   auto ownership = readUnconvertedOwnership(cache, reference["ownership"]);
   auto location = readLocation(cache, reference["location"]);
-  auto referend = readReferend(cache, reference["referend"]);
+  auto kind = readKind(cache, reference["kind"]);
 //  std::string debugStr = reference["debugStr"];
 
   return cache->getReference(
       ownership,
       location,
-      referend);
+      kind);
 }
 
 Mutability readMutability(const json& mutability) {
@@ -221,7 +244,7 @@ VariableId* readVariableId(MetalCache* cache, const json& variable) {
   int height = variable["height"];
   std::string maybeName;
   if (variable["optName"]["__type"] == "Some") {
-    maybeName = variable["optName"]["value"];
+    maybeName = readName(cache, variable["optName"]["value"])->name;
   }
 
   return makeIfNotPresent(
@@ -272,7 +295,7 @@ Expression* readExpression(MetalCache* cache, const json& expression) {
     return new LocalStore(
         readLocal(cache, expression["local"]),
         readExpression(cache, expression["sourceExpr"]),
-        expression["localName"],
+        readName(cache, expression["localName"])->name,
         expression["knownLive"]);
   } else if (type == "MemberStore") {
     return new MemberStore(
@@ -282,7 +305,7 @@ Expression* readExpression(MetalCache* cache, const json& expression) {
         expression["memberIndex"],
         readExpression(cache, expression["sourceExpr"]),
         readReference(cache, expression["resultType"]),
-        expression["memberName"]);
+        readName(cache, expression["memberName"])->name);
   } else if (type == "Discard") {
     return new Discard(
         readExpression(cache, expression["sourceExpr"]),
@@ -298,12 +321,12 @@ Expression* readExpression(MetalCache* cache, const json& expression) {
     return new LocalLoad(
         readLocal(cache, expression["local"]),
         readUnconvertedOwnership(cache, expression["targetOwnership"]),
-        expression["localName"]);
+        readName(cache, expression["localName"])->name);
   } else if (type == "WeakAlias") {
     return new WeakAlias(
         readExpression(cache, expression["sourceExpr"]),
         readReference(cache, expression["sourceType"]),
-        readReferend(cache, expression["sourceReferend"]),
+        readKind(cache, expression["sourceKind"]),
         readReference(cache, expression["resultType"]));
   } else if (type == "NarrowPermission") {
     return new NarrowPermission(
@@ -349,24 +372,24 @@ Expression* readExpression(MetalCache* cache, const json& expression) {
   } else if (type == "MemberLoad") {
     return new MemberLoad(
         readExpression(cache, expression["structExpr"]),
-        readStructReferend(cache, expression["structId"]),
+        readStructKind(cache, expression["structId"]),
         readReference(cache, expression["structType"]),
         expression["structKnownLive"],
         expression["memberIndex"],
         readUnconvertedOwnership(cache, expression["targetOwnership"]),
         readReference(cache, expression["expectedMemberType"]),
         readReference(cache, expression["expectedResultType"]),
-        expression["memberName"]);
+        readName(cache, expression["memberName"])->name);
   } else if (type == "NewArrayFromValues") {
     return new NewArrayFromValues(
         readArray(cache, expression["sourceExprs"], readExpression),
         readReference(cache, expression["resultType"]),
-        readStaticSizedArray(cache, expression["resultReferend"]));
+        readStaticSizedArray(cache, expression["resultKind"]));
   } else if (type == "StaticSizedArrayLoad") {
     return new StaticSizedArrayLoad(
         readExpression(cache, expression["arrayExpr"]),
         readReference(cache, expression["arrayType"]),
-        readStaticSizedArray(cache, expression["arrayReferend"]),
+        readStaticSizedArray(cache, expression["arrayKind"]),
         expression["arrayKnownLive"],
         readExpression(cache, expression["indexExpr"]),
         readReference(cache, expression["resultType"]),
@@ -377,11 +400,11 @@ Expression* readExpression(MetalCache* cache, const json& expression) {
     return new RuntimeSizedArrayLoad(
         readExpression(cache, expression["arrayExpr"]),
         readReference(cache, expression["arrayType"]),
-        readRuntimeSizedArray(cache, expression["arrayReferend"]),
+        readRuntimeSizedArray(cache, expression["arrayKind"]),
         expression["arrayKnownLive"],
         readExpression(cache, expression["indexExpr"]),
         readReference(cache, expression["indexType"]),
-        readReferend(cache, expression["indexReferend"]),
+        readKind(cache, expression["indexKind"]),
         readReference(cache, expression["resultType"]),
         readUnconvertedOwnership(cache, expression["targetOwnership"]),
         readReference(cache, expression["expectedElementType"]));
@@ -389,22 +412,22 @@ Expression* readExpression(MetalCache* cache, const json& expression) {
     return new RuntimeSizedArrayStore(
         readExpression(cache, expression["arrayExpr"]),
         readReference(cache, expression["arrayType"]),
-        readRuntimeSizedArray(cache, expression["arrayReferend"]),
+        readRuntimeSizedArray(cache, expression["arrayKind"]),
         expression["arrayKnownLive"],
         readExpression(cache, expression["indexExpr"]),
         readReference(cache, expression["indexType"]),
-        readReferend(cache, expression["indexReferend"]),
+        readKind(cache, expression["indexKind"]),
         readExpression(cache, expression["sourceExpr"]),
         readReference(cache, expression["sourceType"]),
-        readReferend(cache, expression["sourceReferend"]));
+        readKind(cache, expression["sourceKind"]));
   } else if (type == "ConstructRuntimeSizedArray") {
     return new ConstructRuntimeSizedArray(
         readExpression(cache, expression["sizeExpr"]),
         readReference(cache, expression["sizeType"]),
-        readReferend(cache, expression["sizeReferend"]),
+        readKind(cache, expression["sizeKind"]),
         readExpression(cache, expression["generatorExpr"]),
         readReference(cache, expression["generatorType"]),
-        readReferend(cache, expression["generatorReferend"]),
+        readKind(cache, expression["generatorKind"]),
         readPrototype(cache, expression["generatorMethod"]),
         expression["generatorKnownLive"],
         readReference(cache, expression["resultType"]),
@@ -413,7 +436,7 @@ Expression* readExpression(MetalCache* cache, const json& expression) {
     return new StaticArrayFromCallable(
         readExpression(cache, expression["generatorExpr"]),
         readReference(cache, expression["generatorType"]),
-        readReferend(cache, expression["generatorReferend"]),
+        readKind(cache, expression["generatorKind"]),
         readPrototype(cache, expression["generatorMethod"]),
         expression["generatorKnownLive"],
         readReference(cache, expression["resultType"]),
@@ -422,10 +445,10 @@ Expression* readExpression(MetalCache* cache, const json& expression) {
     return new DestroyRuntimeSizedArray(
         readExpression(cache, expression["arrayExpr"]),
         readReference(cache, expression["arrayType"]),
-        readRuntimeSizedArray(cache, expression["arrayReferend"]),
+        readRuntimeSizedArray(cache, expression["arrayKind"]),
         readExpression(cache, expression["consumerExpr"]),
         readReference(cache, expression["consumerType"]),
-        readInterfaceReferend(cache, expression["consumerReferend"]),
+        readInterfaceKind(cache, expression["consumerKind"]),
         readPrototype(cache, expression["consumerMethod"]),
         expression["consumerKnownLive"]);
   } else if (type == "ArrayLength") {
@@ -437,14 +460,14 @@ Expression* readExpression(MetalCache* cache, const json& expression) {
     return new StructToInterfaceUpcast(
         readExpression(cache, expression["sourceExpr"]),
         readReference(cache, expression["sourceStructType"]),
-        readStructReferend(cache, expression["sourceStructReferend"]),
+        readStructKind(cache, expression["sourceStructKind"]),
         readReference(cache, expression["targetInterfaceType"]),
-        readInterfaceReferend(cache, expression["targetInterfaceReferend"]));
+        readInterfaceKind(cache, expression["targetInterfaceKind"]));
   } else if (type == "DestroyStaticSizedArrayIntoFunction") {
     return new DestroyStaticSizedArrayIntoFunction(
         readExpression(cache, expression["arrayExpr"]),
         readReference(cache, expression["arrayType"]),
-        readStaticSizedArray(cache, expression["arrayReferend"]),
+        readStaticSizedArray(cache, expression["arrayKind"]),
         readExpression(cache, expression["consumerExpr"]),
         readReference(cache, expression["consumerType"]),
         readPrototype(cache, expression["consumerMethod"]),
@@ -455,7 +478,7 @@ Expression* readExpression(MetalCache* cache, const json& expression) {
     return new InterfaceCall(
         readArray(cache, expression["argExprs"], readExpression),
         expression["virtualParamIndex"],
-        readInterfaceReferend(cache, expression["interfaceRef"]),
+        readInterfaceKind(cache, expression["interfaceRef"]),
         expression["indexInEdge"],
         readPrototype(cache, expression["functionType"]));
   } else if (type == "ConstantStr") {
@@ -470,26 +493,26 @@ Expression* readExpression(MetalCache* cache, const json& expression) {
         expression["sourceKnownLive"],
         readPrototype(cache, expression["someConstructor"]),
         readReference(cache, expression["someType"]),
-        readStructReferend(cache, expression["someReferend"]),
+        readStructKind(cache, expression["someKind"]),
         readPrototype(cache, expression["noneConstructor"]),
         readReference(cache, expression["noneType"]),
-        readStructReferend(cache, expression["noneReferend"]),
+        readStructKind(cache, expression["noneKind"]),
         readReference(cache, expression["resultOptType"]),
-        readInterfaceReferend(cache, expression["resultOptReferend"]));
+        readInterfaceKind(cache, expression["resultOptKind"]));
   } else if (type == "AsSubtype") {
     return new AsSubtype(
         readExpression(cache, expression["sourceExpr"]),
         readReference(cache, expression["sourceType"]),
         expression["sourceKnownLive"],
-        readReferend(cache, expression["targetReferend"]),
+        readKind(cache, expression["targetKind"]),
         readPrototype(cache, expression["okConstructor"]),
         readReference(cache, expression["okType"]),
-        readStructReferend(cache, expression["okReferend"]),
+        readStructKind(cache, expression["okKind"]),
         readPrototype(cache, expression["errConstructor"]),
         readReference(cache, expression["errType"]),
-        readStructReferend(cache, expression["errReferend"]),
+        readStructKind(cache, expression["errKind"]),
         readReference(cache, expression["resultResultType"]),
-        readInterfaceReferend(cache, expression["resultResultReferend"]));
+        readInterfaceKind(cache, expression["resultResultKind"]));
   } else {
     std::cerr << "Unexpected instruction: " << type << std::endl;
     assert(false);
@@ -500,7 +523,7 @@ StructMember* readStructMember(MetalCache* cache, const json& struuct) {
   assert(struuct.is_object());
   assert(struuct["__type"] == "StructMember");
   return new StructMember(
-      struuct["fullName"],
+      readName(cache, struuct["fullName"])->name,
       struuct["name"],
       readVariability(struuct["variability"]),
       readReference(cache, struuct["type"]));
@@ -526,8 +549,8 @@ Edge* readEdge(MetalCache* cache, const json& edge) {
   assert(edge.is_object());
   assert(edge["__type"] == "Edge");
   return new Edge(
-      readStructReferend(cache, edge["structName"]),
-      readInterfaceReferend(cache, edge["interfaceName"]),
+      readStructKind(cache, edge["structName"]),
+      readInterfaceKind(cache, edge["interfaceName"]),
       readArray(cache, edge["methods"], readInterfaceMethodAndPrototypeEntry));
 }
 
@@ -538,7 +561,7 @@ StructDefinition* readStruct(MetalCache* cache, const json& struuct) {
   auto result =
       new StructDefinition(
           readName(cache, struuct["name"]),
-          readStructReferend(cache, struuct["referend"]),
+          readStructKind(cache, struuct["kind"]),
           mutability == Mutability::IMMUTABLE ? cache->rcImmRegionId : cache->mutRegionId,
           mutability,
           readArray(cache, struuct["edges"], readEdge),
@@ -547,7 +570,7 @@ StructDefinition* readStruct(MetalCache* cache, const json& struuct) {
 
   auto structName = result->name;
   if (structName->name == std::string("Tup0_0")) {
-    cache->emptyTupleStruct = cache->getStructReferend(structName);
+    cache->emptyTupleStruct = cache->getStructKind(structName);
     cache->emptyTupleStructRef =
         cache->getReference(Ownership::SHARE, Location::INLINE, cache->emptyTupleStruct);
   }
@@ -561,7 +584,7 @@ InterfaceDefinition* readInterface(MetalCache* cache, const json& interface) {
   auto mutability = readMutability(interface["mutability"]);
   return new InterfaceDefinition(
       readName(cache, interface["name"]),
-      readInterfaceReferend(cache, interface["referend"]),
+      readInterfaceKind(cache, interface["kind"]),
       mutability == Mutability::IMMUTABLE ? cache->rcImmRegionId : cache->mutRegionId,
       mutability,
       {},
@@ -577,21 +600,23 @@ Function* readFunction(MetalCache* cache, const json& function) {
       readExpression(cache, function["block"]));
 }
 
-std::pair<Referend*, Prototype*> readReferendAndPrototypeEntry(MetalCache* cache, const json& edge) {
+std::pair<Kind*, Prototype*> readKindAndPrototypeEntry(MetalCache* cache, const json& edge) {
   assert(edge.is_object());
   assert(edge["__type"] == "Entry");
   return std::make_pair(
-      readReferend(cache, edge["referend"]),
+      readKind(cache, edge["kind"]),
       readPrototype(cache, edge["destructor"]));
 }
 
-Program* readProgram(MetalCache* cache, const json& program) {
+Package* readPackage(MetalCache* cache, const json& program) {
   assert(program.is_object());
-  assert(program["__type"] == "Program");
-  return new Program(
+  assert(program["__type"] == "Package");
+  return new Package(
+      cache->addressNumberer,
       readArrayIntoMap<std::string, InterfaceDefinition*>(
           cache,
           std::hash<std::string>(),
+          std::equal_to<std::string>(),
           program["interfaces"],
           [](MetalCache* cache, json j){
             auto s = readInterface(cache, j);
@@ -600,6 +625,7 @@ Program* readProgram(MetalCache* cache, const json& program) {
       readArrayIntoMap<std::string, StructDefinition*>(
           cache,
           std::hash<std::string>(),
+          std::equal_to<std::string>(),
           program["structs"],
           [](MetalCache* cache, json j){
             auto s = readStruct(cache, j);
@@ -608,6 +634,7 @@ Program* readProgram(MetalCache* cache, const json& program) {
       readArrayIntoMap<std::string, StaticSizedArrayDefinitionT*>(
           cache,
           std::hash<std::string>(),
+          std::equal_to<std::string>(),
           program["staticSizedArrays"],
           [](MetalCache* cache, json j){
             auto s = readStaticSizedArrayDefinition(cache, j);
@@ -616,44 +643,97 @@ Program* readProgram(MetalCache* cache, const json& program) {
       readArrayIntoMap<std::string, RuntimeSizedArrayDefinitionT*>(
           cache,
           std::hash<std::string>(),
+          std::equal_to<std::string>(),
           program["runtimeSizedArrays"],
           [](MetalCache* cache, json j){
             auto s = readRuntimeSizedArrayDefinition(cache, j);
             return std::make_pair(s->name->name, s);
           }),
-      readStructReferend(cache, program["emptyTupleStructReferend"]),
-      readArrayIntoMap<std::string, Prototype*>(
-          cache,
-          std::hash<std::string>(),
-          program["externFunctions"],
-          [](MetalCache* cache, json j){
-            auto f = readPrototype(cache, j);
-            return std::make_pair(f->name->name, f);
-          }),
+      readStructKind(cache, program["emptyTupleStructKind"]),
+//      readArrayIntoMap<std::string, Prototype*>(
+//          cache,
+//          std::hash<std::string>(),
+//          std::equal_to<std::string>(),
+//          program["externFunctions"],
+//          [](MetalCache* cache, json j){
+//            auto f = readPrototype(cache, j);
+//            return std::make_pair(f->name->name, f);
+//          }),
       readArrayIntoMap<std::string, Function*>(
           cache,
           std::hash<std::string>(),
+          std::equal_to<std::string>(),
           program["functions"],
           [](MetalCache* cache, json j){
             auto f = readFunction(cache, j);
             return std::make_pair(f->prototype->name->name, f);
           }),
-      readArrayIntoMap<Referend*, Prototype*>(
+      readArrayIntoMap<Kind*, Prototype*>(
           cache,
-          AddressHasher<Referend*>(cache->addressNumberer),
-          program["immDestructorsByReferend"],
-          readReferendAndPrototypeEntry),
-      readArrayIntoMap<Name*, std::vector<std::string>>(
+          AddressHasher<Kind*>(cache->addressNumberer),
+          std::equal_to<Kind*>(),
+          program["immDestructorsByKind"],
+          readKindAndPrototypeEntry),
+      readArrayIntoMap<std::string, Prototype*>(
           cache,
-          AddressHasher<Name*>(cache->addressNumberer),
-          program["fullNameToExportedNames"],
+          std::hash<std::string>(),
+          std::equal_to<std::string>(),
+          program["exportNameToFunction"],
           [](MetalCache* cache, json entryJ){
-            auto fullName = readName(cache, entryJ["fullName"]);
-            auto exportedNamesJ = entryJ["exportedNames"];
-            auto exportedNames =
-                readArray(cache, exportedNamesJ, [](MetalCache* cache, json j) -> std::string {
-                  return j;
-                });
-            return std::make_pair(fullName, exportedNames);
+            auto exportName = readString(cache, entryJ["exportName"]);
+            auto prototype = readPrototype(cache, entryJ["prototype"]);
+            return std::make_pair(exportName, prototype);
+          }),
+      readArrayIntoMap<std::string, Kind*>(
+          cache,
+          std::hash<std::string>(),
+          std::equal_to<std::string>(),
+          program["exportNameToKind"],
+          [](MetalCache* cache, json entryJ){
+            auto exportName = readString(cache, entryJ["exportName"]);
+            auto kind = readKind(cache, entryJ["kind"]);
+            return std::make_pair(exportName, kind);
+          }),
+      readArrayIntoMap<std::string, Prototype*>(
+          cache,
+          std::hash<std::string>(),
+          std::equal_to<std::string>(),
+          program["externNameToFunction"],
+          [](MetalCache* cache, json entryJ){
+            auto externName = readString(cache, entryJ["externName"]);
+            auto prototype = readPrototype(cache, entryJ["prototype"]);
+            return std::make_pair(externName, prototype);
+          }),
+      readArrayIntoMap<std::string, Kind*>(
+          cache,
+          std::hash<std::string>(),
+          std::equal_to<std::string>(),
+          program["externNameToKind"],
+          [](MetalCache* cache, json entryJ){
+            auto externName = readString(cache, entryJ["externName"]);
+            auto kind = readKind(cache, entryJ["kind"]);
+            return std::make_pair(externName, kind);
+          }));
+}
+
+std::pair<PackageCoordinate*, Package*> readPackageCoordinateAndPackageEntry(MetalCache* cache, const json& edge) {
+  assert(edge.is_object());
+  assert(edge["__type"] == "Entry");
+  return std::make_pair<PackageCoordinate*, Package*>(
+      readPackageCoordinate(cache, edge["packageCoordinate"]),
+      readPackage(cache, edge["package"]));
+}
+
+Program* readProgram(MetalCache* cache, const json& program) {
+  assert(program.is_object());
+  assert(program["__type"] == "Program");
+  return new Program(
+      readArrayIntoMap<PackageCoordinate*, Package*, AddressHasher<PackageCoordinate*>, std::equal_to<PackageCoordinate*>>(
+          cache,
+          cache->addressNumberer->makeHasher<PackageCoordinate*>(),
+          std::equal_to<PackageCoordinate*>(),
+          program["packages"],
+          [](MetalCache* cache, json j){
+            return readPackageCoordinateAndPackageEntry(cache, j);
           }));
 }

--- a/Midas/src/c-compiler/metal/types.h
+++ b/Midas/src/c-compiler/metal/types.h
@@ -15,15 +15,15 @@ class CodeLocation;
 
 // Defined in this file
 class Reference;
-class Referend;
+class Kind;
 class Int;
 class Bool;
 class Str;
 class Void;
 class Float;
 class Never;
-class InterfaceReferend;
-class StructReferend;
+class InterfaceKind;
+class StructKind;
 class RawArrayT;
 class StaticSizedArrayT;
 class RuntimeSizedArrayT;
@@ -79,18 +79,18 @@ class Reference {
 public:
   Ownership ownership;
   Location location;
-  Referend* referend;
+  Kind* kind;
 //  std::string debugStr;
 
   Reference(
       Ownership ownership_,
       Location location_,
-      Referend* referend_
+      Kind* kind_
 //      , const std::string& debugStr_
   ) :
       ownership(ownership_),
       location(location_),
-      referend(referend_)
+      kind(kind_)
 //    , debugStr(debugStr_)
   {
 
@@ -103,13 +103,13 @@ public:
   std::string str() { return ""; }
 };
 
-class Referend {
+class Kind {
 public:
-    virtual ~Referend() {}
+    virtual ~Kind() {}
     virtual PackageCoordinate* getPackageCoordinate() const = 0;
 };
 
-class Int : public Referend {
+class Int : public Kind {
 public:
   RegionId* regionId;
 
@@ -119,7 +119,7 @@ public:
   PackageCoordinate* getPackageCoordinate() const override { return regionId->packageCoord; }
 };
 
-class Bool : public Referend {
+class Bool : public Kind {
 public:
   RegionId* regionId;
 
@@ -129,7 +129,7 @@ public:
   PackageCoordinate* getPackageCoordinate() const override { return regionId->packageCoord; }
 };
 
-class Str : public Referend {
+class Str : public Kind {
 public:
   RegionId* regionId;
 
@@ -139,7 +139,7 @@ public:
   PackageCoordinate* getPackageCoordinate() const override { return regionId->packageCoord; }
 };
 
-class Float : public Referend {
+class Float : public Kind {
 public:
   RegionId* regionId;
 
@@ -149,7 +149,7 @@ public:
   PackageCoordinate* getPackageCoordinate() const override { return regionId->packageCoord; }
 };
 
-class Never : public Referend {
+class Never : public Kind {
 public:
   RegionId* regionId;
 
@@ -159,11 +159,11 @@ public:
   PackageCoordinate* getPackageCoordinate() const override { return regionId->packageCoord; }
 };
 
-class InterfaceReferend : public Referend {
+class InterfaceKind : public Kind {
 public:
     Name* fullName;
 
-  InterfaceReferend(Name* fullName_) :
+  InterfaceKind(Name* fullName_) :
       fullName(fullName_) {}
 
   PackageCoordinate* getPackageCoordinate() const override { return fullName->packageCoord; }
@@ -171,11 +171,11 @@ public:
 };
 
 // Interned
-class StructReferend : public Referend {
+class StructKind : public Kind {
 public:
     Name* fullName;
 
-    StructReferend(Name* fullName_) :
+    StructKind(Name* fullName_) :
         fullName(fullName_) {}
 
   PackageCoordinate* getPackageCoordinate() const override { return fullName->packageCoord; }
@@ -201,7 +201,7 @@ public:
 };
 
 // Interned
-class StaticSizedArrayT : public Referend {
+class StaticSizedArrayT : public Kind {
 public:
   Name* name;
 
@@ -215,17 +215,17 @@ public:
 class StaticSizedArrayDefinitionT {
 public:
   Name* name;
-  StaticSizedArrayT* referend;
+  StaticSizedArrayT* kind;
   int size;
   RawArrayT* rawArray;
 
   StaticSizedArrayDefinitionT(
       Name* name_,
-      StaticSizedArrayT* referend_,
+      StaticSizedArrayT* kind_,
       int size_,
       RawArrayT* rawArray_) :
       name(name_),
-      referend(referend_),
+      kind(kind_),
       size(size_),
       rawArray(rawArray_) {}
 
@@ -234,7 +234,7 @@ public:
 
 
 // Interned
-class RuntimeSizedArrayT : public Referend {
+class RuntimeSizedArrayT : public Kind {
 public:
   Name* name;
 
@@ -248,15 +248,15 @@ public:
 class RuntimeSizedArrayDefinitionT {
 public:
   Name* name;
-  RuntimeSizedArrayT* referend;
+  RuntimeSizedArrayT* kind;
   RawArrayT* rawArray;
 
   RuntimeSizedArrayDefinitionT(
       Name* name_,
-      RuntimeSizedArrayT* referend_,
+      RuntimeSizedArrayT* kind_,
       RawArrayT* rawArray_) :
       name(name_),
-      referend(referend_),
+      kind(kind_),
       rawArray(rawArray_) {}
 
 };

--- a/Midas/src/c-compiler/metal/types.h
+++ b/Midas/src/c-compiler/metal/types.h
@@ -6,8 +6,11 @@
 #include <vector>
 #include <cassert>
 
+#include "name.h"
+
 // Defined elsewhere
 class Name;
+class PackageCoordinate;
 class CodeLocation;
 
 // Defined in this file
@@ -64,10 +67,11 @@ enum class Variability {
 };
 
 struct RegionId {
+  PackageCoordinate* packageCoord;
   std::string id;
 
-  RegionId(std::string id_) :
-      id(id_) {}
+  RegionId(PackageCoordinate* packageCoord_, std::string id_) :
+      packageCoord(packageCoord_), id(id_) {}
 };
 
 // Interned
@@ -102,6 +106,7 @@ public:
 class Referend {
 public:
     virtual ~Referend() {}
+    virtual PackageCoordinate* getPackageCoordinate() const = 0;
 };
 
 class Int : public Referend {
@@ -110,6 +115,8 @@ public:
 
   Int(RegionId* regionId_) :
       regionId(regionId_) {}
+
+  PackageCoordinate* getPackageCoordinate() const override { return regionId->packageCoord; }
 };
 
 class Bool : public Referend {
@@ -118,6 +125,8 @@ public:
 
   Bool(RegionId* regionId_) :
       regionId(regionId_) {}
+
+  PackageCoordinate* getPackageCoordinate() const override { return regionId->packageCoord; }
 };
 
 class Str : public Referend {
@@ -126,6 +135,8 @@ public:
 
   Str(RegionId* regionId_) :
       regionId(regionId_) {}
+
+  PackageCoordinate* getPackageCoordinate() const override { return regionId->packageCoord; }
 };
 
 class Float : public Referend {
@@ -134,6 +145,8 @@ public:
 
   Float(RegionId* regionId_) :
       regionId(regionId_) {}
+
+  PackageCoordinate* getPackageCoordinate() const override { return regionId->packageCoord; }
 };
 
 class Never : public Referend {
@@ -142,6 +155,8 @@ public:
 
   Never(RegionId* regionId_) :
       regionId(regionId_) {}
+
+  PackageCoordinate* getPackageCoordinate() const override { return regionId->packageCoord; }
 };
 
 class InterfaceReferend : public Referend {
@@ -150,6 +165,8 @@ public:
 
   InterfaceReferend(Name* fullName_) :
       fullName(fullName_) {}
+
+  PackageCoordinate* getPackageCoordinate() const override { return fullName->packageCoord; }
 
 };
 
@@ -160,6 +177,8 @@ public:
 
     StructReferend(Name* fullName_) :
         fullName(fullName_) {}
+
+  PackageCoordinate* getPackageCoordinate() const override { return fullName->packageCoord; }
 };
 
 // Interned
@@ -190,6 +209,7 @@ public:
       Name* name_) :
       name(name_) {}
 
+  PackageCoordinate* getPackageCoordinate() const override { return name->packageCoord; }
 };
 
 class StaticSizedArrayDefinitionT {
@@ -222,6 +242,7 @@ public:
       Name* name_) :
       name(name_) {}
 
+  PackageCoordinate* getPackageCoordinate() const override { return name->packageCoord; }
 };
 
 class RuntimeSizedArrayDefinitionT {

--- a/Midas/src/c-compiler/midasfunctions.cpp
+++ b/Midas/src/c-compiler/midasfunctions.cpp
@@ -5,19 +5,19 @@
 
 //void declareExtraInterfaceMethod(
 //    GlobalState* globalState,
-//    InterfaceReferend* referend,
+//    InterfaceKind* kind,
 //    InterfaceMethod* newMethod,
-//    std::function<Prototype*(StructReferend*)> declarer,
-//    std::function<void(StructReferend*, Prototype*)> bodyGenerator) {
+//    std::function<Prototype*(StructKind*)> declarer,
+//    std::function<void(StructKind*, Prototype*)> bodyGenerator) {
 //  auto program = globalState->program;
 //
 //  std::vector<Prototype*> substructPrototypes;
 //
-//  globalState->addInterfaceExtraMethod(referend, newMethod);
+//  globalState->addInterfaceExtraMethod(kind, newMethod);
 //
 //  for (auto nameAndStruct : globalState->program->structs) {
 //    for (auto edge : nameAndStruct.second->edges) {
-//      if (edge->interfaceName == referend) {
+//      if (edge->interfaceName == kind) {
 //        auto substruct = edge->structName;
 //
 //        Reference *substructReference = nullptr;
@@ -40,8 +40,8 @@
 //
 //  for (auto substructPrototype : substructPrototypes) {
 //    auto substruct =
-//        dynamic_cast<StructReferend*>(
-//            substructPrototype->params[newMethod->virtualParamIndex]->referend);
+//        dynamic_cast<StructKind*>(
+//            substructPrototype->params[newMethod->virtualParamIndex]->kind);
 //    assert(substruct);
 //    bodyGenerator(substruct, substructPrototype);
 //  }

--- a/Midas/src/c-compiler/midasfunctions.h
+++ b/Midas/src/c-compiler/midasfunctions.h
@@ -5,9 +5,9 @@
 
 //void declareExtraInterfaceMethod(
 //    GlobalState* globalState,
-//    InterfaceReferend* referend,
+//    InterfaceKind* kind,
 //    InterfaceMethod* newMethod,
 //    std::function<LLVMValueRef(Prototype*)> declarer,
-//    std::function<void(StructReferend*, Prototype*)> bodyGenerator);
+//    std::function<void(StructKind*, Prototype*)> bodyGenerator);
 
 #endif

--- a/Midas/src/c-compiler/region/assist/assist.cpp
+++ b/Midas/src/c-compiler/region/assist/assist.cpp
@@ -18,25 +18,25 @@ Assist::Assist(GlobalState* globalState_) :
         globalState,
         makeAssistAndNaiveRCWeakableControlBlock(globalState),
         WrcWeaks::makeWeakRefHeaderStruct(globalState)),
-    referendStructs(
+    kindStructs(
         globalState,
-        [this](Referend* referend) -> IReferendStructsSource* {
-          if (globalState->getReferendWeakability(referend) == Weakability::NON_WEAKABLE) {
+        [this](Kind* kind) -> IKindStructsSource* {
+          if (globalState->getKindWeakability(kind) == Weakability::NON_WEAKABLE) {
             return &mutNonWeakableStructs;
           } else {
             return &mutWeakableStructs;
           }
         }),
     weakRefStructs(
-        [this](Referend* referend) -> IWeakRefStructsSource* {
-          if (globalState->getReferendWeakability(referend) == Weakability::NON_WEAKABLE) {
+        [this](Kind* kind) -> IWeakRefStructsSource* {
+          if (globalState->getKindWeakability(kind) == Weakability::NON_WEAKABLE) {
             assert(false);
           } else {
             return &mutWeakableStructs;
           }
         }),
     fatWeaks(globalState_, &weakRefStructs),
-    wrcWeaks(globalState_, &referendStructs, &weakRefStructs) {
+    wrcWeaks(globalState_, &kindStructs, &weakRefStructs) {
   regionLT = LLVMStructCreateNamed(globalState->context, "__Assist_Region");
   LLVMStructSetBody(regionLT, nullptr, 0, false);
 }
@@ -59,36 +59,36 @@ void Assist::alias(
     LLVMBuilderRef builder,
     Reference* sourceRef,
     Ref ref) {
-  auto sourceRnd = sourceRef->referend;
+  auto sourceRnd = sourceRef->kind;
   buildFlare(FL(), globalState, functionState, builder);
   if (dynamic_cast<Int *>(sourceRnd) ||
       dynamic_cast<Bool *>(sourceRnd) ||
       dynamic_cast<Float *>(sourceRnd)) {
     // Do nothing for these, they're always inlined and copied.
-  } else if (dynamic_cast<InterfaceReferend *>(sourceRnd) ||
-      dynamic_cast<StructReferend *>(sourceRnd) ||
+  } else if (dynamic_cast<InterfaceKind *>(sourceRnd) ||
+      dynamic_cast<StructKind *>(sourceRnd) ||
       dynamic_cast<StaticSizedArrayT *>(sourceRnd) ||
       dynamic_cast<RuntimeSizedArrayT *>(sourceRnd) ||
       dynamic_cast<Str *>(sourceRnd)) {
     if (sourceRef->ownership == Ownership::OWN) {
       // This can happen if we just allocated something. It's RC is already zero, and we want to
       // bump it to 1 for the owning reference.
-      adjustStrongRc(from, globalState, functionState, &referendStructs, builder, ref, sourceRef, 1);
+      adjustStrongRc(from, globalState, functionState, &kindStructs, builder, ref, sourceRef, 1);
     } else if (sourceRef->ownership == Ownership::BORROW) {
-      adjustStrongRc(from, globalState, functionState, &referendStructs, builder, ref, sourceRef, 1);
+      adjustStrongRc(from, globalState, functionState, &kindStructs, builder, ref, sourceRef, 1);
     } else if (sourceRef->ownership == Ownership::WEAK) {
       aliasWeakRef(from, functionState, builder, sourceRef, ref);
     } else if (sourceRef->ownership == Ownership::SHARE) {
       if (sourceRef->location == Location::INLINE) {
         // Do nothing, we can just let inline structs disappear
       } else {
-        adjustStrongRc(from, globalState, functionState, &referendStructs, builder, ref, sourceRef, 1);
+        adjustStrongRc(from, globalState, functionState, &kindStructs, builder, ref, sourceRef, 1);
       }
     } else
       assert(false);
   } else {
     std::cerr << "Unimplemented type in alias: "
-        << typeid(*sourceRef->referend).name() << std::endl;
+        << typeid(*sourceRef->kind).name() << std::endl;
     assert(false);
   }
   buildFlare(FL(), globalState, functionState, builder);
@@ -105,9 +105,9 @@ void Assist::dealias(
     assert(false);
   } else if (sourceMT->ownership == Ownership::OWN) {
     // This can happen if we're sending an owning reference to the outside world, see DEPAR.
-    adjustStrongRc(from, globalState, functionState, &referendStructs, builder, sourceRef, sourceMT, -1);
+    adjustStrongRc(from, globalState, functionState, &kindStructs, builder, sourceRef, sourceMT, -1);
   } else if (sourceMT->ownership == Ownership::BORROW) {
-    adjustStrongRc(from, globalState, functionState, &referendStructs, builder, sourceRef, sourceMT, -1);
+    adjustStrongRc(from, globalState, functionState, &kindStructs, builder, sourceRef, sourceMT, -1);
   } else if (sourceMT->ownership == Ownership::WEAK) {
     discardWeakRef(from, functionState, builder, sourceMT, sourceRef);
   } else assert(false);
@@ -146,12 +146,12 @@ Ref Assist::asSubtype(
     Reference* sourceInterfaceRefMT,
     Ref sourceInterfaceRef,
     bool sourceRefKnownLive,
-    Referend* targetReferend,
+    Kind* targetKind,
     std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
     std::function<Ref(LLVMBuilderRef)> buildElse) {
   return regularDowncast(
       globalState, functionState, builder, thenResultIsNever, elseResultIsNever, resultOptTypeM, constraintRefM,
-      sourceInterfaceRefMT, sourceInterfaceRef, sourceRefKnownLive, targetReferend, buildThen, buildElse);
+      sourceInterfaceRefMT, sourceInterfaceRef, sourceRefKnownLive, targetKind, buildThen, buildElse);
 }
 
 LLVMTypeRef Assist::translateType(Reference* referenceM) {
@@ -161,10 +161,10 @@ LLVMTypeRef Assist::translateType(Reference* referenceM) {
     case Ownership::OWN:
     case Ownership::BORROW:
       assert(referenceM->location != Location::INLINE);
-      return translateReferenceSimple(globalState, &referendStructs, referenceM->referend);
+      return translateReferenceSimple(globalState, &kindStructs, referenceM->kind);
     case Ownership::WEAK:
       assert(referenceM->location != Location::INLINE);
-      return translateWeakReference(globalState, &weakRefStructs, referenceM->referend);
+      return translateWeakReference(globalState, &weakRefStructs, referenceM->kind);
     default:
       assert(false);
   }
@@ -174,28 +174,28 @@ Ref Assist::upcastWeak(
     FunctionState* functionState,
     LLVMBuilderRef builder,
     WeakFatPtrLE sourceRefLE,
-    StructReferend* sourceStructReferendM,
+    StructKind* sourceStructKindM,
     Reference* sourceStructTypeM,
-    InterfaceReferend* targetInterfaceReferendM,
+    InterfaceKind* targetInterfaceKindM,
     Reference* targetInterfaceTypeM) {
   return wrap(
       this,
       targetInterfaceTypeM,
       wrcWeaks.weakStructPtrToWrciWeakInterfacePtr(
-          globalState, functionState, builder, sourceRefLE, sourceStructReferendM,
-          sourceStructTypeM, targetInterfaceReferendM, targetInterfaceTypeM));
+          globalState, functionState, builder, sourceRefLE, sourceStructKindM,
+          sourceStructTypeM, targetInterfaceKindM, targetInterfaceTypeM));
 }
 
 void Assist::declareStaticSizedArray(
     StaticSizedArrayDefinitionT* staticSizedArrayMT) {
-  globalState->regionIdByReferend.emplace(staticSizedArrayMT->referend, getRegionId());
-  referendStructs.declareStaticSizedArray(staticSizedArrayMT);
+  globalState->regionIdByKind.emplace(staticSizedArrayMT->kind, getRegionId());
+  kindStructs.declareStaticSizedArray(staticSizedArrayMT);
 }
 
 void Assist::declareRuntimeSizedArray(
     RuntimeSizedArrayDefinitionT* runtimeSizedArrayMT) {
-  globalState->regionIdByReferend.emplace(runtimeSizedArrayMT->referend, getRegionId());
-  referendStructs.declareRuntimeSizedArray(runtimeSizedArrayMT);
+  globalState->regionIdByKind.emplace(runtimeSizedArrayMT->kind, getRegionId());
+  kindStructs.declareRuntimeSizedArray(runtimeSizedArrayMT);
 }
 
 void Assist::defineRuntimeSizedArray(
@@ -203,7 +203,7 @@ void Assist::defineRuntimeSizedArray(
   auto elementLT =
       globalState->getRegion(runtimeSizedArrayMT->rawArray->elementType)
           ->translateType(runtimeSizedArrayMT->rawArray->elementType);
-  referendStructs.defineRuntimeSizedArray(runtimeSizedArrayMT, elementLT);
+  kindStructs.defineRuntimeSizedArray(runtimeSizedArrayMT, elementLT);
 }
 
 void Assist::defineStaticSizedArray(
@@ -211,13 +211,13 @@ void Assist::defineStaticSizedArray(
   auto elementLT =
       globalState->getRegion(staticSizedArrayMT->rawArray->elementType)
           ->translateType(staticSizedArrayMT->rawArray->elementType);
-  referendStructs.defineStaticSizedArray(staticSizedArrayMT, elementLT);
+  kindStructs.defineStaticSizedArray(staticSizedArrayMT, elementLT);
 }
 
 void Assist::declareStruct(
     StructDefinition* structM) {
-  globalState->regionIdByReferend.emplace(structM->referend, getRegionId());
-  referendStructs.declareStruct(structM->referend);
+  globalState->regionIdByKind.emplace(structM->kind, getRegionId());
+  kindStructs.declareStruct(structM->kind);
 }
 
 void Assist::defineStruct(
@@ -228,32 +228,32 @@ void Assist::defineStruct(
         globalState->getRegion(structM->members[i]->type)
             ->translateType(structM->members[i]->type));
   }
-  referendStructs.defineStruct(
-      structM->referend,
+  kindStructs.defineStruct(
+      structM->kind,
       innerStructMemberTypesL);
 }
 
 void Assist::declareEdge(
     Edge* edge) {
-  referendStructs.declareEdge(edge);
+  kindStructs.declareEdge(edge);
 }
 
 void Assist::defineEdge(Edge* edge) {
   auto interfaceFunctionsLT = globalState->getInterfaceFunctionTypes(edge->interfaceName);
   auto edgeFunctionsL = globalState->getEdgeFunctions(edge);
-  referendStructs.defineEdge(edge, interfaceFunctionsLT, edgeFunctionsL);
+  kindStructs.defineEdge(edge, interfaceFunctionsLT, edgeFunctionsL);
 }
 
 void Assist::declareInterface(
     InterfaceDefinition* interfaceM) {
-  globalState->regionIdByReferend.emplace(interfaceM->referend, getRegionId());
-  referendStructs.declareInterface(interfaceM);
+  globalState->regionIdByKind.emplace(interfaceM->kind, getRegionId());
+  kindStructs.declareInterface(interfaceM);
 }
 
 void Assist::defineInterface(
     InterfaceDefinition* interfaceM) {
-  auto interfaceMethodTypesL = globalState->getInterfaceFunctionTypes(interfaceM->referend);
-  referendStructs.defineInterface(interfaceM, interfaceMethodTypesL);
+  auto interfaceMethodTypesL = globalState->getInterfaceFunctionTypes(interfaceM->kind);
+  kindStructs.defineInterface(interfaceM, interfaceMethodTypesL);
 }
 
 Ref Assist::weakAlias(
@@ -262,7 +262,7 @@ Ref Assist::weakAlias(
     Reference* sourceRefMT,
     Reference* targetRefMT,
     Ref sourceRef) {
-  return regularWeakAlias(globalState, functionState, &referendStructs, &wrcWeaks, builder, sourceRefMT, targetRefMT, sourceRef);
+  return regularWeakAlias(globalState, functionState, &kindStructs, &wrcWeaks, builder, sourceRefMT, targetRefMT, sourceRef);
 }
 
 void Assist::discardOwningRef(
@@ -273,13 +273,13 @@ void Assist::discardOwningRef(
     Reference* sourceMT,
     Ref sourceRef) {
   auto exprWrapperPtrLE =
-      referendStructs.makeWrapperPtr(
+      kindStructs.makeWrapperPtr(
           FL(), functionState, builder, sourceMT,
           checkValidReference(FL(), functionState, builder, sourceMT, sourceRef));
 
   adjustStrongRc(
       AFL("Destroy decrementing the owning ref"),
-      globalState, functionState, &referendStructs, builder, sourceRef, sourceMT, -1);
+      globalState, functionState, &kindStructs, builder, sourceRef, sourceMT, -1);
   // No need to check the RC, we know we're freeing right now.
 
   // Free it!v
@@ -291,7 +291,7 @@ void Assist::noteWeakableDestroyed(
     LLVMBuilderRef builder,
     Reference* refM,
     ControlBlockPtrLE controlBlockPtrLE) {
-  auto rc = referendStructs.getStrongRcFromControlBlockPtr(builder, refM, controlBlockPtrLE);
+  auto rc = kindStructs.getStrongRcFromControlBlockPtr(builder, refM, controlBlockPtrLE);
   auto conditionLE = LLVMBuildICmp(builder, LLVMIntEQ, rc, constI32LE(globalState, 0), "assertCondition");
   buildIf(
       globalState, functionState, builder, isZeroLE(builder, conditionLE),
@@ -302,12 +302,12 @@ void Assist::noteWeakableDestroyed(
         LLVMBuildCall(thenBuilder, globalState->externs->exit, &exitCodeIntLE, 1, "");
       });
 
-  if (auto structReferendM = dynamic_cast<StructReferend*>(refM->referend)) {
-    auto structM = globalState->program->getStruct(structReferendM->fullName);
+  if (auto structKindM = dynamic_cast<StructKind*>(refM->kind)) {
+    auto structM = globalState->program->getStruct(structKindM);
     if (structM->weakability == Weakability::WEAKABLE) {
       wrcWeaks.innerNoteWeakableDestroyed(functionState, builder, refM, controlBlockPtrLE);
     }
-  } else if (auto interfaceReferendM = dynamic_cast<InterfaceReferend*>(refM->referend)) {
+  } else if (auto interfaceKindM = dynamic_cast<InterfaceKind*>(refM->kind)) {
     assert(false); // Do we ever deallocate an interface?
   } else {
     // Do nothing, only structs and interfaces are weakable in assist mode.
@@ -331,7 +331,7 @@ Ref Assist::loadMember(
     buildFlare(FL(), globalState, functionState, builder);
     auto unupgradedMemberLE =
         regularLoadMember(
-            globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+            globalState, functionState, builder, &kindStructs, structRefMT, structRef,
             memberIndex, expectedMemberType, targetType, memberName);
     buildFlare(FL(), globalState, functionState, builder);
     return upgradeLoadResultToRefWithTargetOwnership(
@@ -358,13 +358,13 @@ void Assist::storeMember(
     case Ownership::OWN:
     case Ownership::BORROW: {
       storeMemberStrong(
-          globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+          globalState, functionState, builder, &kindStructs, structRefMT, structRef,
           structKnownLive, memberIndex, memberName, newMemberLE);
       break;
     }
     case Ownership::WEAK: {
       storeMemberWeak(
-          globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+          globalState, functionState, builder, &kindStructs, structRefMT, structRef,
           structKnownLive, memberIndex, memberName, newMemberLE);
       break;
     }
@@ -387,11 +387,11 @@ std::tuple<LLVMValueRef, LLVMValueRef> Assist::explodeInterfaceRef(
     case Ownership::OWN:
     case Ownership::BORROW: {
       return explodeStrongInterfaceRef(
-          globalState, functionState, builder, &referendStructs, virtualParamMT, virtualArgRef);
+          globalState, functionState, builder, &kindStructs, virtualParamMT, virtualArgRef);
     }
     case Ownership::WEAK: {
       return explodeWeakInterfaceRef(
-          globalState, functionState, builder, &referendStructs, &fatWeaks, &weakRefStructs,
+          globalState, functionState, builder, &kindStructs, &fatWeaks, &weakRefStructs,
           virtualParamMT, virtualArgRef,
           [this, functionState, builder, virtualParamMT](WeakFatPtrLE weakFatPtrLE) {
             return wrcWeaks.weakInterfaceRefToWeakStructRef(
@@ -432,12 +432,12 @@ Ref Assist::getIsAliveFromWeakRef(
 
 LLVMValueRef Assist::getStringBytesPtr(FunctionState* functionState, LLVMBuilderRef builder, Ref ref) {
   auto strWrapperPtrLE =
-      referendStructs.makeWrapperPtr(
+      kindStructs.makeWrapperPtr(
           FL(), functionState, builder,
           globalState->metalCache->strRef,
           checkValidReference(
               FL(), functionState, builder, globalState->metalCache->strRef, ref));
-  return referendStructs.getStringBytesPtr(functionState, builder, strWrapperPtrLE);
+  return kindStructs.getStringBytesPtr(functionState, builder, strWrapperPtrLE);
 }
 
 Ref Assist::constructStaticSizedArray(
@@ -445,19 +445,19 @@ Ref Assist::constructStaticSizedArray(
     FunctionState *functionState,
     LLVMBuilderRef builder,
     Reference *referenceM,
-    StaticSizedArrayT *referendM) {
-  auto ssaDef = globalState->program->getStaticSizedArray(referendM->name);
+    StaticSizedArrayT *kindM) {
+  auto ssaDef = globalState->program->getStaticSizedArray(kindM);
   auto resultRef =
       ::constructStaticSizedArray(
-          globalState, functionState, builder, referenceM, referendM, &referendStructs,
-          [this, functionState, referenceM, referendM](LLVMBuilderRef innerBuilder, ControlBlockPtrLE controlBlockPtrLE) {
+          globalState, functionState, builder, referenceM, kindM, &kindStructs,
+          [this, functionState, referenceM, kindM](LLVMBuilderRef innerBuilder, ControlBlockPtrLE controlBlockPtrLE) {
             fillControlBlock(
                 FL(),
                 functionState,
                 innerBuilder,
-                referenceM->referend,
+                referenceM->kind,
                 controlBlockPtrLE,
-                referendM->name->name);
+                kindM->name->name);
           });
   // We dont increment here, see SRCAO
   return resultRef;
@@ -480,14 +480,14 @@ Ref Assist::allocate(
     LLVMBuilderRef builder,
     Reference* desiredReference,
     const std::vector<Ref>& memberRefs) {
-  auto structReferend = dynamic_cast<StructReferend*>(desiredReference->referend);
-  auto structM = globalState->program->getStruct(structReferend->fullName);
+  auto structKind = dynamic_cast<StructKind*>(desiredReference->kind);
+  auto structM = globalState->program->getStruct(structKind);
   auto resultRef =
       innerAllocate(
-          FL(), globalState, functionState, builder, desiredReference, &referendStructs, memberRefs, Weakability::WEAKABLE,
+          FL(), globalState, functionState, builder, desiredReference, &kindStructs, memberRefs, Weakability::WEAKABLE,
           [this, functionState, desiredReference, structM](LLVMBuilderRef innerBuilder, ControlBlockPtrLE controlBlockPtrLE) {
             fillControlBlock(
-                FL(), functionState, innerBuilder, desiredReference->referend,
+                FL(), functionState, innerBuilder, desiredReference->kind,
                 controlBlockPtrLE, structM->name->name);
           });
   return resultRef;
@@ -512,7 +512,7 @@ WrapperPtrLE Assist::lockWeakRef(
           weakRefStructs.makeWeakFatPtr(
               refM,
               checkValidReference(FL(), functionState, builder, refM, weakRefLE));
-      return referendStructs.makeWrapperPtr(
+      return kindStructs.makeWrapperPtr(
           FL(), functionState, builder, refM,
           wrcWeaks.lockWrciFatPtr(from, functionState, builder, refM, weakFatPtrLE));
     }
@@ -528,7 +528,7 @@ Ref Assist::getRuntimeSizedArrayLength(
     Reference* rsaRefMT,
     Ref arrayRef,
     bool arrayKnownLive) {
-  return getRuntimeSizedArrayLengthStrong(globalState, functionState, builder, &referendStructs, rsaRefMT, arrayRef);
+  return getRuntimeSizedArrayLengthStrong(globalState, functionState, builder, &kindStructs, rsaRefMT, arrayRef);
 }
 
 
@@ -550,9 +550,9 @@ LLVMValueRef Assist::getCensusObjectId(
     return constI64LE(globalState, -1);
   } else {
     auto controlBlockPtrLE =
-        referendStructs.getControlBlockPtr(checkerAFL, functionState, builder, ref, refM);
+        kindStructs.getControlBlockPtr(checkerAFL, functionState, builder, ref, refM);
     auto exprLE =
-        referendStructs.getObjIdFromControlBlockPtr(builder, refM->referend, controlBlockPtrLE);
+        kindStructs.getObjIdFromControlBlockPtr(builder, refM->kind, controlBlockPtrLE);
     return exprLE;
   }
 }
@@ -575,13 +575,13 @@ LLVMValueRef Assist::checkValidReference(
   if (globalState->opt->census) {
     if (refM->ownership == Ownership::OWN) {
         buildFlare(FL(), globalState, functionState, builder);
-      regularCheckValidReference(checkerAFL, globalState, functionState, builder, &referendStructs, refM, refLE);
+      regularCheckValidReference(checkerAFL, globalState, functionState, builder, &kindStructs, refM, refLE);
     } else if (refM->ownership == Ownership::SHARE) {
       assert(false);
     } else {
         buildFlare(FL(), globalState, functionState, builder);
       if (refM->ownership == Ownership::BORROW) {
-        regularCheckValidReference(checkerAFL, globalState, functionState, builder, &referendStructs, refM, refLE);
+        regularCheckValidReference(checkerAFL, globalState, functionState, builder, &kindStructs, refM, refLE);
       } else if (refM->ownership == Ownership::WEAK) {
         wrcWeaks.buildCheckWeakRef(checkerAFL, functionState, builder, refM, ref);
       } else
@@ -655,8 +655,8 @@ Ref Assist::upgradeLoadResultToRefWithTargetOwnership(
       return sourceRef;
     } else if (targetOwnership == Ownership::WEAK) {
       // Making a weak ref from a constraint ref local.
-      assert(dynamic_cast<StructReferend *>(sourceType->referend) ||
-          dynamic_cast<InterfaceReferend *>(sourceType->referend));
+      assert(dynamic_cast<StructKind *>(sourceType->kind) ||
+          dynamic_cast<InterfaceKind *>(sourceType->kind));
       buildFlare(FL(), globalState, functionState, builder);
       return wrcWeaks.assembleWeakRef(functionState, builder, sourceType, targetType, sourceRef);
     } else {
@@ -676,11 +676,11 @@ void Assist::fillControlBlock(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     ControlBlockPtrLE controlBlockPtrLE,
     const std::string& typeName) {
   regularFillControlBlock(
-      from, globalState, functionState, &referendStructs, builder, referendM, controlBlockPtrLE,
+      from, globalState, functionState, &kindStructs, builder, kindM, controlBlockPtrLE,
       typeName, &wrcWeaks);
 }
 
@@ -692,9 +692,9 @@ LoadResult Assist::loadElementFromSSA(
     Ref arrayRef,
     bool arrayKnownLive,
     Ref indexRef) {
-  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT->name);
+  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT);
   return regularloadElementFromSSA(
-      globalState, functionState, builder, ssaRefMT, ssaMT, ssaDef->rawArray->elementType, ssaDef->size, ssaDef->rawArray->mutability, arrayRef, arrayKnownLive, indexRef, &referendStructs);
+      globalState, functionState, builder, ssaRefMT, ssaMT, ssaDef->rawArray->elementType, ssaDef->size, ssaDef->rawArray->mutability, arrayRef, arrayKnownLive, indexRef, &kindStructs);
 }
 
 LoadResult Assist::loadElementFromRSA(
@@ -705,9 +705,9 @@ LoadResult Assist::loadElementFromRSA(
     Ref arrayRef,
     bool arrayKnownLive,
     Ref indexRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   return regularLoadElementFromRSAWithoutUpgrade(
-      globalState, functionState, builder, &referendStructs, rsaRefMT, rsaMT, rsaDef->rawArray->mutability, rsaDef->rawArray->elementType, arrayRef,
+      globalState, functionState, builder, &kindStructs, rsaRefMT, rsaMT, rsaDef->rawArray->mutability, rsaDef->rawArray->elementType, arrayRef,
       arrayKnownLive, indexRef);
 }
 
@@ -720,10 +720,10 @@ Ref Assist::storeElementInRSA(
     bool arrayKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
 
   auto arrayWrapperPtrLE =
-      referendStructs.makeWrapperPtr(
+      kindStructs.makeWrapperPtr(
           FL(), functionState, builder, rsaRefMT,
           globalState->getRegion(rsaRefMT)->checkValidReference(FL(), functionState, builder, rsaRefMT, arrayRef));
   auto sizeRef = ::getRuntimeSizedArrayLength(globalState, functionState, builder, arrayWrapperPtrLE);
@@ -738,21 +738,21 @@ Ref Assist::upcast(
     LLVMBuilderRef builder,
 
     Reference* sourceStructMT,
-    StructReferend* sourceStructReferendM,
+    StructKind* sourceStructKindM,
     Ref sourceRefLE,
 
     Reference* targetInterfaceTypeM,
-    InterfaceReferend* targetInterfaceReferendM) {
+    InterfaceKind* targetInterfaceKindM) {
     buildFlare(FL(), globalState, functionState, builder);
 
   switch (sourceStructMT->ownership) {
     case Ownership::SHARE:
     case Ownership::OWN:
     case Ownership::BORROW: {
-      return upcastStrong(globalState, functionState, builder, &referendStructs, sourceStructMT, sourceStructReferendM, sourceRefLE, targetInterfaceTypeM, targetInterfaceReferendM);
+      return upcastStrong(globalState, functionState, builder, &kindStructs, sourceStructMT, sourceStructKindM, sourceRefLE, targetInterfaceTypeM, targetInterfaceKindM);
     }
     case Ownership::WEAK: {
-      return ::upcastWeak(globalState, functionState, builder, &weakRefStructs, sourceStructMT, sourceStructReferendM, sourceRefLE, targetInterfaceTypeM, targetInterfaceReferendM);
+      return ::upcastWeak(globalState, functionState, builder, &weakRefStructs, sourceStructMT, sourceStructKindM, sourceRefLE, targetInterfaceTypeM, targetInterfaceKindM);
     }
     default:
       assert(false);
@@ -766,7 +766,7 @@ void Assist::deallocate(
     LLVMBuilderRef builder,
     Reference* refMT,
     Ref ref) {
-  innerDeallocate(from, globalState, functionState, &referendStructs, builder, refMT, ref);
+  innerDeallocate(from, globalState, functionState, &kindStructs, builder, refMT, ref);
 }
 
 Ref Assist::constructRuntimeSizedArray(
@@ -778,13 +778,13 @@ Ref Assist::constructRuntimeSizedArray(
     Ref sizeRef,
     const std::string& typeName) {
   auto rsaWrapperPtrLT =
-      referendStructs.getRuntimeSizedArrayWrapperStruct(runtimeSizedArrayT);
-  auto rsaDef = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT->name);
-  auto elementType = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT->name)->rawArray->elementType;
+      kindStructs.getRuntimeSizedArrayWrapperStruct(runtimeSizedArrayT);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT);
+  auto elementType = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT)->rawArray->elementType;
   auto rsaElementLT = globalState->getRegion(elementType)->translateType(elementType);
   auto resultRef =
       ::constructRuntimeSizedArray(
-          globalState, functionState, builder, &referendStructs, rsaMT, rsaDef->rawArray->elementType, runtimeSizedArrayT,
+          globalState, functionState, builder, &kindStructs, rsaMT, rsaDef->rawArray->elementType, runtimeSizedArrayT,
           rsaWrapperPtrLT, rsaElementLT, sizeRef, typeName,
           [this, functionState, runtimeSizedArrayT, rsaMT, typeName](
               LLVMBuilderRef innerBuilder, ControlBlockPtrLE controlBlockPtrLE) {
@@ -806,109 +806,97 @@ void Assist::checkInlineStructType(
     Reference* refMT,
     Ref ref) {
   auto argLE = checkValidReference(FL(), functionState, builder, refMT, ref);
-  auto structReferend = dynamic_cast<StructReferend*>(refMT->referend);
-  assert(structReferend);
-  assert(LLVMTypeOf(argLE) == referendStructs.getInnerStruct(structReferend));
+  auto structKind = dynamic_cast<StructKind*>(refMT->kind);
+  assert(structKind);
+  assert(LLVMTypeOf(argLE) == kindStructs.getInnerStruct(structKind));
 }
 
-void Assist::generateRuntimeSizedArrayDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName,
+std::string Assist::generateRuntimeSizedArrayDefsC(
+    Package* currentPackage,
+
     RuntimeSizedArrayDefinitionT* rsaDefM) {
   if (rsaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto baseName : globalState->program->getExportedNames(rsaDefM->name)) {
-      auto refTypeName = baseName + "Ref";
-      std::stringstream s;
-      s << "typedef struct " << refTypeName << " { void* unused; } " << refTypeName << ";" << std::endl;
-      cByExportedName->insert(std::make_pair(baseName, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(rsaDefM->kind);
+    return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
 
-void Assist::generateStaticSizedArrayDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName,
+std::string Assist::generateStaticSizedArrayDefsC(
+    Package* currentPackage,
     StaticSizedArrayDefinitionT* ssaDefM) {
   if (ssaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto baseName : globalState->program->getExportedNames(ssaDefM->name)) {
-      auto refTypeName = baseName + "Ref";
-      std::stringstream s;
-      s << "typedef struct " << refTypeName << " { void* unused; } " << refTypeName << ";" << std::endl;
-      cByExportedName->insert(std::make_pair(baseName, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(ssaDefM->kind);
+    return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
 
-void Assist::generateStructDefsC(std::unordered_map<std::string, std::string>* cByExportedName, StructDefinition* structDefM) {
+std::string Assist::generateStructDefsC(
+    Package* currentPackage, StructDefinition* structDefM) {
   if (structDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto baseName : globalState->program->getExportedNames(structDefM->referend->fullName)) {
-      auto refTypeName = baseName + "Ref";
-      std::stringstream s;
-      s << "typedef struct " << refTypeName << " { void* unused; } " << refTypeName << ";" << std::endl;
-      cByExportedName->insert(std::make_pair(baseName, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(structDefM->kind);
+    return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
 
-void Assist::generateInterfaceDefsC(std::unordered_map<std::string, std::string>* cByExportedName, InterfaceDefinition* interfaceDefM) {
+std::string Assist::generateInterfaceDefsC(
+    Package* currentPackage, InterfaceDefinition* interfaceDefM) {
   if (interfaceDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto name : globalState->program->getExportedNames(interfaceDefM->referend->fullName)) {
-      std::stringstream s;
-      s << "typedef struct " << name << "Ref { void* unused1; void* unused2; } " << name << "Ref;";
-      cByExportedName->insert(std::make_pair(name, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(interfaceDefM->kind);
+    return std::string() + "typedef struct " + name + "Ref { void* unused1; void* unused2; } " + name + "Ref;\n";
   }
 }
 
-std::string Assist::getMemberArbitraryRefNameCSeeMMEDT(Reference* refMT) {
-  if (refMT->ownership == Ownership::SHARE) {
-    assert(false);
-  } else if (auto structRefMT = dynamic_cast<StructReferend*>(refMT->referend)) {
-    auto structMT = globalState->program->getStruct(structRefMT->fullName);
-    for (auto baseName : globalState->program->getExportedNames(structRefMT->fullName)) {
-      if (structMT->mutability == Mutability::MUTABLE) {
-        assert(refMT->location != Location::INLINE);
-        return baseName + "Ref";
-      } else {
-        if (refMT->location == Location::INLINE) {
-          return baseName + "Inl";
-        } else {
-          return baseName + "Ref";
-        }
-      }
-    }
-  } else if (auto interfaceMT = dynamic_cast<InterfaceReferend*>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(interfaceMT->fullName) + "Ref";
-  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(rsaMT->name) + "Ref";
-  } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(ssaMT->name) + "Ref";
-  } else {
-    assert(false);
-  }
-  assert(false);
-  return "";
-}
+//std::string Assist::getMemberArbitraryRefNameCSeeMMEDT(Reference* refMT) {
+//  if (refMT->ownership == Ownership::SHARE) {
+//    assert(false);
+//  } else if (auto structRefMT = dynamic_cast<StructKind*>(refMT->kind)) {
+//    auto structMT = globalState->program->getStruct(structRefMT);
+//    for (auto baseName : globalState->program->getExportedNames(structRefMT->fullName)) {
+//      if (structMT->mutability == Mutability::MUTABLE) {
+//        assert(refMT->location != Location::INLINE);
+//        return baseName + "Ref";
+//      } else {
+//        if (refMT->location == Location::INLINE) {
+//          return baseName + "Inl";
+//        } else {
+//          return baseName + "Ref";
+//        }
+//      }
+//    }
+//  } else if (auto interfaceMT = dynamic_cast<InterfaceKind*>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(interfaceMT->fullName) + "Ref";
+//  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(rsaMT->name) + "Ref";
+//  } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(ssaMT->name) + "Ref";
+//  } else {
+//    assert(false);
+//  }
+//  assert(false);
+//  return "";
+//}
 
 Reference* Assist::getExternalType(Reference* refMT) {
   return refMT;
 //  if (refMT->ownership == Ownership::SHARE) {
 //    assert(false);
 //  } else {
-//    if (auto structReferend = dynamic_cast<StructReferend*>(refMT->referend)) {
+//    if (auto structKind = dynamic_cast<StructKind*>(refMT->kind)) {
 //      if (refMT->location == Location::INLINE) {
 //        assert(false); // what do we do in this case? malloc an owning thing and send it in?
 //        // perhaps just disallow sending inl owns?
 //      }
-//      return LLVMPointerType(referendStructs.getWrapperStruct(structReferend), 0);
-//    } else if (auto interfaceReferend = dynamic_cast<InterfaceReferend*>(refMT->referend)) {
-//      return LLVMPointerType(referendStructs.getInterfaceRefStruct(interfaceReferend), 0);
+//      return LLVMPointerType(kindStructs.getWrapperStruct(structKind), 0);
+//    } else if (auto interfaceKind = dynamic_cast<InterfaceKind*>(refMT->kind)) {
+//      return LLVMPointerType(kindStructs.getInterfaceRefStruct(interfaceKind), 0);
 //    } else {
 //      std::cerr << "Invalid type for extern!" << std::endl;
 //      assert(false);
@@ -938,7 +926,7 @@ LLVMTypeRef Assist::getInterfaceMethodVirtualParamAnyType(Reference* reference) 
     case Ownership::SHARE:
       return LLVMPointerType(LLVMInt8TypeInContext(globalState->context), 0);
     case Ownership::WEAK:
-      return mutWeakableStructs.getWeakVoidRefStruct(reference->referend);
+      return mutWeakableStructs.getWeakVoidRefStruct(reference->kind);
     default:
       assert(false);
   }
@@ -975,9 +963,9 @@ void Assist::initializeElementInRSA(
     bool arrayRefKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   auto arrayWrapperPtrLE =
-      referendStructs.makeWrapperPtr(
+      kindStructs.makeWrapperPtr(
           FL(), functionState, builder, rsaRefMT,
           globalState->getRegion(rsaRefMT)->checkValidReference(FL(), functionState, builder, rsaRefMT, rsaRef));
 
@@ -1007,9 +995,9 @@ void Assist::initializeElementInSSA(
     bool arrayRefKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT->name);
+  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT);
   auto arrayWrapperPtrLE =
-      referendStructs.makeWrapperPtr(
+      kindStructs.makeWrapperPtr(
           FL(), functionState, builder, ssaRefMT,
           globalState->getRegion(ssaRefMT)->checkValidReference(FL(), functionState, builder, ssaRefMT, arrayRef));
   auto sizeRef = globalState->constI64(ssaDef->size);
@@ -1030,11 +1018,11 @@ Ref Assist::deinitializeElementFromSSA(
   exit(1);
 }
 
-Weakability Assist::getReferendWeakability(Referend* referend) {
-  if (auto structReferend = dynamic_cast<StructReferend*>(referend)) {
-    return globalState->lookupStruct(structReferend->fullName)->weakability;
-  } else if (auto interfaceReferend = dynamic_cast<InterfaceReferend*>(referend)) {
-    return globalState->lookupInterface(interfaceReferend->fullName)->weakability;
+Weakability Assist::getKindWeakability(Kind* kind) {
+  if (auto structKind = dynamic_cast<StructKind*>(kind)) {
+    return globalState->lookupStruct(structKind)->weakability;
+  } else if (auto interfaceKind = dynamic_cast<InterfaceKind*>(kind)) {
+    return globalState->lookupInterface(interfaceKind)->weakability;
   } else {
     return Weakability::NON_WEAKABLE;
   }
@@ -1072,4 +1060,10 @@ Ref Assist::loadLocal(FunctionState* functionState, LLVMBuilderRef builder, Loca
 
 Ref Assist::localStore(FunctionState* functionState, LLVMBuilderRef builder, Local* local, LLVMValueRef localAddr, Ref refToStore, bool knownLive) {
   return normalLocalStore(globalState, functionState, builder, local, localAddr, refToStore);
+}
+
+std::string Assist::getExportName(
+    Package* package,
+    Reference* reference) {
+  return package->getKindExportName(reference->kind) + (reference->location == Location::YONDER ? "Ref" : "");
 }

--- a/Midas/src/c-compiler/region/assist/assist.cpp
+++ b/Midas/src/c-compiler/region/assist/assist.cpp
@@ -818,7 +818,7 @@ std::string Assist::generateRuntimeSizedArrayDefsC(
   if (rsaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(rsaDefM->kind);
+    auto name = currentPackage->getKindExportName(rsaDefM->kind, true);
     return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
@@ -829,7 +829,7 @@ std::string Assist::generateStaticSizedArrayDefsC(
   if (ssaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(ssaDefM->kind);
+    auto name = currentPackage->getKindExportName(ssaDefM->kind, true);
     return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
@@ -839,7 +839,7 @@ std::string Assist::generateStructDefsC(
   if (structDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(structDefM->kind);
+    auto name = currentPackage->getKindExportName(structDefM->kind, true);
     return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
@@ -849,7 +849,7 @@ std::string Assist::generateInterfaceDefsC(
   if (interfaceDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(interfaceDefM->kind);
+    auto name = currentPackage->getKindExportName(interfaceDefM->kind, true);
     return std::string() + "typedef struct " + name + "Ref { void* unused1; void* unused2; } " + name + "Ref;\n";
   }
 }
@@ -1064,6 +1064,7 @@ Ref Assist::localStore(FunctionState* functionState, LLVMBuilderRef builder, Loc
 
 std::string Assist::getExportName(
     Package* package,
-    Reference* reference) {
-  return package->getKindExportName(reference->kind) + (reference->location == Location::YONDER ? "Ref" : "");
+    Reference* reference,
+    bool includeProjectName) {
+  return package->getKindExportName(reference->kind, includeProjectName) + (reference->location == Location::YONDER ? "Ref" : "");
 }

--- a/Midas/src/c-compiler/region/assist/assist.h
+++ b/Midas/src/c-compiler/region/assist/assist.h
@@ -58,7 +58,7 @@ public:
       Reference* sourceInterfaceRefMT,
       Ref sourceInterfaceRef,
       bool sourceRefKnownLive,
-      Referend* targetReferend,
+      Kind* targetKind,
       std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
       std::function<Ref(LLVMBuilderRef)> buildElse) override;
 
@@ -75,9 +75,9 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       WeakFatPtrLE sourceRefLE,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Reference* sourceStructTypeM,
-      InterfaceReferend* targetInterfaceReferendM,
+      InterfaceKind* targetInterfaceKindM,
       Reference* targetInterfaceTypeM) override;
 
   void declareStaticSizedArray(
@@ -193,11 +193,11 @@ public:
       LLVMBuilderRef builder,
 
       Reference* sourceStructMT,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Ref sourceRefLE,
 
       Reference* targetInterfaceTypeM,
-      InterfaceReferend* targetInterfaceReferendM) override;
+      InterfaceKind* targetInterfaceKindM) override;
 
   WrapperPtrLE lockWeakRef(
       AreaAndFileAndLine from,
@@ -214,7 +214,7 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       Reference* referenceM,
-      StaticSizedArrayT* referendM) override;
+      StaticSizedArrayT* kindM) override;
 
   // should expose a dereference thing instead
 //  LLVMValueRef getStaticSizedArrayElementsPtr(
@@ -356,7 +356,7 @@ public:
 //      FunctionState* functionState,
 //      LLVMBuilderRef builder,
 //      Location location,
-//      LLVMTypeRef referendLT) override;
+//      LLVMTypeRef kindLT) override;
 
 //  LLVMValueRef mallocRuntimeSizedArray(
 //      LLVMBuilderRef builder,
@@ -369,48 +369,54 @@ public:
 //    return mutWeakableStructs.makeWeakFatPtr(referenceM_, ptrLE);
 //  }
   // TODO get rid of these once refactor is done
-//  ControlBlock* getControlBlock(Referend* referend) override {
-//    return referendStructs.getControlBlock(referend);
+//  ControlBlock* getControlBlock(Kind* kind) override {
+//    return kindStructs.getControlBlock(kind);
 //  }
-//  IReferendStructsSource* getReferendStructsSource() override {
-//    return &referendStructs;
+//  IKindStructsSource* getKindStructsSource() override {
+//    return &kindStructs;
 //  }
 //  IWeakRefStructsSource* getWeakRefStructsSource() override {
 //    return &weakRefStructs;
 //  }
   LLVMValueRef getStringLen(FunctionState* functionState, LLVMBuilderRef builder, Ref ref) override {
     auto strWrapperPtrLE =
-        referendStructs.makeWrapperPtr(
+        kindStructs.makeWrapperPtr(
             FL(), functionState, builder,
             globalState->metalCache->strRef,
             checkValidReference(
                 FL(), functionState, builder, globalState->metalCache->strRef, ref));
-    return referendStructs.getStringLen(functionState, builder, strWrapperPtrLE);
+    return kindStructs.getStringLen(functionState, builder, strWrapperPtrLE);
   }
-//  LLVMTypeRef getWeakRefHeaderStruct(Referend* referend) override {
-//    return mutWeakableStructs.getWeakRefHeaderStruct(referend);
+//  LLVMTypeRef getWeakRefHeaderStruct(Kind* kind) override {
+//    return mutWeakableStructs.getWeakRefHeaderStruct(kind);
 //  }
-//  LLVMTypeRef getWeakVoidRefStruct(Referend* referend) override {
-//    return mutWeakableStructs.getWeakVoidRefStruct(referend);
+//  LLVMTypeRef getWeakVoidRefStruct(Kind* kind) override {
+//    return mutWeakableStructs.getWeakVoidRefStruct(kind);
 //  }
   void fillControlBlock(
       AreaAndFileAndLine from,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       ControlBlockPtrLE controlBlockPtrLE,
       const std::string& typeName);
 
-  std::string getMemberArbitraryRefNameCSeeMMEDT(
-      Reference* refMT) override;
-  void generateStructDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StructDefinition* refMT) override;
-  void generateInterfaceDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, InterfaceDefinition* refMT) override;
-  void generateStaticSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StaticSizedArrayDefinitionT* ssaDefM) override;
-  void generateRuntimeSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, RuntimeSizedArrayDefinitionT* rsaDefM) override;
+
+  std::string getExportName(
+      Package* package,
+      Reference* reference) override;
+  std::string generateStructDefsC(
+    Package* currentPackage,
+      StructDefinition* refMT) override;
+  std::string generateInterfaceDefsC(
+    Package* currentPackage,
+      InterfaceDefinition* refMT) override;
+  std::string generateStaticSizedArrayDefsC(
+    Package* currentPackage,
+      StaticSizedArrayDefinitionT* ssaDefM) override;
+  std::string generateRuntimeSizedArrayDefsC(
+    Package* currentPackage,
+      RuntimeSizedArrayDefinitionT* rsaDefM) override;
 
 
   Reference* getExternalType(
@@ -449,7 +455,7 @@ public:
   void declareExtraFunctions() override {}
   void defineExtraFunctions() override {}
 
-  Weakability getReferendWeakability(Referend* referend) override;
+  Weakability getKindWeakability(Kind* kind) override;
 
   LLVMValueRef getInterfaceMethodFunctionPtr(
       FunctionState* functionState,
@@ -480,10 +486,10 @@ private:
 
   LLVMTypeRef regionLT;
 
-  ReferendStructs mutNonWeakableStructs;
-  WeakableReferendStructs mutWeakableStructs;
+  KindStructs mutNonWeakableStructs;
+  WeakableKindStructs mutWeakableStructs;
 
-  ReferendStructsRouter referendStructs;
+  KindStructsRouter kindStructs;
   WeakRefStructsRouter weakRefStructs;
 
   FatWeaks fatWeaks;

--- a/Midas/src/c-compiler/region/assist/assist.h
+++ b/Midas/src/c-compiler/region/assist/assist.h
@@ -404,7 +404,8 @@ public:
 
   std::string getExportName(
       Package* package,
-      Reference* reference) override;
+      Reference* reference,
+      bool includeProjectName) override;
   std::string generateStructDefsC(
     Package* currentPackage,
       StructDefinition* refMT) override;

--- a/Midas/src/c-compiler/region/common/common.h
+++ b/Midas/src/c-compiler/region/common/common.h
@@ -12,27 +12,27 @@ LLVMValueRef weakStructPtrToGenWeakInterfacePtr(
     FunctionState* functionState,
     LLVMBuilderRef builder,
     LLVMValueRef sourceRefLE,
-    StructReferend* sourceStructReferendM,
+    StructKind* sourceStructKindM,
     Reference* sourceStructTypeM,
-    InterfaceReferend* targetInterfaceReferendM,
+    InterfaceKind* targetInterfaceKindM,
     Reference* targetInterfaceTypeM);
 
 LLVMValueRef upcastThinPtr(
     GlobalState* globalState,
     FunctionState* functionState,
-    IReferendStructsSource* referendStructsSource,
+    IKindStructsSource* kindStructsSource,
     LLVMBuilderRef builder,
 
     Reference* sourceStructTypeM,
-    StructReferend* sourceStructReferendM,
+    StructKind* sourceStructKindM,
     WrapperPtrLE sourceRefLE,
 
     Reference* targetInterfaceTypeM,
-    InterfaceReferend* targetInterfaceReferendM);
+    InterfaceKind* targetInterfaceKindM);
 
-LLVMTypeRef translateReferenceSimple(GlobalState* globalState, IReferendStructsSource* structs, Referend* referend);
+LLVMTypeRef translateReferenceSimple(GlobalState* globalState, IKindStructsSource* structs, Kind* kind);
 
-LLVMTypeRef translateWeakReference(GlobalState* globalState, IWeakRefStructsSource* weakRefStructs, Referend* referend);
+LLVMTypeRef translateWeakReference(GlobalState* globalState, IWeakRefStructsSource* weakRefStructs, Kind* kind);
 
 
 
@@ -55,17 +55,17 @@ LLVMValueRef fillControlBlockCensusFields(
     AreaAndFileAndLine from,
     GlobalState* globalState,
     FunctionState* functionState,
-    IReferendStructsSource* structs,
+    IKindStructsSource* structs,
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     LLVMValueRef newControlBlockLE,
     const std::string& typeName);
 
 LLVMValueRef insertStrongRc(
     GlobalState* globalState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* structs,
-    Referend* referendM,
+    IKindStructsSource* structs,
+    Kind* kindM,
     LLVMValueRef newControlBlockLE);
 
 void buildCheckGen(
@@ -90,9 +90,9 @@ LLVMValueRef makeInterfaceRefStruct(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* structs,
-    StructReferend* sourceStructReferendM,
-    InterfaceReferend* targetInterfaceReferendM,
+    IKindStructsSource* structs,
+    StructKind* sourceStructKindM,
+    InterfaceKind* targetInterfaceKindM,
     ControlBlockPtrLE controlBlockPtrLE);
 
 LLVMValueRef getTablePtrFromInterfaceRef(
@@ -107,7 +107,7 @@ void innerDeallocate(
     AreaAndFileAndLine from,
     GlobalState* globalState,
     FunctionState* functionState,
-    IReferendStructsSource* referendStrutsSource,
+    IKindStructsSource* kindStrutsSource,
     LLVMBuilderRef builder,
     Reference* refMT,
     Ref ref);
@@ -151,14 +151,14 @@ WrapperPtrLE mallocStr(
     LLVMBuilderRef builder,
     LLVMValueRef lengthLE,
     LLVMValueRef sourceCharsPtrLE,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     std::function<void(LLVMBuilderRef builder, ControlBlockPtrLE controlBlockPtrLE)> fillControlBlock);
 LLVMValueRef mallocKnownSize(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Location location,
-    LLVMTypeRef referendLT);
+    LLVMTypeRef kindLT);
 void fillInnerStruct(
     GlobalState* globalState,
     FunctionState* functionState,
@@ -169,7 +169,7 @@ void fillInnerStruct(
 Ref constructWrappedStruct(
     GlobalState* globalState,
     FunctionState* functionState,
-    IReferendStructsSource* referendStructsSource,
+    IKindStructsSource* kindStructsSource,
     LLVMBuilderRef builder,
     LLVMTypeRef structL,
     Reference* structTypeM,
@@ -190,7 +190,7 @@ Ref innerAllocate(
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Reference* desiredReference,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     const std::vector<Ref>& memberRefs,
     Weakability effectiveWeakability,
     std::function<void(LLVMBuilderRef builder, ControlBlockPtrLE controlBlockPtrLE)> fillControlBlock);
@@ -253,11 +253,11 @@ Ref resilientDowncast(
     Reference *resultOptTypeM,
     Reference *sourceInterfaceRefMT,
     Ref &sourceInterfaceRef,
-    Referend *targetReferend,
+    Kind *targetKind,
     const std::function<Ref(LLVMBuilderRef, Ref)> &buildThen,
     std::function<Ref(LLVMBuilderRef)> &buildElse,
-    StructReferend *targetStructReferend,
-    InterfaceReferend *sourceInterfaceReferend);
+    StructKind *targetStructKind,
+    InterfaceKind *sourceInterfaceKind);
 ControlBlock makeResilientV1WeakableControlBlock(GlobalState* globalState);
 ControlBlock makeResilientV3WeakableControlBlock(GlobalState* globalState);
 ControlBlock makeMutNonWeakableControlBlock(GlobalState* globalState, RegionId* regionId);
@@ -279,7 +279,7 @@ Ref constructStaticSizedArray(
     LLVMBuilderRef builder,
     Reference* refM,
     StaticSizedArrayT* ssaMT,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     std::function<void(LLVMBuilderRef builder, ControlBlockPtrLE controlBlockPtrLE)> fillControlBlock);
 
 
@@ -288,7 +288,7 @@ void regularCheckValidReference(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* refM,
     LLVMValueRef refLE);
 
@@ -296,7 +296,7 @@ LoadResult regularLoadElementFromRSAWithoutUpgrade(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* rsaRefMT,
     RuntimeSizedArrayT* rsaMT,
     Mutability mutability,
@@ -309,7 +309,7 @@ LoadResult resilientLoadElementFromRSAWithoutUpgrade(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* rsaRefMT,
     Mutability mutability,
     Reference* elementType,
@@ -322,7 +322,7 @@ Ref regularStoreElementInSSA(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* rsaRefMT,
     Reference* elementType,
     int size,
@@ -334,7 +334,7 @@ void regularInitializeElementInSSA(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* ssaRefMT,
     Reference* elementType,
     int size,
@@ -346,7 +346,7 @@ Ref constructRuntimeSizedArray(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* rsaMT,
     Reference* elementType,
     RuntimeSizedArrayT* runtimeSizedArrayT,
@@ -360,7 +360,7 @@ LoadResult regularLoadStrongMember(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* structRefMT,
     Ref structRef,
     int memberIndex,
@@ -372,7 +372,7 @@ LoadResult regularLoadMember(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* structRefMT,
     Ref structRef,
     int memberIndex,
@@ -385,7 +385,7 @@ LoadResult resilientLoadWeakMember(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* structRefMT,
     Ref structRef,
     bool structKnownLive,
@@ -398,12 +398,12 @@ Ref upcastStrong(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* sourceStructMT,
-    StructReferend* sourceStructReferendM,
+    StructKind* sourceStructKindM,
     Ref sourceRefLE,
     Reference* targetInterfaceTypeM,
-    InterfaceReferend* targetInterfaceReferendM);
+    InterfaceKind* targetInterfaceKindM);
 
 Ref upcastWeak(
     GlobalState* globalState,
@@ -411,10 +411,10 @@ Ref upcastWeak(
     LLVMBuilderRef builder,
     IWeakRefStructsSource* weakRefStructs,
     Reference* sourceStructMT,
-    StructReferend* sourceStructReferendM,
+    StructKind* sourceStructKindM,
     Ref sourceRefLE,
     Reference* targetInterfaceTypeM,
-    InterfaceReferend* targetInterfaceReferendM);
+    InterfaceKind* targetInterfaceKindM);
 
 LoadResult regularloadElementFromSSA(
     GlobalState* globalState,
@@ -428,7 +428,7 @@ LoadResult regularloadElementFromSSA(
     Ref arrayRef,
     bool arrayKnownLive,
     Ref indexRef,
-    IReferendStructsSource* referendStructs);
+    IKindStructsSource* kindStructs);
 
 LoadResult resilientloadElementFromSSA(
     GlobalState* globalState,
@@ -442,16 +442,16 @@ LoadResult resilientloadElementFromSSA(
     Ref arrayRef,
     bool arrayKnownLive,
     Ref indexRef,
-    IReferendStructsSource* referendStructs);
+    IKindStructsSource* kindStructs);
 
 
 void regularFillControlBlock(
     AreaAndFileAndLine from,
     GlobalState* globalState,
     FunctionState* functionState,
-    IReferendStructsSource* structs,
+    IKindStructsSource* structs,
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     ControlBlockPtrLE controlBlockPtrLE,
     const std::string& typeName,
     WrcWeaks* wrcWeaks);
@@ -460,9 +460,9 @@ void gmFillControlBlock(
     AreaAndFileAndLine from,
     GlobalState* globalState,
     FunctionState* functionState,
-    IReferendStructsSource* structs,
+    IKindStructsSource* structs,
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     ControlBlockPtrLE controlBlockPtrLE,
     const std::string& typeName,
     HybridGenerationalMemory* hgmWeaks);
@@ -471,7 +471,7 @@ Ref getRuntimeSizedArrayLengthStrong(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* rsaRefMT,
     Ref arrayRef);
 
@@ -479,7 +479,7 @@ std::tuple<LLVMValueRef, LLVMValueRef> explodeStrongInterfaceRef(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* virtualParamMT,
     Ref virtualArgRef);
 
@@ -487,7 +487,7 @@ std::tuple<LLVMValueRef, LLVMValueRef> explodeWeakInterfaceRef(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     FatWeaks* fatWeaks,
     IWeakRefStructsSource* weakRefStructs,
     Reference* virtualParamMT,
@@ -499,7 +499,7 @@ void storeMemberStrong(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* structRefMT,
     Ref structRef,
     bool structKnownLive,
@@ -511,7 +511,7 @@ void storeMemberWeak(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* structRefMT,
     Ref structRef,
     bool structKnownLive,
@@ -523,7 +523,7 @@ void storeMemberWeak(
 Ref regularWeakAlias(
     GlobalState* globalState,
     FunctionState* functionState,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     WrcWeaks* wrcWeaks,
     LLVMBuilderRef builder,
     Reference* sourceRefMT,
@@ -565,7 +565,7 @@ void initializeElementInRSA(
     GlobalState* globalState,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     RuntimeSizedArrayT* rsaMT,
     Reference* rsaRefMT,
     Ref rsaRef,
@@ -589,7 +589,7 @@ Ref regularDowncast(
     Reference* sourceInterfaceRefMT,
     Ref sourceInterfaceRef,
     bool sourceRefKnownLive,
-    Referend* targetReferend,
+    Kind* targetKind,
     std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
     std::function<Ref(LLVMBuilderRef)> buildElse);
 

--- a/Midas/src/c-compiler/region/common/controlblock.cpp
+++ b/Midas/src/c-compiler/region/common/controlblock.cpp
@@ -5,7 +5,7 @@
 LLVMValueRef getTypeNameStrPtrFromControlBlockPtr(
     GlobalState* globalState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* structs,
+    IKindStructsSource* structs,
     Reference* refM,
     ControlBlockPtrLE controlBlockPtr) {
   return LLVMBuildLoad(
@@ -13,7 +13,7 @@ LLVMValueRef getTypeNameStrPtrFromControlBlockPtr(
       LLVMBuildStructGEP(
           builder,
           controlBlockPtr.refLE,
-          structs->getControlBlock(refM->referend)->getMemberIndex(ControlBlockMember::CENSUS_TYPE_STR),
+          structs->getControlBlock(refM->kind)->getMemberIndex(ControlBlockMember::CENSUS_TYPE_STR),
           "typeNameStrPtrPtr"),
       "typeNameStrPtr");
 }

--- a/Midas/src/c-compiler/region/common/defaultlayout/ikindstructssource.h
+++ b/Midas/src/c-compiler/region/common/defaultlayout/ikindstructssource.h
@@ -1,19 +1,19 @@
 #ifndef REGION_COMMON_DEFAULTLAYOUT_IREFERENDSTRUCTSSOURCE_H_
 #define REGION_COMMON_DEFAULTLAYOUT_IREFERENDSTRUCTSSOURCE_H_
 
-class IReferendStructsSource {
+class IKindStructsSource {
 public:
-  virtual ~IReferendStructsSource() = default;
-  virtual ControlBlock* getControlBlock(Referend* referend) = 0;
-  virtual LLVMTypeRef getInnerStruct(StructReferend* structReferend) = 0;
-  virtual LLVMTypeRef getWrapperStruct(StructReferend* structReferend) = 0;
+  virtual ~IKindStructsSource() = default;
+  virtual ControlBlock* getControlBlock(Kind* kind) = 0;
+  virtual LLVMTypeRef getInnerStruct(StructKind* structKind) = 0;
+  virtual LLVMTypeRef getWrapperStruct(StructKind* structKind) = 0;
   virtual LLVMTypeRef getStaticSizedArrayWrapperStruct(StaticSizedArrayT* ssaMT) = 0;
   virtual LLVMTypeRef getRuntimeSizedArrayWrapperStruct(RuntimeSizedArrayT* rsaMT) = 0;
   virtual LLVMTypeRef getStringWrapperStruct() = 0;
-  virtual LLVMTypeRef getInterfaceRefStruct(InterfaceReferend* interfaceReferend) = 0;
-  virtual LLVMTypeRef getInterfaceTableStruct(InterfaceReferend* interfaceReferend) = 0;
-  virtual void defineStruct(StructReferend* structM, std::vector<LLVMTypeRef> membersLT) = 0;
-  virtual void declareStruct(StructReferend* structM) = 0;
+  virtual LLVMTypeRef getInterfaceRefStruct(InterfaceKind* interfaceKind) = 0;
+  virtual LLVMTypeRef getInterfaceTableStruct(InterfaceKind* interfaceKind) = 0;
+  virtual void defineStruct(StructKind* structM, std::vector<LLVMTypeRef> membersLT) = 0;
+  virtual void declareStruct(StructKind* structM) = 0;
   virtual void declareEdge(Edge* edge) = 0;
   virtual void defineEdge(
       Edge* edge,
@@ -59,7 +59,7 @@ public:
 //      AreaAndFileAndLine checkerAFL,
 //      FunctionState* functionState,
 //      LLVMBuilderRef builder,
-//      Referend* referendM,
+//      Kind* kindM,
 //      LLVMValueRef controlBlockPtrLE) = 0;
 
   virtual LLVMValueRef getStringBytesPtr(
@@ -75,14 +75,14 @@ public:
       AreaAndFileAndLine from,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       InterfaceFatPtrLE interfaceFatPtrLE) = 0;
 
   virtual ControlBlockPtrLE getControlBlockPtrWithoutChecking(
       AreaAndFileAndLine from,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       InterfaceFatPtrLE interfaceFatPtrLE) = 0;
 
   virtual ControlBlockPtrLE getControlBlockPtr(
@@ -111,7 +111,7 @@ public:
 
   virtual LLVMValueRef getStructContentsPtr(
       LLVMBuilderRef builder,
-      Referend* referend,
+      Kind* kind,
       WrapperPtrLE wrapperPtrLE) = 0;
 
   virtual LLVMValueRef getVoidPtrFromInterfacePtr(
@@ -122,7 +122,7 @@ public:
 
   virtual LLVMValueRef getObjIdFromControlBlockPtr(
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       ControlBlockPtrLE controlBlockPtr) = 0;
 
   // See CRCISFAORC for why we don't take in a mutability.

--- a/Midas/src/c-compiler/region/common/defaultlayout/structs.cpp
+++ b/Midas/src/c-compiler/region/common/defaultlayout/structs.cpp
@@ -11,7 +11,7 @@ constexpr int WEAK_REF_HEADER_MEMBER_INDEX_FOR_TARGET_GEN = 0;
 constexpr int WEAK_REF_HEADER_MEMBER_INDEX_FOR_LGTI = 1;
 
 
-ReferendStructs::ReferendStructs(GlobalState* globalState_, ControlBlock controlBlock_)
+KindStructs::KindStructs(GlobalState* globalState_, ControlBlock controlBlock_)
   : globalState(globalState_),
     controlBlock(controlBlock_) {
 
@@ -42,52 +42,52 @@ ReferendStructs::ReferendStructs(GlobalState* globalState_, ControlBlock control
   }
 }
 
-ControlBlock* ReferendStructs::getControlBlock() {
+ControlBlock* KindStructs::getControlBlock() {
   return &controlBlock;
 }
-ControlBlock* ReferendStructs::getControlBlock(Referend* referend) {
+ControlBlock* KindStructs::getControlBlock(Kind* kind) {
   return &controlBlock;
 }
-LLVMTypeRef ReferendStructs::getInnerStruct(StructReferend* structReferend) {
-  auto structIter = innerStructs.find(structReferend->fullName->name);
+LLVMTypeRef KindStructs::getInnerStruct(StructKind* structKind) {
+  auto structIter = innerStructs.find(structKind->fullName->name);
   assert(structIter != innerStructs.end());
   return structIter->second;
 }
-LLVMTypeRef ReferendStructs::getWrapperStruct(StructReferend* structReferend) {
-  auto structIter = wrapperStructs.find(structReferend->fullName->name);
+LLVMTypeRef KindStructs::getWrapperStruct(StructKind* structKind) {
+  auto structIter = wrapperStructs.find(structKind->fullName->name);
   assert(structIter != wrapperStructs.end());
   return structIter->second;
 }
-LLVMTypeRef ReferendStructs::getStaticSizedArrayWrapperStruct(StaticSizedArrayT* ssaMT) {
+LLVMTypeRef KindStructs::getStaticSizedArrayWrapperStruct(StaticSizedArrayT* ssaMT) {
   auto structIter = staticSizedArrayWrapperStructs.find(ssaMT->name->name);
   assert(structIter != staticSizedArrayWrapperStructs.end());
   return structIter->second;
 }
-LLVMTypeRef ReferendStructs::getRuntimeSizedArrayWrapperStruct(RuntimeSizedArrayT* rsaMT) {
+LLVMTypeRef KindStructs::getRuntimeSizedArrayWrapperStruct(RuntimeSizedArrayT* rsaMT) {
   auto structIter = runtimeSizedArrayWrapperStructs.find(rsaMT->name->name);
   assert(structIter != runtimeSizedArrayWrapperStructs.end());
   return structIter->second;
 }
-LLVMTypeRef ReferendStructs::getInterfaceRefStruct(InterfaceReferend* interfaceReferend) {
-  auto structIter = interfaceRefStructs.find(interfaceReferend->fullName->name);
+LLVMTypeRef KindStructs::getInterfaceRefStruct(InterfaceKind* interfaceKind) {
+  auto structIter = interfaceRefStructs.find(interfaceKind->fullName->name);
   assert(structIter != interfaceRefStructs.end());
   return structIter->second;
 }
-LLVMTypeRef ReferendStructs::getInterfaceTableStruct(InterfaceReferend* interfaceReferend) {
-  auto structIter = interfaceTableStructs.find(interfaceReferend->fullName->name);
+LLVMTypeRef KindStructs::getInterfaceTableStruct(InterfaceKind* interfaceKind) {
+  auto structIter = interfaceTableStructs.find(interfaceKind->fullName->name);
   assert(structIter != interfaceTableStructs.end());
   return structIter->second;
 }
-LLVMTypeRef ReferendStructs::getStringWrapperStruct() {
+LLVMTypeRef KindStructs::getStringWrapperStruct() {
   return stringWrapperStructL;
 }
 
-WeakableReferendStructs::WeakableReferendStructs(
+WeakableKindStructs::WeakableKindStructs(
   GlobalState* globalState_,
   ControlBlock controlBlock,
   LLVMTypeRef weakRefHeaderStructL_)
 : globalState(globalState_),
-  referendStructs(globalState_, std::move(controlBlock)),
+  kindStructs(globalState_, std::move(controlBlock)),
   weakRefHeaderStructL(weakRefHeaderStructL_) {
 
   assert(weakRefHeaderStructL);
@@ -104,47 +104,47 @@ WeakableReferendStructs::WeakableReferendStructs(
   LLVMStructSetBody(weakVoidRefStructL, structWeakRefStructMemberTypesL.data(), structWeakRefStructMemberTypesL.size(), false);
 }
 
-ControlBlock* WeakableReferendStructs::getControlBlock(Referend* referend) {
-  return referendStructs.getControlBlock(referend);
+ControlBlock* WeakableKindStructs::getControlBlock(Kind* kind) {
+  return kindStructs.getControlBlock(kind);
 }
-ControlBlock* WeakableReferendStructs::getControlBlock() {
-  return referendStructs.getControlBlock();
+ControlBlock* WeakableKindStructs::getControlBlock() {
+  return kindStructs.getControlBlock();
 }
-LLVMTypeRef WeakableReferendStructs::getInnerStruct(StructReferend* structReferend) {
-  return referendStructs.getInnerStruct(structReferend);
+LLVMTypeRef WeakableKindStructs::getInnerStruct(StructKind* structKind) {
+  return kindStructs.getInnerStruct(structKind);
 }
-LLVMTypeRef WeakableReferendStructs::getWrapperStruct(StructReferend* structReferend) {
-  return referendStructs.getWrapperStruct(structReferend);
+LLVMTypeRef WeakableKindStructs::getWrapperStruct(StructKind* structKind) {
+  return kindStructs.getWrapperStruct(structKind);
 }
-LLVMTypeRef WeakableReferendStructs::getStaticSizedArrayWrapperStruct(StaticSizedArrayT* ssaMT) {
-  return referendStructs.getStaticSizedArrayWrapperStruct(ssaMT);
+LLVMTypeRef WeakableKindStructs::getStaticSizedArrayWrapperStruct(StaticSizedArrayT* ssaMT) {
+  return kindStructs.getStaticSizedArrayWrapperStruct(ssaMT);
 }
-LLVMTypeRef WeakableReferendStructs::getRuntimeSizedArrayWrapperStruct(RuntimeSizedArrayT* rsaMT) {
-  return referendStructs.getRuntimeSizedArrayWrapperStruct(rsaMT);
+LLVMTypeRef WeakableKindStructs::getRuntimeSizedArrayWrapperStruct(RuntimeSizedArrayT* rsaMT) {
+  return kindStructs.getRuntimeSizedArrayWrapperStruct(rsaMT);
 }
-LLVMTypeRef WeakableReferendStructs::getInterfaceRefStruct(InterfaceReferend* interfaceReferend) {
-  return referendStructs.getInterfaceRefStruct(interfaceReferend);
+LLVMTypeRef WeakableKindStructs::getInterfaceRefStruct(InterfaceKind* interfaceKind) {
+  return kindStructs.getInterfaceRefStruct(interfaceKind);
 }
-LLVMTypeRef WeakableReferendStructs::getInterfaceTableStruct(InterfaceReferend* interfaceReferend) {
-  return referendStructs.getInterfaceRefStruct(interfaceReferend);
+LLVMTypeRef WeakableKindStructs::getInterfaceTableStruct(InterfaceKind* interfaceKind) {
+  return kindStructs.getInterfaceRefStruct(interfaceKind);
 }
-LLVMTypeRef WeakableReferendStructs::getStructWeakRefStruct(StructReferend* structReferend) {
-  auto structIter = structWeakRefStructs.find(structReferend->fullName->name);
+LLVMTypeRef WeakableKindStructs::getStructWeakRefStruct(StructKind* structKind) {
+  auto structIter = structWeakRefStructs.find(structKind->fullName->name);
   assert(structIter != structWeakRefStructs.end());
   return structIter->second;
 }
-LLVMTypeRef WeakableReferendStructs::getStaticSizedArrayWeakRefStruct(StaticSizedArrayT* ssaMT) {
+LLVMTypeRef WeakableKindStructs::getStaticSizedArrayWeakRefStruct(StaticSizedArrayT* ssaMT) {
   auto structIter = staticSizedArrayWeakRefStructs.find(ssaMT->name->name);
   assert(structIter != staticSizedArrayWeakRefStructs.end());
   return structIter->second;
 }
-LLVMTypeRef WeakableReferendStructs::getRuntimeSizedArrayWeakRefStruct(RuntimeSizedArrayT* rsaMT) {
+LLVMTypeRef WeakableKindStructs::getRuntimeSizedArrayWeakRefStruct(RuntimeSizedArrayT* rsaMT) {
   auto structIter = runtimeSizedArrayWeakRefStructs.find(rsaMT->name->name);
   assert(structIter != runtimeSizedArrayWeakRefStructs.end());
   return structIter->second;
 }
-LLVMTypeRef WeakableReferendStructs::getInterfaceWeakRefStruct(InterfaceReferend* interfaceReferend) {
-  auto interfaceIter = interfaceWeakRefStructs.find(interfaceReferend->fullName->name);
+LLVMTypeRef WeakableKindStructs::getInterfaceWeakRefStruct(InterfaceKind* interfaceKind) {
+  auto interfaceIter = interfaceWeakRefStructs.find(interfaceKind->fullName->name);
   assert(interfaceIter != interfaceWeakRefStructs.end());
   return interfaceIter->second;
 }
@@ -156,14 +156,14 @@ LLVMTypeRef WeakableReferendStructs::getInterfaceWeakRefStruct(InterfaceReferend
 
 
 
-void ReferendStructs::defineStruct(
-    StructReferend* structReferend,
+void KindStructs::defineStruct(
+    StructKind* structKind,
     std::vector<LLVMTypeRef> membersLT) {
-  LLVMTypeRef valStructL = getInnerStruct(structReferend);
+  LLVMTypeRef valStructL = getInnerStruct(structKind);
   LLVMStructSetBody(
       valStructL, membersLT.data(), membersLT.size(), false);
 
-  LLVMTypeRef wrapperStructL = getWrapperStruct(structReferend);
+  LLVMTypeRef wrapperStructL = getWrapperStruct(structKind);
   std::vector<LLVMTypeRef> wrapperStructMemberTypesL;
 
   // First member is a ref counts struct. We don't include the int directly
@@ -177,7 +177,7 @@ void ReferendStructs::defineStruct(
       wrapperStructL, wrapperStructMemberTypesL.data(), wrapperStructMemberTypesL.size(), false);
 }
 
-void ReferendStructs::declareStruct(StructReferend* structM) {
+void KindStructs::declareStruct(StructKind* structM) {
 
   auto innerStructL =
       LLVMStructCreateNamed(
@@ -193,7 +193,7 @@ void ReferendStructs::declareStruct(StructReferend* structM) {
 }
 
 
-void ReferendStructs::declareEdge(
+void KindStructs::declareEdge(
     Edge* edge) {
 
   auto interfaceTableStructL =
@@ -208,7 +208,7 @@ void ReferendStructs::declareEdge(
   globalState->interfaceTablePtrs.emplace(edge, itablePtr);
 }
 
-void ReferendStructs::defineEdge(
+void KindStructs::defineEdge(
     Edge* edge,
     std::vector<LLVMTypeRef> interfaceFunctionsLT,
     std::vector<LLVMValueRef> functions) {
@@ -226,7 +226,7 @@ void ReferendStructs::defineEdge(
   LLVMSetInitializer(itablePtr,  itableLE);
 }
 
-void ReferendStructs::declareInterface(InterfaceDefinition* interface) {
+void KindStructs::declareInterface(InterfaceDefinition* interface) {
   assert(interfaceTableStructs.count(interface->name->name) == 0);
   auto interfaceTableStructL =
       LLVMStructCreateNamed(
@@ -256,35 +256,35 @@ void ReferendStructs::declareInterface(InterfaceDefinition* interface) {
   interfaceRefStructs.emplace(interface->name->name, interfaceRefStructL);
 }
 
-void ReferendStructs::defineInterface(
+void KindStructs::defineInterface(
     InterfaceDefinition* interface,
     std::vector<LLVMTypeRef> interfaceMethodTypesL) {
   LLVMTypeRef itableStruct =
-      getInterfaceTableStruct(interface->referend);
+      getInterfaceTableStruct(interface->kind);
 
   LLVMStructSetBody(
       itableStruct, interfaceMethodTypesL.data(), interfaceMethodTypesL.size(), false);
 }
 
 
-void ReferendStructs::declareStaticSizedArray(
+void KindStructs::declareStaticSizedArray(
     StaticSizedArrayDefinitionT* staticSizedArrayMT) {
 
   auto countedStruct = LLVMStructCreateNamed(globalState->context, staticSizedArrayMT->name->name.c_str());
   staticSizedArrayWrapperStructs.emplace(staticSizedArrayMT->name->name, countedStruct);
 }
 
-void ReferendStructs::declareRuntimeSizedArray(
+void KindStructs::declareRuntimeSizedArray(
     RuntimeSizedArrayDefinitionT* runtimeSizedArrayMT) {
   auto countedStruct = LLVMStructCreateNamed(globalState->context, (runtimeSizedArrayMT->name->name + "rc").c_str());
   runtimeSizedArrayWrapperStructs.emplace(runtimeSizedArrayMT->name->name, countedStruct);
 }
 
-void ReferendStructs::defineRuntimeSizedArray(
+void KindStructs::defineRuntimeSizedArray(
     RuntimeSizedArrayDefinitionT* runtimeSizedArrayMT,
     LLVMTypeRef elementLT) {
 
-  auto runtimeSizedArrayWrapperStruct = getRuntimeSizedArrayWrapperStruct(runtimeSizedArrayMT->referend);
+  auto runtimeSizedArrayWrapperStruct = getRuntimeSizedArrayWrapperStruct(runtimeSizedArrayMT->kind);
   auto innerArrayLT = LLVMArrayType(elementLT, 0);
 
   std::vector<LLVMTypeRef> elementsL;
@@ -298,10 +298,10 @@ void ReferendStructs::defineRuntimeSizedArray(
   LLVMStructSetBody(runtimeSizedArrayWrapperStruct, elementsL.data(), elementsL.size(), false);
 }
 
-void ReferendStructs::defineStaticSizedArray(
+void KindStructs::defineStaticSizedArray(
     StaticSizedArrayDefinitionT* staticSizedArrayMT,
     LLVMTypeRef elementLT) {
-  auto staticSizedArrayWrapperStruct = getStaticSizedArrayWrapperStruct(staticSizedArrayMT->referend);
+  auto staticSizedArrayWrapperStruct = getStaticSizedArrayWrapperStruct(staticSizedArrayMT->kind);
 
   auto innerArrayLT = LLVMArrayType(elementLT, staticSizedArrayMT->size);
 
@@ -315,30 +315,30 @@ void ReferendStructs::defineStaticSizedArray(
 }
 
 
-WrapperPtrLE ReferendStructs::makeWrapperPtr(
+WrapperPtrLE KindStructs::makeWrapperPtr(
     AreaAndFileAndLine checkerAFL,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Reference* referenceM,
     LLVMValueRef ptrLE) {
   assert(ptrLE != nullptr);
-  Referend* referend = referenceM->referend;
+  Kind* kind = referenceM->kind;
 
   WrapperPtrLE wrapperPtrLE = makeWrapperPtrWithoutChecking(checkerAFL, functionState, builder, referenceM, ptrLE);
 
-  if (dynamic_cast<StructReferend*>(referend)) {
+  if (dynamic_cast<StructKind*>(kind)) {
     auto controlBlockPtrLE = getConcreteControlBlockPtr(checkerAFL, functionState, builder, referenceM, wrapperPtrLE);
     buildAssertCensusContains(checkerAFL, globalState, functionState, builder, controlBlockPtrLE.refLE);
-  } else if (dynamic_cast<InterfaceReferend*>(referend)) {
+  } else if (dynamic_cast<InterfaceKind*>(kind)) {
     // can we even get a wrapper struct for an interface?
     assert(false);
-  } else if (dynamic_cast<StaticSizedArrayT*>(referend)) {
+  } else if (dynamic_cast<StaticSizedArrayT*>(kind)) {
     auto controlBlockPtrLE = getConcreteControlBlockPtr(checkerAFL, functionState, builder, referenceM, wrapperPtrLE);
     buildAssertCensusContains(checkerAFL, globalState, functionState, builder, controlBlockPtrLE.refLE);
-  } else if (dynamic_cast<RuntimeSizedArrayT*>(referend)) {
+  } else if (dynamic_cast<RuntimeSizedArrayT*>(kind)) {
     auto controlBlockPtrLE = getConcreteControlBlockPtr(checkerAFL, functionState, builder, referenceM, wrapperPtrLE);
     buildAssertCensusContains(checkerAFL, globalState, functionState, builder, controlBlockPtrLE.refLE);
-  } else if (dynamic_cast<Str*>(referend)) {
+  } else if (dynamic_cast<Str*>(kind)) {
     auto controlBlockPtrLE = getConcreteControlBlockPtr(checkerAFL, functionState, builder, referenceM, wrapperPtrLE);
     buildAssertCensusContains(checkerAFL, globalState, functionState, builder, controlBlockPtrLE.refLE);
   } else assert(false);
@@ -347,7 +347,7 @@ WrapperPtrLE ReferendStructs::makeWrapperPtr(
 }
 
 
-WrapperPtrLE ReferendStructs::makeWrapperPtrWithoutChecking(
+WrapperPtrLE KindStructs::makeWrapperPtrWithoutChecking(
     AreaAndFileAndLine checkerAFL,
     FunctionState* functionState,
     LLVMBuilderRef builder,
@@ -355,17 +355,17 @@ WrapperPtrLE ReferendStructs::makeWrapperPtrWithoutChecking(
     LLVMValueRef ptrLE) {
   assert(ptrLE != nullptr);
 
-  Referend* referend = referenceM->referend;
+  Kind* kind = referenceM->kind;
   LLVMTypeRef wrapperStructLT = nullptr;
-  if (auto structReferend = dynamic_cast<StructReferend*>(referend)) {
-    wrapperStructLT = getWrapperStruct(structReferend);
-  } else if (auto interfaceReferend = dynamic_cast<InterfaceReferend*>(referend)) {
+  if (auto structKind = dynamic_cast<StructKind*>(kind)) {
+    wrapperStructLT = getWrapperStruct(structKind);
+  } else if (auto interfaceKind = dynamic_cast<InterfaceKind*>(kind)) {
     assert(false); // can we even get a wrapper struct for an interface?
-  } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(referend)) {
+  } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(kind)) {
     wrapperStructLT = getStaticSizedArrayWrapperStruct(ssaMT);
-  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(referend)) {
+  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(kind)) {
     wrapperStructLT = getRuntimeSizedArrayWrapperStruct(rsaMT);
-  } else if (auto strMT = dynamic_cast<Str*>(referend)) {
+  } else if (auto strMT = dynamic_cast<Str*>(kind)) {
     wrapperStructLT = stringWrapperStructL;
   } else assert(false);
   assert(LLVMTypeOf(ptrLE) == LLVMPointerType(wrapperStructLT, 0));
@@ -375,15 +375,15 @@ WrapperPtrLE ReferendStructs::makeWrapperPtrWithoutChecking(
   return wrapperPtrLE;
 }
 
-InterfaceFatPtrLE ReferendStructs::makeInterfaceFatPtrWithoutChecking(
+InterfaceFatPtrLE KindStructs::makeInterfaceFatPtrWithoutChecking(
     AreaAndFileAndLine checkerAFL,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Reference* referenceM_,
     LLVMValueRef ptrLE) {
-  auto interfaceReferendM = dynamic_cast<InterfaceReferend*>(referenceM_->referend);
-  assert(interfaceReferendM);
-  assert(LLVMTypeOf(ptrLE) == getInterfaceRefStruct(interfaceReferendM));
+  auto interfaceKindM = dynamic_cast<InterfaceKind*>(referenceM_->kind);
+  assert(interfaceKindM);
+  assert(LLVMTypeOf(ptrLE) == getInterfaceRefStruct(interfaceKindM));
 
   auto interfaceFatPtrLE = InterfaceFatPtrLE(referenceM_, ptrLE);
 
@@ -393,7 +393,7 @@ InterfaceFatPtrLE ReferendStructs::makeInterfaceFatPtrWithoutChecking(
   return interfaceFatPtrLE;
 }
 
-InterfaceFatPtrLE ReferendStructs::makeInterfaceFatPtr(
+InterfaceFatPtrLE KindStructs::makeInterfaceFatPtr(
     AreaAndFileAndLine checkerAFL,
     FunctionState* functionState,
     LLVMBuilderRef builder,
@@ -408,44 +408,44 @@ InterfaceFatPtrLE ReferendStructs::makeInterfaceFatPtr(
   return interfaceFatPtrLE;
 }
 
-ControlBlockPtrLE ReferendStructs::makeControlBlockPtr(
+ControlBlockPtrLE KindStructs::makeControlBlockPtr(
     AreaAndFileAndLine checkerAFL,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     LLVMValueRef controlBlockPtrLE) {
-  auto result = makeControlBlockPtrWithoutChecking(checkerAFL, functionState, builder, referendM, controlBlockPtrLE);
+  auto result = makeControlBlockPtrWithoutChecking(checkerAFL, functionState, builder, kindM, controlBlockPtrLE);
   buildAssertCensusContains(checkerAFL, globalState, functionState, builder, controlBlockPtrLE);
   return result;
 }
 
-ControlBlockPtrLE ReferendStructs::makeControlBlockPtrWithoutChecking(
+ControlBlockPtrLE KindStructs::makeControlBlockPtrWithoutChecking(
     AreaAndFileAndLine checkerAFL,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     LLVMValueRef controlBlockPtrLE) {
   auto actualTypeOfControlBlockPtrLE = LLVMTypeOf(controlBlockPtrLE);
-  auto expectedControlBlockStructL = getControlBlock(referendM)->getStruct();
+  auto expectedControlBlockStructL = getControlBlock(kindM)->getStruct();
   auto expectedControlBlockStructPtrL = LLVMPointerType(expectedControlBlockStructL, 0);
   assert(actualTypeOfControlBlockPtrLE == expectedControlBlockStructPtrL);
 
-  return ControlBlockPtrLE(referendM, controlBlockPtrLE);
+  return ControlBlockPtrLE(kindM, controlBlockPtrLE);
 }
 
 
-LLVMValueRef ReferendStructs::getStringBytesPtr(
+LLVMValueRef KindStructs::getStringBytesPtr(
     FunctionState* functionState,
     LLVMBuilderRef builder,
     WrapperPtrLE ptrLE) {
   return getCharsPtrFromWrapperPtr(globalState, builder, ptrLE);
 }
 
-LLVMValueRef ReferendStructs::getStringLen(FunctionState* functionState, LLVMBuilderRef builder, WrapperPtrLE ptrLE) {
+LLVMValueRef KindStructs::getStringLen(FunctionState* functionState, LLVMBuilderRef builder, WrapperPtrLE ptrLE) {
   return getLenFromStrWrapperPtr(builder, ptrLE);
 }
 
-ControlBlockPtrLE ReferendStructs::getConcreteControlBlockPtr(
+ControlBlockPtrLE KindStructs::getConcreteControlBlockPtr(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
@@ -454,11 +454,11 @@ ControlBlockPtrLE ReferendStructs::getConcreteControlBlockPtr(
   // Control block is always the 0th element of every concrete struct.
   return makeControlBlockPtr(
       from, functionState, builder,
-      wrapperPtrLE.refM->referend,
+      wrapperPtrLE.refM->kind,
       LLVMBuildStructGEP(builder, wrapperPtrLE.refLE, 0, "controlPtr"));
 }
 
-ControlBlockPtrLE ReferendStructs::getConcreteControlBlockPtrWithoutChecking(
+ControlBlockPtrLE KindStructs::getConcreteControlBlockPtrWithoutChecking(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
@@ -467,75 +467,75 @@ ControlBlockPtrLE ReferendStructs::getConcreteControlBlockPtrWithoutChecking(
   // Control block is always the 0th element of every concrete struct.
   return makeControlBlockPtrWithoutChecking(
       from, functionState, builder,
-      wrapperPtrLE.refM->referend,
+      wrapperPtrLE.refM->kind,
       LLVMBuildStructGEP(builder, wrapperPtrLE.refLE, 0, "controlPtr"));
 }
 
 
 
-ControlBlockPtrLE ReferendStructs::getControlBlockPtr(
+ControlBlockPtrLE KindStructs::getControlBlockPtr(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     InterfaceFatPtrLE interfaceFatPtrLE) {
   // Interface fat pointer's first element points directly at the control block,
   // and we dont have to cast it. We would have to cast if we were accessing the
   // actual object though.
   return makeControlBlockPtr(
       from, functionState, builder,
-      interfaceFatPtrLE.refM->referend,
+      interfaceFatPtrLE.refM->kind,
       LLVMBuildExtractValue(builder, interfaceFatPtrLE.refLE, 0, "controlPtr"));
 }
 
-ControlBlockPtrLE ReferendStructs::getControlBlockPtrWithoutChecking(
+ControlBlockPtrLE KindStructs::getControlBlockPtrWithoutChecking(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     InterfaceFatPtrLE interfaceFatPtrLE) {
   // Interface fat pointer's first element points directly at the control block,
   // and we dont have to cast it. We would have to cast if we were accessing the
   // actual object though.
   return makeControlBlockPtrWithoutChecking(
       from, functionState, builder,
-      interfaceFatPtrLE.refM->referend,
+      interfaceFatPtrLE.refM->kind,
       LLVMBuildExtractValue(builder, interfaceFatPtrLE.refLE, 0, "controlPtr"));
 }
 
-ControlBlockPtrLE ReferendStructs::getControlBlockPtr(
+ControlBlockPtrLE KindStructs::getControlBlockPtr(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     // This will be a pointer if a mutable struct, or a fat ref if an interface.
     Ref ref,
     Reference* referenceM) {
-  auto referendM = referenceM->referend;
-  if (dynamic_cast<InterfaceReferend*>(referendM)) {
+  auto kindM = referenceM->kind;
+  if (dynamic_cast<InterfaceKind*>(kindM)) {
     auto referenceLE =
         makeInterfaceFatPtr(
             from, functionState, builder, referenceM,
             globalState->getRegion(referenceM)->checkValidReference(from, functionState, builder, referenceM, ref));
-    return getControlBlockPtr(from, functionState, builder, referendM, referenceLE);
-  } else if (dynamic_cast<StructReferend*>(referendM)) {
+    return getControlBlockPtr(from, functionState, builder, kindM, referenceLE);
+  } else if (dynamic_cast<StructKind*>(kindM)) {
     auto referenceLE =
         makeWrapperPtr(
             from, functionState, builder, referenceM,
             globalState->getRegion(referenceM)->checkValidReference(from, functionState, builder, referenceM, ref));
     return getConcreteControlBlockPtr(from, functionState, builder, referenceM, referenceLE);
-  } else if (dynamic_cast<StaticSizedArrayT*>(referendM)) {
+  } else if (dynamic_cast<StaticSizedArrayT*>(kindM)) {
     auto referenceLE =
         makeWrapperPtr(
             from, functionState, builder, referenceM,
             globalState->getRegion(referenceM)->checkValidReference(from, functionState, builder, referenceM, ref));
     return getConcreteControlBlockPtr(from, functionState, builder, referenceM, referenceLE);
-  } else if (dynamic_cast<RuntimeSizedArrayT*>(referendM)) {
+  } else if (dynamic_cast<RuntimeSizedArrayT*>(kindM)) {
     auto referenceLE =
         makeWrapperPtr(
             from, functionState, builder, referenceM,
             globalState->getRegion(referenceM)->checkValidReference(from, functionState, builder, referenceM, ref));
     return getConcreteControlBlockPtr(from, functionState, builder, referenceM, referenceLE);
-  } else if (dynamic_cast<Str*>(referendM)) {
+  } else if (dynamic_cast<Str*>(kindM)) {
     auto referenceLE =
         makeWrapperPtr(
             from, functionState, builder, referenceM,
@@ -546,27 +546,27 @@ ControlBlockPtrLE ReferendStructs::getControlBlockPtr(
   }
 }
 
-ControlBlockPtrLE ReferendStructs::getControlBlockPtr(
+ControlBlockPtrLE KindStructs::getControlBlockPtr(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     // This will be a pointer if a mutable struct, or a fat ref if an interface.
     LLVMValueRef ref,
     Reference* referenceM) {
-  auto referendM = referenceM->referend;
-  if (dynamic_cast<InterfaceReferend*>(referendM)) {
+  auto kindM = referenceM->kind;
+  if (dynamic_cast<InterfaceKind*>(kindM)) {
     auto referenceLE = makeInterfaceFatPtr(from, functionState, builder, referenceM, ref);
-    return getControlBlockPtr(from, functionState, builder, referendM, referenceLE);
-  } else if (dynamic_cast<StructReferend*>(referendM)) {
+    return getControlBlockPtr(from, functionState, builder, kindM, referenceLE);
+  } else if (dynamic_cast<StructKind*>(kindM)) {
     auto referenceLE = makeWrapperPtr(from, functionState, builder, referenceM, ref);
     return getConcreteControlBlockPtr(from, functionState, builder, referenceM, referenceLE);
-  } else if (dynamic_cast<StaticSizedArrayT*>(referendM)) {
+  } else if (dynamic_cast<StaticSizedArrayT*>(kindM)) {
     auto referenceLE = makeWrapperPtr(from, functionState, builder, referenceM, ref);
     return getConcreteControlBlockPtr(from, functionState, builder, referenceM, referenceLE);
-  } else if (dynamic_cast<RuntimeSizedArrayT*>(referendM)) {
+  } else if (dynamic_cast<RuntimeSizedArrayT*>(kindM)) {
     auto referenceLE = makeWrapperPtr(from, functionState, builder, referenceM, ref);
     return getConcreteControlBlockPtr(from, functionState, builder, referenceM, referenceLE);
-  } else if (dynamic_cast<Str*>(referendM)) {
+  } else if (dynamic_cast<Str*>(kindM)) {
     auto referenceLE = makeWrapperPtr(from, functionState, builder, referenceM, ref);
     return getConcreteControlBlockPtr(from, functionState, builder, referenceM, referenceLE);
   } else {
@@ -574,27 +574,27 @@ ControlBlockPtrLE ReferendStructs::getControlBlockPtr(
   }
 }
 
-ControlBlockPtrLE ReferendStructs::getControlBlockPtrWithoutChecking(
+ControlBlockPtrLE KindStructs::getControlBlockPtrWithoutChecking(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     // This will be a pointer if a mutable struct, or a fat ref if an interface.
     LLVMValueRef ref,
     Reference* referenceM) {
-  auto referendM = referenceM->referend;
-  if (dynamic_cast<InterfaceReferend*>(referendM)) {
+  auto kindM = referenceM->kind;
+  if (dynamic_cast<InterfaceKind*>(kindM)) {
     auto referenceLE = makeInterfaceFatPtrWithoutChecking(from, functionState, builder, referenceM, ref);
-    return getControlBlockPtrWithoutChecking(from, functionState, builder, referendM, referenceLE);
-  } else if (dynamic_cast<StructReferend*>(referendM)) {
+    return getControlBlockPtrWithoutChecking(from, functionState, builder, kindM, referenceLE);
+  } else if (dynamic_cast<StructKind*>(kindM)) {
     auto referenceLE = makeWrapperPtrWithoutChecking(from, functionState, builder, referenceM, ref);
     return getConcreteControlBlockPtrWithoutChecking(from, functionState, builder, referenceM, referenceLE);
-  } else if (dynamic_cast<StaticSizedArrayT*>(referendM)) {
+  } else if (dynamic_cast<StaticSizedArrayT*>(kindM)) {
     auto referenceLE = makeWrapperPtrWithoutChecking(from, functionState, builder, referenceM, ref);
     return getConcreteControlBlockPtrWithoutChecking(from, functionState, builder, referenceM, referenceLE);
-  } else if (dynamic_cast<RuntimeSizedArrayT*>(referendM)) {
+  } else if (dynamic_cast<RuntimeSizedArrayT*>(kindM)) {
     auto referenceLE = makeWrapperPtrWithoutChecking(from, functionState, builder, referenceM, ref);
     return getConcreteControlBlockPtrWithoutChecking(from, functionState, builder, referenceM, referenceLE);
-  } else if (dynamic_cast<Str*>(referendM)) {
+  } else if (dynamic_cast<Str*>(kindM)) {
     auto referenceLE = makeWrapperPtrWithoutChecking(from, functionState, builder, referenceM, ref);
     return getConcreteControlBlockPtrWithoutChecking(from, functionState, builder, referenceM, referenceLE);
   } else {
@@ -603,9 +603,9 @@ ControlBlockPtrLE ReferendStructs::getControlBlockPtrWithoutChecking(
 }
 
 
-LLVMValueRef ReferendStructs::getStructContentsPtr(
+LLVMValueRef KindStructs::getStructContentsPtr(
     LLVMBuilderRef builder,
-    Referend* referend,
+    Kind* kind,
     WrapperPtrLE wrapperPtrLE) {
   return LLVMBuildStructGEP(
       builder,
@@ -615,7 +615,7 @@ LLVMValueRef ReferendStructs::getStructContentsPtr(
 }
 
 
-LLVMValueRef ReferendStructs::getVoidPtrFromInterfacePtr(
+LLVMValueRef KindStructs::getVoidPtrFromInterfacePtr(
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Reference* virtualParamMT,
@@ -623,14 +623,14 @@ LLVMValueRef ReferendStructs::getVoidPtrFromInterfacePtr(
   assert(LLVMTypeOf(virtualArgLE.refLE) == globalState->getRegion(virtualParamMT)->translateType(virtualParamMT));
   return LLVMBuildPointerCast(
       builder,
-      getControlBlockPtr(FL(), functionState, builder, virtualParamMT->referend, virtualArgLE).refLE,
+      getControlBlockPtr(FL(), functionState, builder, virtualParamMT->kind, virtualArgLE).refLE,
       LLVMPointerType(LLVMInt8TypeInContext(globalState->context), 0),
       "objAsVoidPtr");
 }
 
-LLVMValueRef ReferendStructs::getObjIdFromControlBlockPtr(
+LLVMValueRef KindStructs::getObjIdFromControlBlockPtr(
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     ControlBlockPtrLE controlBlockPtr) {
   assert(globalState->opt->census);
   return LLVMBuildLoad(
@@ -638,12 +638,12 @@ LLVMValueRef ReferendStructs::getObjIdFromControlBlockPtr(
       LLVMBuildStructGEP(
           builder,
           controlBlockPtr.refLE,
-          getControlBlock(referendM)->getMemberIndex(ControlBlockMember::CENSUS_OBJ_ID),
+          getControlBlock(kindM)->getMemberIndex(ControlBlockMember::CENSUS_OBJ_ID),
           "objIdPtr"),
       "objId");
 }
 
-LLVMValueRef ReferendStructs::getStrongRcFromControlBlockPtr(
+LLVMValueRef KindStructs::getStrongRcFromControlBlockPtr(
     LLVMBuilderRef builder,
     Reference* refM,
     ControlBlockPtrLE structExpr) {
@@ -666,7 +666,7 @@ LLVMValueRef ReferendStructs::getStrongRcFromControlBlockPtr(
 }
 
 // See CRCISFAORC for why we don't take in a mutability.
-LLVMValueRef ReferendStructs::getStrongRcPtrFromControlBlockPtr(
+LLVMValueRef KindStructs::getStrongRcPtrFromControlBlockPtr(
     LLVMBuilderRef builder,
     Reference* refM,
     ControlBlockPtrLE controlBlockPtr) {
@@ -687,19 +687,19 @@ LLVMValueRef ReferendStructs::getStrongRcPtrFromControlBlockPtr(
   return LLVMBuildStructGEP(
       builder,
       controlBlockPtr.refLE,
-      getControlBlock(refM->referend)->getMemberIndex(ControlBlockMember::STRONG_RC),
+      getControlBlock(refM->kind)->getMemberIndex(ControlBlockMember::STRONG_RC),
       "rcPtr");
 }
 
 
 
 
-void WeakableReferendStructs::defineStruct(
-    StructReferend* struuct,
+void WeakableKindStructs::defineStruct(
+    StructKind* struuct,
     std::vector<LLVMTypeRef> membersLT) {
   assert(weakRefHeaderStructL);
 
-  referendStructs.defineStruct(struuct, membersLT);
+  kindStructs.defineStruct(struuct, membersLT);
 
   LLVMTypeRef wrapperStructL = getWrapperStruct(struuct);
 
@@ -710,8 +710,8 @@ void WeakableReferendStructs::defineStruct(
   LLVMStructSetBody(structWeakRefStructL, structWeakRefStructMemberTypesL.data(), structWeakRefStructMemberTypesL.size(), false);
 }
 
-void WeakableReferendStructs::declareStruct(StructReferend* structM) {
-  referendStructs.declareStruct(structM);
+void WeakableKindStructs::declareStruct(StructKind* structM) {
+  kindStructs.declareStruct(structM);
 
   auto structWeakRefStructL =
       LLVMStructCreateNamed(
@@ -721,20 +721,20 @@ void WeakableReferendStructs::declareStruct(StructReferend* structM) {
 }
 
 
-void WeakableReferendStructs::declareEdge(
+void WeakableKindStructs::declareEdge(
     Edge* edge) {
-  referendStructs.declareEdge(edge);
+  kindStructs.declareEdge(edge);
 }
 
-void WeakableReferendStructs::defineEdge(
+void WeakableKindStructs::defineEdge(
     Edge* edge,
     std::vector<LLVMTypeRef> interfaceFunctionsLT,
     std::vector<LLVMValueRef> functions) {
-  referendStructs.defineEdge(edge, interfaceFunctionsLT, functions);
+  kindStructs.defineEdge(edge, interfaceFunctionsLT, functions);
 }
 
-void WeakableReferendStructs::declareInterface(InterfaceDefinition* interface) {
-  referendStructs.declareInterface(interface);
+void WeakableKindStructs::declareInterface(InterfaceDefinition* interface) {
+  kindStructs.declareInterface(interface);
 
   auto interfaceWeakRefStructL =
       LLVMStructCreateNamed(
@@ -744,7 +744,7 @@ void WeakableReferendStructs::declareInterface(InterfaceDefinition* interface) {
   interfaceWeakRefStructs.emplace(interface->name->name, interfaceWeakRefStructL);
 
 
-  LLVMTypeRef refStructL = getInterfaceRefStruct(interface->referend);
+  LLVMTypeRef refStructL = getInterfaceRefStruct(interface->kind);
 
   std::vector<LLVMTypeRef> interfaceWeakRefStructMemberTypesL;
   interfaceWeakRefStructMemberTypesL.push_back(weakRefHeaderStructL);
@@ -752,18 +752,18 @@ void WeakableReferendStructs::declareInterface(InterfaceDefinition* interface) {
   LLVMStructSetBody(interfaceWeakRefStructL, interfaceWeakRefStructMemberTypesL.data(), interfaceWeakRefStructMemberTypesL.size(), false);
 }
 
-void WeakableReferendStructs::defineInterface(
+void WeakableKindStructs::defineInterface(
     InterfaceDefinition* interface,
     std::vector<LLVMTypeRef> interfaceMethodTypesL) {
   assert(weakRefHeaderStructL);
 
-  referendStructs.defineInterface(interface, interfaceMethodTypesL);
+  kindStructs.defineInterface(interface, interfaceMethodTypesL);
 }
 
 
-void WeakableReferendStructs::declareStaticSizedArray(
+void WeakableKindStructs::declareStaticSizedArray(
     StaticSizedArrayDefinitionT* staticSizedArrayMT) {
-  referendStructs.declareStaticSizedArray(staticSizedArrayMT);
+  kindStructs.declareStaticSizedArray(staticSizedArrayMT);
 
   auto weakRefStructL =
       LLVMStructCreateNamed(
@@ -772,9 +772,9 @@ void WeakableReferendStructs::declareStaticSizedArray(
   staticSizedArrayWeakRefStructs.emplace(staticSizedArrayMT->name->name, weakRefStructL);
 }
 
-void WeakableReferendStructs::declareRuntimeSizedArray(
+void WeakableKindStructs::declareRuntimeSizedArray(
     RuntimeSizedArrayDefinitionT* runtimeSizedArrayMT) {
-  referendStructs.declareRuntimeSizedArray(runtimeSizedArrayMT);
+  kindStructs.declareRuntimeSizedArray(runtimeSizedArrayMT);
 
   auto weakRefStructL =
       LLVMStructCreateNamed(
@@ -783,48 +783,48 @@ void WeakableReferendStructs::declareRuntimeSizedArray(
   runtimeSizedArrayWeakRefStructs.emplace(runtimeSizedArrayMT->name->name, weakRefStructL);
 }
 
-void WeakableReferendStructs::defineRuntimeSizedArray(
+void WeakableKindStructs::defineRuntimeSizedArray(
     RuntimeSizedArrayDefinitionT* runtimeSizedArrayMT,
     LLVMTypeRef elementLT) {
   assert(weakRefHeaderStructL);
 
-  referendStructs.defineRuntimeSizedArray(runtimeSizedArrayMT, elementLT);
+  kindStructs.defineRuntimeSizedArray(runtimeSizedArrayMT, elementLT);
 
-  auto runtimeSizedArrayWrapperStruct = getRuntimeSizedArrayWrapperStruct(runtimeSizedArrayMT->referend);
+  auto runtimeSizedArrayWrapperStruct = getRuntimeSizedArrayWrapperStruct(runtimeSizedArrayMT->kind);
 
-  auto arrayWeakRefStructL = getRuntimeSizedArrayWeakRefStruct(runtimeSizedArrayMT->referend);
+  auto arrayWeakRefStructL = getRuntimeSizedArrayWeakRefStruct(runtimeSizedArrayMT->kind);
   std::vector<LLVMTypeRef> arrayWeakRefStructMemberTypesL;
   arrayWeakRefStructMemberTypesL.push_back(weakRefHeaderStructL);
   arrayWeakRefStructMemberTypesL.push_back(LLVMPointerType(runtimeSizedArrayWrapperStruct, 0));
   LLVMStructSetBody(arrayWeakRefStructL, arrayWeakRefStructMemberTypesL.data(), arrayWeakRefStructMemberTypesL.size(), false);
 }
 
-void WeakableReferendStructs::defineStaticSizedArray(
+void WeakableKindStructs::defineStaticSizedArray(
     StaticSizedArrayDefinitionT* staticSizedArrayMT,
     LLVMTypeRef elementLT) {
   assert(weakRefHeaderStructL);
 
-  referendStructs.defineStaticSizedArray(staticSizedArrayMT, elementLT);
+  kindStructs.defineStaticSizedArray(staticSizedArrayMT, elementLT);
 
-  auto staticSizedArrayWrapperStruct = getStaticSizedArrayWrapperStruct(staticSizedArrayMT->referend);
+  auto staticSizedArrayWrapperStruct = getStaticSizedArrayWrapperStruct(staticSizedArrayMT->kind);
 
-  auto arrayWeakRefStructL = getStaticSizedArrayWeakRefStruct(staticSizedArrayMT->referend);
+  auto arrayWeakRefStructL = getStaticSizedArrayWeakRefStruct(staticSizedArrayMT->kind);
   std::vector<LLVMTypeRef> arrayWeakRefStructMemberTypesL;
   arrayWeakRefStructMemberTypesL.push_back(weakRefHeaderStructL);
   arrayWeakRefStructMemberTypesL.push_back(LLVMPointerType(staticSizedArrayWrapperStruct, 0));
   LLVMStructSetBody(arrayWeakRefStructL, arrayWeakRefStructMemberTypesL.data(), arrayWeakRefStructMemberTypesL.size(), false);
 }
 
-WeakFatPtrLE WeakableReferendStructs::makeWeakFatPtr(Reference* referenceM_, LLVMValueRef ptrLE) {
-  if (auto structReferendM = dynamic_cast<StructReferend*>(referenceM_->referend)) {
-    assert(LLVMTypeOf(ptrLE) == getStructWeakRefStruct(structReferendM));
-  } else if (auto interfaceReferendM = dynamic_cast<InterfaceReferend*>(referenceM_->referend)) {
+WeakFatPtrLE WeakableKindStructs::makeWeakFatPtr(Reference* referenceM_, LLVMValueRef ptrLE) {
+  if (auto structKindM = dynamic_cast<StructKind*>(referenceM_->kind)) {
+    assert(LLVMTypeOf(ptrLE) == getStructWeakRefStruct(structKindM));
+  } else if (auto interfaceKindM = dynamic_cast<InterfaceKind*>(referenceM_->kind)) {
     assert(
         LLVMTypeOf(ptrLE) == weakVoidRefStructL ||
-            LLVMTypeOf(ptrLE) == getInterfaceWeakRefStruct(interfaceReferendM));
-  } else if (auto ssaT = dynamic_cast<StaticSizedArrayT*>(referenceM_->referend)) {
+            LLVMTypeOf(ptrLE) == getInterfaceWeakRefStruct(interfaceKindM));
+  } else if (auto ssaT = dynamic_cast<StaticSizedArrayT*>(referenceM_->kind)) {
     assert(LLVMTypeOf(ptrLE) == getStaticSizedArrayWeakRefStruct(ssaT));
-  } else if (auto rsaT = dynamic_cast<RuntimeSizedArrayT*>(referenceM_->referend)) {
+  } else if (auto rsaT = dynamic_cast<RuntimeSizedArrayT*>(referenceM_->kind)) {
     assert(LLVMTypeOf(ptrLE) == getRuntimeSizedArrayWeakRefStruct(rsaT));
   } else {
     assert(false);
@@ -832,13 +832,13 @@ WeakFatPtrLE WeakableReferendStructs::makeWeakFatPtr(Reference* referenceM_, LLV
   return WeakFatPtrLE(referenceM_, ptrLE);
 }
 
-WeakFatPtrLE WeakableReferendStructs::downcastWeakFatPtr(
+WeakFatPtrLE WeakableKindStructs::downcastWeakFatPtr(
     LLVMBuilderRef builder,
-    StructReferend* targetStructReferend,
+    StructKind* targetStructKind,
     Reference* targetRefMT,
     LLVMValueRef sourceWeakFatPtrLE) {
-  assert(targetRefMT->referend == targetStructReferend);
-  auto weakRefVoidStructLT = getWeakVoidRefStruct(targetStructReferend);
+  assert(targetRefMT->kind == targetStructKind);
+  auto weakRefVoidStructLT = getWeakVoidRefStruct(targetStructKind);
   assert(LLVMTypeOf(sourceWeakFatPtrLE) == weakRefVoidStructLT);
 
   auto weakRefHeaderStruct =
@@ -847,11 +847,11 @@ WeakFatPtrLE WeakableReferendStructs::downcastWeakFatPtr(
       LLVMBuildExtractValue(builder, sourceWeakFatPtrLE, 1, "objVoidPtr");
 
   auto underlyingStructPtrLT =
-      LLVMPointerType(referendStructs.getWrapperStruct(targetStructReferend), 0);
+      LLVMPointerType(kindStructs.getWrapperStruct(targetStructKind), 0);
   auto underlyingStructPtrLE =
       LLVMBuildBitCast(builder, objVoidPtrLE, underlyingStructPtrLT, "subtypePtr");
 
-  auto resultStructRefLT = getStructWeakRefStruct(targetStructReferend);
+  auto resultStructRefLT = getStructWeakRefStruct(targetStructKind);
   auto resultStructRefLE = LLVMGetUndef(resultStructRefLT);
   resultStructRefLE = LLVMBuildInsertValue(builder, resultStructRefLE, weakRefHeaderStruct, 0, "withHeader");
   resultStructRefLE = LLVMBuildInsertValue(builder, resultStructRefLE, underlyingStructPtrLE, 1, "withBoth");
@@ -860,153 +860,153 @@ WeakFatPtrLE WeakableReferendStructs::downcastWeakFatPtr(
   return targetWeakRef;
 }
 
-ControlBlockPtrLE WeakableReferendStructs::getConcreteControlBlockPtr(
+ControlBlockPtrLE WeakableKindStructs::getConcreteControlBlockPtr(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Reference* reference,
     WrapperPtrLE wrapperPtrLE) {
-  return referendStructs.getConcreteControlBlockPtr(from, functionState, builder, reference, wrapperPtrLE);
+  return kindStructs.getConcreteControlBlockPtr(from, functionState, builder, reference, wrapperPtrLE);
 }
 
-LLVMTypeRef WeakableReferendStructs::getStringWrapperStruct() {
-  return referendStructs.getStringWrapperStruct();
+LLVMTypeRef WeakableKindStructs::getStringWrapperStruct() {
+  return kindStructs.getStringWrapperStruct();
 }
 
-WrapperPtrLE WeakableReferendStructs::makeWrapperPtr(
+WrapperPtrLE WeakableKindStructs::makeWrapperPtr(
     AreaAndFileAndLine checkerAFL,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Reference* referenceM,
     LLVMValueRef ptrLE) {
-  return referendStructs.makeWrapperPtr(checkerAFL, functionState, builder, referenceM, ptrLE);
+  return kindStructs.makeWrapperPtr(checkerAFL, functionState, builder, referenceM, ptrLE);
 }
 
-InterfaceFatPtrLE WeakableReferendStructs::makeInterfaceFatPtr(
+InterfaceFatPtrLE WeakableKindStructs::makeInterfaceFatPtr(
     AreaAndFileAndLine checkerAFL,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Reference* referenceM_,
     LLVMValueRef ptrLE) {
-  return referendStructs.makeInterfaceFatPtr(checkerAFL, functionState, builder, referenceM_, ptrLE);
+  return kindStructs.makeInterfaceFatPtr(checkerAFL, functionState, builder, referenceM_, ptrLE);
 }
 
-InterfaceFatPtrLE WeakableReferendStructs::makeInterfaceFatPtrWithoutChecking(
+InterfaceFatPtrLE WeakableKindStructs::makeInterfaceFatPtrWithoutChecking(
     AreaAndFileAndLine checkerAFL,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Reference* referenceM_,
     LLVMValueRef ptrLE) {
-  return referendStructs.makeInterfaceFatPtrWithoutChecking(checkerAFL, functionState, builder, referenceM_, ptrLE);
+  return kindStructs.makeInterfaceFatPtrWithoutChecking(checkerAFL, functionState, builder, referenceM_, ptrLE);
 }
 
-//ControlBlockPtrLE WeakableReferendStructs::makeControlBlockPtr(
+//ControlBlockPtrLE WeakableKindStructs::makeControlBlockPtr(
 //    AreaAndFileAndLine checkerAFL,
 //    FunctionState* functionState,
 //    LLVMBuilderRef builder,
-//    Referend* referendM,
+//    Kind* kindM,
 //    LLVMValueRef controlBlockPtrLE) {
-//  return referendStructs.makeControlBlockPtr(checkerAFL, functionState, builder, referendM, controlBlockPtrLE);
+//  return kindStructs.makeControlBlockPtr(checkerAFL, functionState, builder, kindM, controlBlockPtrLE);
 //}
 
-LLVMValueRef WeakableReferendStructs::getStringBytesPtr(
+LLVMValueRef WeakableKindStructs::getStringBytesPtr(
     FunctionState* functionState,
     LLVMBuilderRef builder,
     WrapperPtrLE ptrLE) {
-  return referendStructs.getStringBytesPtr(functionState, builder, ptrLE);
+  return kindStructs.getStringBytesPtr(functionState, builder, ptrLE);
 }
 
-LLVMValueRef WeakableReferendStructs::getStringLen(
+LLVMValueRef WeakableKindStructs::getStringLen(
     FunctionState* functionState, LLVMBuilderRef builder, WrapperPtrLE ptrLE) {
-  return referendStructs.getStringLen(functionState, builder, ptrLE);
+  return kindStructs.getStringLen(functionState, builder, ptrLE);
 }
 
 
-ControlBlockPtrLE WeakableReferendStructs::getControlBlockPtr(
+ControlBlockPtrLE WeakableKindStructs::getControlBlockPtr(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     InterfaceFatPtrLE interfaceFatPtrLE) {
-  return referendStructs.getControlBlockPtr(from, functionState, builder, referendM, interfaceFatPtrLE);
+  return kindStructs.getControlBlockPtr(from, functionState, builder, kindM, interfaceFatPtrLE);
 }
 
-ControlBlockPtrLE WeakableReferendStructs::getControlBlockPtrWithoutChecking(
+ControlBlockPtrLE WeakableKindStructs::getControlBlockPtrWithoutChecking(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     InterfaceFatPtrLE interfaceFatPtrLE) {
-  return referendStructs.getControlBlockPtrWithoutChecking(from, functionState, builder, referendM, interfaceFatPtrLE);
+  return kindStructs.getControlBlockPtrWithoutChecking(from, functionState, builder, kindM, interfaceFatPtrLE);
 }
 
-ControlBlockPtrLE WeakableReferendStructs::getControlBlockPtr(
+ControlBlockPtrLE WeakableKindStructs::getControlBlockPtr(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     // This will be a pointer if a mutable struct, or a fat ref if an interface.
     Ref ref,
     Reference* referenceM) {
-  return referendStructs.getControlBlockPtr(from, functionState, builder, ref, referenceM);
+  return kindStructs.getControlBlockPtr(from, functionState, builder, ref, referenceM);
 }
 
-ControlBlockPtrLE WeakableReferendStructs::getControlBlockPtr(
+ControlBlockPtrLE WeakableKindStructs::getControlBlockPtr(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     // This will be a pointer if a mutable struct, or a fat ref if an interface.
     LLVMValueRef ref,
     Reference* referenceM) {
-  return referendStructs.getControlBlockPtr(from, functionState, builder, ref, referenceM);
+  return kindStructs.getControlBlockPtr(from, functionState, builder, ref, referenceM);
 }
 
-ControlBlockPtrLE WeakableReferendStructs::getControlBlockPtrWithoutChecking(
+ControlBlockPtrLE WeakableKindStructs::getControlBlockPtrWithoutChecking(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     // This will be a pointer if a mutable struct, or a fat ref if an interface.
     LLVMValueRef ref,
     Reference* referenceM) {
-  return referendStructs.getControlBlockPtrWithoutChecking(from, functionState, builder, ref, referenceM);
+  return kindStructs.getControlBlockPtrWithoutChecking(from, functionState, builder, ref, referenceM);
 }
 
-LLVMValueRef WeakableReferendStructs::getStructContentsPtr(
+LLVMValueRef WeakableKindStructs::getStructContentsPtr(
     LLVMBuilderRef builder,
-    Referend* referend,
+    Kind* kind,
     WrapperPtrLE wrapperPtrLE) {
-  return referendStructs.getStructContentsPtr(builder, referend, wrapperPtrLE);
+  return kindStructs.getStructContentsPtr(builder, kind, wrapperPtrLE);
 }
 
-LLVMValueRef WeakableReferendStructs::getVoidPtrFromInterfacePtr(
+LLVMValueRef WeakableKindStructs::getVoidPtrFromInterfacePtr(
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Reference* virtualParamMT,
     InterfaceFatPtrLE virtualArgLE) {
-  return referendStructs.getVoidPtrFromInterfacePtr(
+  return kindStructs.getVoidPtrFromInterfacePtr(
       functionState, builder, virtualParamMT, virtualArgLE);
 }
 
-LLVMValueRef WeakableReferendStructs::getObjIdFromControlBlockPtr(
+LLVMValueRef WeakableKindStructs::getObjIdFromControlBlockPtr(
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     ControlBlockPtrLE controlBlockPtr) {
-  return referendStructs.getObjIdFromControlBlockPtr(builder, referendM, controlBlockPtr);
+  return kindStructs.getObjIdFromControlBlockPtr(builder, kindM, controlBlockPtr);
 }
 
 // See CRCISFAORC for why we don't take in a mutability.
 // Strong means owning or borrow or shared; things that control the lifetime.
-LLVMValueRef WeakableReferendStructs::getStrongRcPtrFromControlBlockPtr(
+LLVMValueRef WeakableKindStructs::getStrongRcPtrFromControlBlockPtr(
     LLVMBuilderRef builder,
     Reference* refM,
     ControlBlockPtrLE controlBlockPtr) {
-  return referendStructs.getStrongRcPtrFromControlBlockPtr(builder, refM, controlBlockPtr);
+  return kindStructs.getStrongRcPtrFromControlBlockPtr(builder, refM, controlBlockPtr);
 }
 
 // See CRCISFAORC for why we don't take in a mutability.
 // Strong means owning or borrow or shared; things that control the lifetime.
-LLVMValueRef WeakableReferendStructs::getStrongRcFromControlBlockPtr(
+LLVMValueRef WeakableKindStructs::getStrongRcFromControlBlockPtr(
     LLVMBuilderRef builder,
     Reference* refM,
     ControlBlockPtrLE controlBlockPtr) {
-  return referendStructs.getStrongRcFromControlBlockPtr(builder, refM, controlBlockPtr);
+  return kindStructs.getStrongRcFromControlBlockPtr(builder, refM, controlBlockPtr);
 }

--- a/Midas/src/c-compiler/region/common/defaultlayout/structs.h
+++ b/Midas/src/c-compiler/region/common/defaultlayout/structs.h
@@ -3,53 +3,53 @@
 
 #include <globalstate.h>
 #include "region/common/controlblock.h"
-#include "ireferendstructssource.h"
+#include "ikindstructssource.h"
 
 
 class IWeakRefStructsSource {
 public:
   virtual ~IWeakRefStructsSource() = default;
-  virtual LLVMTypeRef getStructWeakRefStruct(StructReferend *structReferend) = 0;
+  virtual LLVMTypeRef getStructWeakRefStruct(StructKind *structKind) = 0;
   virtual LLVMTypeRef getStaticSizedArrayWeakRefStruct(StaticSizedArrayT *ssaMT) = 0;
   virtual LLVMTypeRef getRuntimeSizedArrayWeakRefStruct(RuntimeSizedArrayT *rsaMT) = 0;
-  virtual LLVMTypeRef getInterfaceWeakRefStruct(InterfaceReferend *interfaceReferend) = 0;
+  virtual LLVMTypeRef getInterfaceWeakRefStruct(InterfaceKind *interfaceKind) = 0;
   virtual WeakFatPtrLE makeWeakFatPtr(Reference* referenceM_, LLVMValueRef ptrLE) = 0;
 
-  virtual LLVMTypeRef getWeakRefHeaderStruct(Referend* referend) = 0;
+  virtual LLVMTypeRef getWeakRefHeaderStruct(Kind* kind) = 0;
   // This is a weak ref to a void*. When we're calling an interface method on a weak,
   // we have no idea who the receiver is. They'll receive this struct as the correctly
   // typed flavor of it (from structWeakRefStructs).
-  virtual LLVMTypeRef getWeakVoidRefStruct(Referend* referend) = 0;
+  virtual LLVMTypeRef getWeakVoidRefStruct(Kind* kind) = 0;
 
   virtual WeakFatPtrLE downcastWeakFatPtr(
       LLVMBuilderRef builder,
-      StructReferend* targetStructReferend,
+      StructKind* targetStructKind,
       Reference* targetRefMT,
       LLVMValueRef sourceWeakFatPtrLE) = 0;
 };
 
 
-// This is a collection of layouts and LLVM types for all sorts of NON-WEAKABLE referends.
-// We feed it referends, and it defines structs for us.
+// This is a collection of layouts and LLVM types for all sorts of NON-WEAKABLE kinds.
+// We feed it kinds, and it defines structs for us.
 // In every mode, immStructs and non-weakable muts use this *directly*.
 // (Keep in mind, resilient modes have no non-weakable muts)
 // Note how we said *directly* above. This is also used *indirectly* by WeakableStructs, who
 // puts somet extra things into the ControlBlock for its own weakability purposes.
-class ReferendStructs : public IReferendStructsSource {
+class KindStructs : public IKindStructsSource {
 public:
-  ReferendStructs(GlobalState* globalState_, ControlBlock controlBlock_);
+  KindStructs(GlobalState* globalState_, ControlBlock controlBlock_);
 
-  ControlBlock* getControlBlock(Referend* referend) override;
+  ControlBlock* getControlBlock(Kind* kind) override;
   ControlBlock* getControlBlock();
-  LLVMTypeRef getInnerStruct(StructReferend* structReferend) override;
-  LLVMTypeRef getWrapperStruct(StructReferend* structReferend) override;
+  LLVMTypeRef getInnerStruct(StructKind* structKind) override;
+  LLVMTypeRef getWrapperStruct(StructKind* structKind) override;
   LLVMTypeRef getStaticSizedArrayWrapperStruct(StaticSizedArrayT* ssaMT) override;
   LLVMTypeRef getRuntimeSizedArrayWrapperStruct(RuntimeSizedArrayT* rsaMT) override;
-  LLVMTypeRef getInterfaceRefStruct(InterfaceReferend* interfaceReferend) override;
-  LLVMTypeRef getInterfaceTableStruct(InterfaceReferend* interfaceReferend) override;
+  LLVMTypeRef getInterfaceRefStruct(InterfaceKind* interfaceKind) override;
+  LLVMTypeRef getInterfaceTableStruct(InterfaceKind* interfaceKind) override;
   LLVMTypeRef getStringWrapperStruct() override;
-  void defineStruct(StructReferend* structM, std::vector<LLVMTypeRef> membersLT) override;
-  void declareStruct(StructReferend* structM) override;
+  void defineStruct(StructKind* structM, std::vector<LLVMTypeRef> membersLT) override;
+  void declareStruct(StructKind* structM) override;
   void declareEdge(Edge* edge) override;
   void defineEdge(
       Edge* edge,
@@ -72,7 +72,7 @@ public:
 
   LLVMValueRef getObjIdFromControlBlockPtr(
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     ControlBlockPtrLE controlBlockPtr) override;
 
   WrapperPtrLE makeWrapperPtr(
@@ -100,7 +100,7 @@ public:
 //      AreaAndFileAndLine checkerAFL,
 //      FunctionState* functionState,
 //      LLVMBuilderRef builder,
-//      Referend* referendM,
+//      Kind* kindM,
 //      LLVMValueRef controlBlockPtrLE) override;
 
   LLVMValueRef getStringBytesPtr(
@@ -120,14 +120,14 @@ public:
       AreaAndFileAndLine from,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       InterfaceFatPtrLE interfaceFatPtrLE) override;
 
   ControlBlockPtrLE getControlBlockPtrWithoutChecking(
       AreaAndFileAndLine from,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       InterfaceFatPtrLE interfaceFatPtrLE) override;
 
   ControlBlockPtrLE getControlBlockPtr(
@@ -173,7 +173,7 @@ public:
 
   LLVMValueRef getStructContentsPtr(
       LLVMBuilderRef builder,
-      Referend* referend,
+      Kind* kind,
       WrapperPtrLE wrapperPtrLE) override;
 
 
@@ -188,14 +188,14 @@ private:
       AreaAndFileAndLine checkerAFL,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       LLVMValueRef controlBlockPtrLE);
 
   ControlBlockPtrLE makeControlBlockPtrWithoutChecking(
       AreaAndFileAndLine checkerAFL,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       LLVMValueRef controlBlockPtrLE);
 
   WrapperPtrLE makeWrapperPtrWithoutChecking(
@@ -240,29 +240,29 @@ private:
   LLVMTypeRef stringInnerStructL = nullptr;
 };
 
-// This is a collection of layouts and LLVM types for all sorts of WEAKABLE referends.
-// We feed it referends, and it defines structs for us.
+// This is a collection of layouts and LLVM types for all sorts of WEAKABLE kinds.
+// We feed it kinds, and it defines structs for us.
 // In every mode, weakable muts use this directly.
 // In every mode, immStructs and non-weakable muts DONT use this directly.
 // (Keep in mind, in resilient modes, all muts are weakable)
-class WeakableReferendStructs : public IReferendStructsSource, public IWeakRefStructsSource {
+class WeakableKindStructs : public IKindStructsSource, public IWeakRefStructsSource {
 public:
-  WeakableReferendStructs(
+  WeakableKindStructs(
       GlobalState* globalState_,
       ControlBlock controlBlock,
       LLVMTypeRef weakRefHeaderStructL_);
 
   ControlBlock* getControlBlock();
-  ControlBlock* getControlBlock(Referend* referend) override;
-  LLVMTypeRef getInnerStruct(StructReferend* structReferend) override;
-  LLVMTypeRef getWrapperStruct(StructReferend* structReferend) override;
+  ControlBlock* getControlBlock(Kind* kind) override;
+  LLVMTypeRef getInnerStruct(StructKind* structKind) override;
+  LLVMTypeRef getWrapperStruct(StructKind* structKind) override;
   LLVMTypeRef getStaticSizedArrayWrapperStruct(StaticSizedArrayT* ssaMT) override;
   LLVMTypeRef getRuntimeSizedArrayWrapperStruct(RuntimeSizedArrayT* rsaMT) override;
-  LLVMTypeRef getInterfaceRefStruct(InterfaceReferend* interfaceReferend) override;
-  LLVMTypeRef getInterfaceTableStruct(InterfaceReferend* interfaceReferend) override;
+  LLVMTypeRef getInterfaceRefStruct(InterfaceKind* interfaceKind) override;
+  LLVMTypeRef getInterfaceTableStruct(InterfaceKind* interfaceKind) override;
 
-  void defineStruct(StructReferend* structM, std::vector<LLVMTypeRef> membersLT) override;
-  void declareStruct(StructReferend* structM) override;
+  void defineStruct(StructKind* structM, std::vector<LLVMTypeRef> membersLT) override;
+  void declareStruct(StructKind* structM) override;
   void declareEdge(Edge* edge) override;
   void defineEdge(
       Edge* edge,
@@ -275,15 +275,15 @@ public:
   void defineRuntimeSizedArray(RuntimeSizedArrayDefinitionT* runtimeSizedArrayMT, LLVMTypeRef elementLT) override;
   void defineStaticSizedArray(StaticSizedArrayDefinitionT* staticSizedArrayMT, LLVMTypeRef elementLT) override;
 
-  LLVMTypeRef getStructWeakRefStruct(StructReferend* structReferend) override;
+  LLVMTypeRef getStructWeakRefStruct(StructKind* structKind) override;
   LLVMTypeRef getStaticSizedArrayWeakRefStruct(StaticSizedArrayT* ssaMT) override;
   LLVMTypeRef getRuntimeSizedArrayWeakRefStruct(RuntimeSizedArrayT* rsaMT) override;
-  LLVMTypeRef getInterfaceWeakRefStruct(InterfaceReferend* interfaceReferend) override;
+  LLVMTypeRef getInterfaceWeakRefStruct(InterfaceKind* interfaceKind) override;
 
   WeakFatPtrLE makeWeakFatPtr(Reference* referenceM_, LLVMValueRef ptrLE) override;
   WeakFatPtrLE downcastWeakFatPtr(
       LLVMBuilderRef builder,
-      StructReferend* targetStructReferend,
+      StructKind* targetStructKind,
       Reference* targetRefMT,
       LLVMValueRef sourceWeakFatPtrLE) override;
 
@@ -321,7 +321,7 @@ public:
 //      AreaAndFileAndLine checkerAFL,
 //      FunctionState* functionState,
 //      LLVMBuilderRef builder,
-//      Referend* referendM,
+//      Kind* kindM,
 //      LLVMValueRef controlBlockPtrLE) override;
 
   LLVMValueRef getStringBytesPtr(
@@ -336,14 +336,14 @@ public:
       AreaAndFileAndLine from,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       InterfaceFatPtrLE interfaceFatPtrLE) override;
 
   ControlBlockPtrLE getControlBlockPtrWithoutChecking(
       AreaAndFileAndLine from,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       InterfaceFatPtrLE interfaceFatPtrLE) override;
 
   ControlBlockPtrLE getControlBlockPtr(
@@ -372,7 +372,7 @@ public:
 
   LLVMValueRef getStructContentsPtr(
       LLVMBuilderRef builder,
-      Referend* referend,
+      Kind* kind,
       WrapperPtrLE wrapperPtrLE) override;
 
   LLVMValueRef getVoidPtrFromInterfacePtr(
@@ -383,7 +383,7 @@ public:
 
   LLVMValueRef getObjIdFromControlBlockPtr(
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       ControlBlockPtrLE controlBlockPtr) override;
 
   // See CRCISFAORC for why we don't take in a mutability.
@@ -400,20 +400,20 @@ public:
       Reference* refM,
       ControlBlockPtrLE controlBlockPtr) override;
 
-  LLVMTypeRef getWeakRefHeaderStruct(Referend* referend) override {
+  LLVMTypeRef getWeakRefHeaderStruct(Kind* kind) override {
     return weakRefHeaderStructL;
   }
   // This is a weak ref to a void*. When we're calling an interface method on a weak,
   // we have no idea who the receiver is. They'll receive this struct as the correctly
   // typed flavor of it (from structWeakRefStructs).
-  LLVMTypeRef getWeakVoidRefStruct(Referend* referend) override {
+  LLVMTypeRef getWeakVoidRefStruct(Kind* kind) override {
     return weakVoidRefStructL;
   }
 
 private:
   GlobalState* globalState = nullptr;
 
-  ReferendStructs referendStructs;
+  KindStructs kindStructs;
 
   LLVMTypeRef weakRefHeaderStructL = nullptr; // contains generation and maybe gen index
   // This is a weak ref to a void*. When we're calling an interface method on a weak,

--- a/Midas/src/c-compiler/region/common/defaultlayout/structsrouter.cpp
+++ b/Midas/src/c-compiler/region/common/defaultlayout/structsrouter.cpp
@@ -2,215 +2,215 @@
 #include <region/rcimm/rcimm.h>
 #include "structsrouter.h"
 
-ReferendStructsRouter::ReferendStructsRouter(
+KindStructsRouter::KindStructsRouter(
     GlobalState* globalState_,
-    GetReferendStructsSource getReferendStructsSource_)
+    GetKindStructsSource getKindStructsSource_)
   : globalState(globalState_),
-    getReferendStructsSource(getReferendStructsSource_) {}
+    getKindStructsSource(getKindStructsSource_) {}
 
-ControlBlock* ReferendStructsRouter::getControlBlock(Referend* referend) {
-  return getReferendStructsSource(referend)->getControlBlock(referend);
+ControlBlock* KindStructsRouter::getControlBlock(Kind* kind) {
+  return getKindStructsSource(kind)->getControlBlock(kind);
 }
-LLVMTypeRef ReferendStructsRouter::getInnerStruct(StructReferend* structReferend) {
-  return getReferendStructsSource(structReferend)->getInnerStruct(structReferend);
+LLVMTypeRef KindStructsRouter::getInnerStruct(StructKind* structKind) {
+  return getKindStructsSource(structKind)->getInnerStruct(structKind);
 }
-LLVMTypeRef ReferendStructsRouter::getWrapperStruct(StructReferend* structReferend) {
-  return getReferendStructsSource(structReferend)->getWrapperStruct(structReferend);
+LLVMTypeRef KindStructsRouter::getWrapperStruct(StructKind* structKind) {
+  return getKindStructsSource(structKind)->getWrapperStruct(structKind);
 }
-LLVMTypeRef ReferendStructsRouter::getStaticSizedArrayWrapperStruct(StaticSizedArrayT* ssaMT) {
-  return getReferendStructsSource(ssaMT)->getStaticSizedArrayWrapperStruct(ssaMT);
+LLVMTypeRef KindStructsRouter::getStaticSizedArrayWrapperStruct(StaticSizedArrayT* ssaMT) {
+  return getKindStructsSource(ssaMT)->getStaticSizedArrayWrapperStruct(ssaMT);
 }
-LLVMTypeRef ReferendStructsRouter::getRuntimeSizedArrayWrapperStruct(RuntimeSizedArrayT* rsaMT) {
-  return getReferendStructsSource(rsaMT)->getRuntimeSizedArrayWrapperStruct(rsaMT);
+LLVMTypeRef KindStructsRouter::getRuntimeSizedArrayWrapperStruct(RuntimeSizedArrayT* rsaMT) {
+  return getKindStructsSource(rsaMT)->getRuntimeSizedArrayWrapperStruct(rsaMT);
 }
-LLVMTypeRef ReferendStructsRouter::getInterfaceRefStruct(InterfaceReferend* interfaceReferend) {
-  return getReferendStructsSource(interfaceReferend)->getInterfaceRefStruct(interfaceReferend);
+LLVMTypeRef KindStructsRouter::getInterfaceRefStruct(InterfaceKind* interfaceKind) {
+  return getKindStructsSource(interfaceKind)->getInterfaceRefStruct(interfaceKind);
 }
-LLVMTypeRef ReferendStructsRouter::getInterfaceTableStruct(InterfaceReferend* interfaceReferend) {
-  return getReferendStructsSource(interfaceReferend)->getInterfaceTableStruct(interfaceReferend);
+LLVMTypeRef KindStructsRouter::getInterfaceTableStruct(InterfaceKind* interfaceKind) {
+  return getKindStructsSource(interfaceKind)->getInterfaceTableStruct(interfaceKind);
 }
-LLVMTypeRef ReferendStructsRouter::getStringWrapperStruct() {
-  return getReferendStructsSource(globalState->metalCache->str)->getStringWrapperStruct();
+LLVMTypeRef KindStructsRouter::getStringWrapperStruct() {
+  return getKindStructsSource(globalState->metalCache->str)->getStringWrapperStruct();
 }
-void ReferendStructsRouter::defineStruct(StructReferend* structM, std::vector<LLVMTypeRef> membersLT) {
-  return getReferendStructsSource(structM)->defineStruct(structM, membersLT);
+void KindStructsRouter::defineStruct(StructKind* structM, std::vector<LLVMTypeRef> membersLT) {
+  return getKindStructsSource(structM)->defineStruct(structM, membersLT);
 }
-void ReferendStructsRouter::declareStruct(StructReferend* structM) {
-  return getReferendStructsSource(structM)->declareStruct(structM);
+void KindStructsRouter::declareStruct(StructKind* structM) {
+  return getKindStructsSource(structM)->declareStruct(structM);
 }
-void ReferendStructsRouter::declareEdge(Edge* edge) {
-  return getReferendStructsSource(edge->structName)->declareEdge(edge);
+void KindStructsRouter::declareEdge(Edge* edge) {
+  return getKindStructsSource(edge->structName)->declareEdge(edge);
 }
-void ReferendStructsRouter::defineEdge(
+void KindStructsRouter::defineEdge(
     Edge* edge,
     std::vector<LLVMTypeRef> interfaceFunctionsLT,
     std::vector<LLVMValueRef> functions) {
-  return getReferendStructsSource(edge->structName)->defineEdge(edge, interfaceFunctionsLT, functions);
+  return getKindStructsSource(edge->structName)->defineEdge(edge, interfaceFunctionsLT, functions);
 }
-void ReferendStructsRouter::declareInterface(InterfaceDefinition* interfaceM) {
-  return getReferendStructsSource(interfaceM->referend)->declareInterface(interfaceM);
+void KindStructsRouter::declareInterface(InterfaceDefinition* interfaceM) {
+  return getKindStructsSource(interfaceM->kind)->declareInterface(interfaceM);
 }
-void ReferendStructsRouter::defineInterface(InterfaceDefinition* interface, std::vector<LLVMTypeRef> interfaceMethodTypesL) {
-  return getReferendStructsSource(interface->referend)->defineInterface(interface, interfaceMethodTypesL);
+void KindStructsRouter::defineInterface(InterfaceDefinition* interface, std::vector<LLVMTypeRef> interfaceMethodTypesL) {
+  return getKindStructsSource(interface->kind)->defineInterface(interface, interfaceMethodTypesL);
 }
-void ReferendStructsRouter::declareStaticSizedArray(StaticSizedArrayDefinitionT* staticSizedArrayMT) {
-  return getReferendStructsSource(staticSizedArrayMT->referend)->declareStaticSizedArray(staticSizedArrayMT);
+void KindStructsRouter::declareStaticSizedArray(StaticSizedArrayDefinitionT* staticSizedArrayMT) {
+  return getKindStructsSource(staticSizedArrayMT->kind)->declareStaticSizedArray(staticSizedArrayMT);
 }
-void ReferendStructsRouter::declareRuntimeSizedArray(RuntimeSizedArrayDefinitionT* runtimeSizedArrayMT) {
-  return getReferendStructsSource(runtimeSizedArrayMT->referend)->declareRuntimeSizedArray(runtimeSizedArrayMT);
+void KindStructsRouter::declareRuntimeSizedArray(RuntimeSizedArrayDefinitionT* runtimeSizedArrayMT) {
+  return getKindStructsSource(runtimeSizedArrayMT->kind)->declareRuntimeSizedArray(runtimeSizedArrayMT);
 }
-void ReferendStructsRouter::defineRuntimeSizedArray(RuntimeSizedArrayDefinitionT* runtimeSizedArrayMT, LLVMTypeRef elementLT) {
-  return getReferendStructsSource(runtimeSizedArrayMT->referend)->defineRuntimeSizedArray(runtimeSizedArrayMT, elementLT);
+void KindStructsRouter::defineRuntimeSizedArray(RuntimeSizedArrayDefinitionT* runtimeSizedArrayMT, LLVMTypeRef elementLT) {
+  return getKindStructsSource(runtimeSizedArrayMT->kind)->defineRuntimeSizedArray(runtimeSizedArrayMT, elementLT);
 }
-void ReferendStructsRouter::defineStaticSizedArray(StaticSizedArrayDefinitionT* staticSizedArrayMT, LLVMTypeRef elementLT) {
-  return getReferendStructsSource(staticSizedArrayMT->referend)->defineStaticSizedArray(staticSizedArrayMT, elementLT);
+void KindStructsRouter::defineStaticSizedArray(StaticSizedArrayDefinitionT* staticSizedArrayMT, LLVMTypeRef elementLT) {
+  return getKindStructsSource(staticSizedArrayMT->kind)->defineStaticSizedArray(staticSizedArrayMT, elementLT);
 }
 
-ControlBlockPtrLE ReferendStructsRouter::getConcreteControlBlockPtr(
+ControlBlockPtrLE KindStructsRouter::getConcreteControlBlockPtr(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Reference* reference,
     WrapperPtrLE wrapperPtrLE) {
-  return getReferendStructsSource(reference->referend)->getConcreteControlBlockPtr(from, functionState, builder, reference, wrapperPtrLE);
+  return getKindStructsSource(reference->kind)->getConcreteControlBlockPtr(from, functionState, builder, reference, wrapperPtrLE);
 }
 
 
-WrapperPtrLE ReferendStructsRouter::makeWrapperPtr(
+WrapperPtrLE KindStructsRouter::makeWrapperPtr(
     AreaAndFileAndLine checkerAFL,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Reference* referenceM,
     LLVMValueRef ptrLE) {
-  return getReferendStructsSource(referenceM->referend)->makeWrapperPtr(checkerAFL, functionState, builder, referenceM, ptrLE);
+  return getKindStructsSource(referenceM->kind)->makeWrapperPtr(checkerAFL, functionState, builder, referenceM, ptrLE);
 }
 
-InterfaceFatPtrLE ReferendStructsRouter::makeInterfaceFatPtr(
+InterfaceFatPtrLE KindStructsRouter::makeInterfaceFatPtr(
     AreaAndFileAndLine checkerAFL,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Reference* referenceM,
     LLVMValueRef ptrLE) {
-  return getReferendStructsSource(referenceM->referend)->makeInterfaceFatPtr(checkerAFL, functionState, builder, referenceM, ptrLE);
+  return getKindStructsSource(referenceM->kind)->makeInterfaceFatPtr(checkerAFL, functionState, builder, referenceM, ptrLE);
 }
 
-InterfaceFatPtrLE ReferendStructsRouter::makeInterfaceFatPtrWithoutChecking(
+InterfaceFatPtrLE KindStructsRouter::makeInterfaceFatPtrWithoutChecking(
     AreaAndFileAndLine checkerAFL,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Reference* referenceM,
     LLVMValueRef ptrLE) {
-  return getReferendStructsSource(referenceM->referend)->makeInterfaceFatPtrWithoutChecking(checkerAFL, functionState, builder, referenceM, ptrLE);
+  return getKindStructsSource(referenceM->kind)->makeInterfaceFatPtrWithoutChecking(checkerAFL, functionState, builder, referenceM, ptrLE);
 }
 
-//ControlBlockPtrLE ReferendStructsRouter::makeControlBlockPtr(
+//ControlBlockPtrLE KindStructsRouter::makeControlBlockPtr(
 //    AreaAndFileAndLine checkerAFL,
 //    FunctionState* functionState,
 //    LLVMBuilderRef builder,
-//    Referend* referendM,
+//    Kind* kindM,
 //    LLVMValueRef ptrLE) {
-//  return getReferendStructsSource(referendM)->makeControlBlockPtr(checkerAFL, functionState, builder, referendM, ptrLE);
+//  return getKindStructsSource(kindM)->makeControlBlockPtr(checkerAFL, functionState, builder, kindM, ptrLE);
 //}
 
-LLVMValueRef ReferendStructsRouter::getStringBytesPtr(
+LLVMValueRef KindStructsRouter::getStringBytesPtr(
     FunctionState* functionState,
     LLVMBuilderRef builder,
     WrapperPtrLE ptrLE) {
-  return getReferendStructsSource(globalState->metalCache->str)->getStringBytesPtr(functionState, builder, ptrLE);
+  return getKindStructsSource(globalState->metalCache->str)->getStringBytesPtr(functionState, builder, ptrLE);
 }
 
-LLVMValueRef ReferendStructsRouter::getStringLen(FunctionState* functionState, LLVMBuilderRef builder, WrapperPtrLE ptrLE) {
-  return getReferendStructsSource(globalState->metalCache->str)->getStringLen(functionState, builder, ptrLE);
+LLVMValueRef KindStructsRouter::getStringLen(FunctionState* functionState, LLVMBuilderRef builder, WrapperPtrLE ptrLE) {
+  return getKindStructsSource(globalState->metalCache->str)->getStringLen(functionState, builder, ptrLE);
 }
 
-ControlBlockPtrLE ReferendStructsRouter::getControlBlockPtr(
+ControlBlockPtrLE KindStructsRouter::getControlBlockPtr(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     InterfaceFatPtrLE interfaceFatPtrLE) {
-  return getReferendStructsSource(referendM)->getControlBlockPtr(from, functionState, builder, referendM, interfaceFatPtrLE);
+  return getKindStructsSource(kindM)->getControlBlockPtr(from, functionState, builder, kindM, interfaceFatPtrLE);
 }
 
-ControlBlockPtrLE ReferendStructsRouter::getControlBlockPtrWithoutChecking(
+ControlBlockPtrLE KindStructsRouter::getControlBlockPtrWithoutChecking(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     InterfaceFatPtrLE interfaceFatPtrLE) {
-  return getReferendStructsSource(referendM)->getControlBlockPtrWithoutChecking(from, functionState, builder, referendM, interfaceFatPtrLE);
+  return getKindStructsSource(kindM)->getControlBlockPtrWithoutChecking(from, functionState, builder, kindM, interfaceFatPtrLE);
 }
 
-ControlBlockPtrLE ReferendStructsRouter::getControlBlockPtr(
+ControlBlockPtrLE KindStructsRouter::getControlBlockPtr(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     // This will be a pointer if a mutable struct, or a fat ref if an interface.
     Ref ref,
     Reference* referenceM) {
-  return getReferendStructsSource(referenceM->referend)->getControlBlockPtr(from, functionState, builder, ref, referenceM);
+  return getKindStructsSource(referenceM->kind)->getControlBlockPtr(from, functionState, builder, ref, referenceM);
 }
 
-LLVMValueRef ReferendStructsRouter::getStructContentsPtr(
+LLVMValueRef KindStructsRouter::getStructContentsPtr(
     LLVMBuilderRef builder,
-    Referend* referend,
+    Kind* kind,
     WrapperPtrLE wrapperPtrLE) {
-  return getReferendStructsSource(referend)->getStructContentsPtr(builder, referend, wrapperPtrLE);
+  return getKindStructsSource(kind)->getStructContentsPtr(builder, kind, wrapperPtrLE);
 }
 
-ControlBlockPtrLE ReferendStructsRouter::getControlBlockPtr(
+ControlBlockPtrLE KindStructsRouter::getControlBlockPtr(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     // This will be a pointer if a mutable struct, or a fat ref if an interface.
     LLVMValueRef ref,
     Reference* referenceM) {
-  return getReferendStructsSource(referenceM->referend)->getControlBlockPtr(from, functionState, builder, ref, referenceM);
+  return getKindStructsSource(referenceM->kind)->getControlBlockPtr(from, functionState, builder, ref, referenceM);
 }
 
-ControlBlockPtrLE ReferendStructsRouter::getControlBlockPtrWithoutChecking(
+ControlBlockPtrLE KindStructsRouter::getControlBlockPtrWithoutChecking(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
     // This will be a pointer if a mutable struct, or a fat ref if an interface.
     LLVMValueRef ref,
     Reference* referenceM) {
-  return getReferendStructsSource(referenceM->referend)->getControlBlockPtrWithoutChecking(
+  return getKindStructsSource(referenceM->kind)->getControlBlockPtrWithoutChecking(
       from, functionState, builder, ref, referenceM);
 }
 
-LLVMValueRef ReferendStructsRouter::getVoidPtrFromInterfacePtr(
+LLVMValueRef KindStructsRouter::getVoidPtrFromInterfacePtr(
     FunctionState* functionState,
     LLVMBuilderRef builder,
     Reference* virtualParamMT,
     InterfaceFatPtrLE virtualArgLE) {
-  return getReferendStructsSource(virtualParamMT->referend)->getVoidPtrFromInterfacePtr(functionState, builder, virtualParamMT, virtualArgLE);
+  return getKindStructsSource(virtualParamMT->kind)->getVoidPtrFromInterfacePtr(functionState, builder, virtualParamMT, virtualArgLE);
 }
 
-LLVMValueRef ReferendStructsRouter::getObjIdFromControlBlockPtr(
+LLVMValueRef KindStructsRouter::getObjIdFromControlBlockPtr(
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     ControlBlockPtrLE controlBlockPtr) {
-  return getReferendStructsSource(referendM)->getObjIdFromControlBlockPtr(builder, referendM, controlBlockPtr);
+  return getKindStructsSource(kindM)->getObjIdFromControlBlockPtr(builder, kindM, controlBlockPtr);
 }
 
-LLVMValueRef ReferendStructsRouter::getStrongRcPtrFromControlBlockPtr(
-    LLVMBuilderRef builder,
-    Reference* refM,
-    ControlBlockPtrLE controlBlockPtr) {
-  return getReferendStructsSource(refM->referend)->getStrongRcPtrFromControlBlockPtr(builder, refM, controlBlockPtr);
-}
-
-LLVMValueRef ReferendStructsRouter::getStrongRcFromControlBlockPtr(
+LLVMValueRef KindStructsRouter::getStrongRcPtrFromControlBlockPtr(
     LLVMBuilderRef builder,
     Reference* refM,
     ControlBlockPtrLE controlBlockPtr) {
-  return getReferendStructsSource(refM->referend)->getStrongRcFromControlBlockPtr(builder, refM, controlBlockPtr);
+  return getKindStructsSource(refM->kind)->getStrongRcPtrFromControlBlockPtr(builder, refM, controlBlockPtr);
+}
+
+LLVMValueRef KindStructsRouter::getStrongRcFromControlBlockPtr(
+    LLVMBuilderRef builder,
+    Reference* refM,
+    ControlBlockPtrLE controlBlockPtr) {
+  return getKindStructsSource(refM->kind)->getStrongRcFromControlBlockPtr(builder, refM, controlBlockPtr);
 }
 
 
-LLVMTypeRef WeakRefStructsRouter::getStructWeakRefStruct(StructReferend* structReferend) {
-  return getWeakRefStructsSource(structReferend)->getStructWeakRefStruct(structReferend);
+LLVMTypeRef WeakRefStructsRouter::getStructWeakRefStruct(StructKind* structKind) {
+  return getWeakRefStructsSource(structKind)->getStructWeakRefStruct(structKind);
 }
 LLVMTypeRef WeakRefStructsRouter::getStaticSizedArrayWeakRefStruct(StaticSizedArrayT* ssaMT) {
   return getWeakRefStructsSource(ssaMT)->getStaticSizedArrayWeakRefStruct(ssaMT);
@@ -218,26 +218,26 @@ LLVMTypeRef WeakRefStructsRouter::getStaticSizedArrayWeakRefStruct(StaticSizedAr
 LLVMTypeRef WeakRefStructsRouter::getRuntimeSizedArrayWeakRefStruct(RuntimeSizedArrayT* rsaMT) {
   return getWeakRefStructsSource(rsaMT)->getRuntimeSizedArrayWeakRefStruct(rsaMT);
 }
-LLVMTypeRef WeakRefStructsRouter::getInterfaceWeakRefStruct(InterfaceReferend* interfaceReferend) {
-  return getWeakRefStructsSource(interfaceReferend)->getInterfaceWeakRefStruct(interfaceReferend);
+LLVMTypeRef WeakRefStructsRouter::getInterfaceWeakRefStruct(InterfaceKind* interfaceKind) {
+  return getWeakRefStructsSource(interfaceKind)->getInterfaceWeakRefStruct(interfaceKind);
 }
 WeakFatPtrLE WeakRefStructsRouter::makeWeakFatPtr(Reference* referenceM_, LLVMValueRef ptrLE) {
-  return getWeakRefStructsSource(referenceM_->referend)->makeWeakFatPtr(referenceM_, ptrLE);
+  return getWeakRefStructsSource(referenceM_->kind)->makeWeakFatPtr(referenceM_, ptrLE);
 }
 
 
 WeakFatPtrLE WeakRefStructsRouter::downcastWeakFatPtr(
     LLVMBuilderRef builder,
-    StructReferend* targetStructReferend,
+    StructKind* targetStructKind,
     Reference* targetRefMT,
     LLVMValueRef sourceWeakFatPtrLE) {
-  return getWeakRefStructsSource(targetStructReferend)->downcastWeakFatPtr(
-      builder, targetStructReferend, targetRefMT, sourceWeakFatPtrLE);
+  return getWeakRefStructsSource(targetStructKind)->downcastWeakFatPtr(
+      builder, targetStructKind, targetRefMT, sourceWeakFatPtrLE);
 }
 
-LLVMTypeRef WeakRefStructsRouter::getWeakRefHeaderStruct(Referend* referend) {
-  return getWeakRefStructsSource(referend)->getWeakRefHeaderStruct(referend);
+LLVMTypeRef WeakRefStructsRouter::getWeakRefHeaderStruct(Kind* kind) {
+  return getWeakRefStructsSource(kind)->getWeakRefHeaderStruct(kind);
 }
-LLVMTypeRef WeakRefStructsRouter::getWeakVoidRefStruct(Referend* referend) {
-  return getWeakRefStructsSource(referend)->getWeakVoidRefStruct(referend);
+LLVMTypeRef WeakRefStructsRouter::getWeakVoidRefStruct(Kind* kind) {
+  return getWeakRefStructsSource(kind)->getWeakVoidRefStruct(kind);
 }

--- a/Midas/src/c-compiler/region/common/defaultlayout/structsrouter.h
+++ b/Midas/src/c-compiler/region/common/defaultlayout/structsrouter.h
@@ -4,29 +4,29 @@
 #include <globalstate.h>
 #include "structs.h"
 
-using GetReferendStructsSource = std::function<IReferendStructsSource*(Referend*)>;
-using GetWeakRefStructsSource = std::function<IWeakRefStructsSource*(Referend*)>;
+using GetKindStructsSource = std::function<IKindStructsSource*(Kind*)>;
+using GetWeakRefStructsSource = std::function<IWeakRefStructsSource*(Kind*)>;
 
 // This is a class that wraps three Structses into one, and routes calls to them based on the
-// referend's Mutability and Weakability.
-class ReferendStructsRouter : public IReferendStructsSource {
+// kind's Mutability and Weakability.
+class KindStructsRouter : public IKindStructsSource {
 public:
-  ReferendStructsRouter(
+  KindStructsRouter(
       GlobalState* globalState,
-      GetReferendStructsSource getReferendStructsSource_);
+      GetKindStructsSource getKindStructsSource_);
 
-  ControlBlock* getControlBlock(Referend* referend) override;
+  ControlBlock* getControlBlock(Kind* kind) override;
 
-  LLVMTypeRef getInnerStruct(StructReferend* structReferend) override;
-  LLVMTypeRef getWrapperStruct(StructReferend* structReferend) override;
+  LLVMTypeRef getInnerStruct(StructKind* structKind) override;
+  LLVMTypeRef getWrapperStruct(StructKind* structKind) override;
   LLVMTypeRef getStaticSizedArrayWrapperStruct(StaticSizedArrayT* ssaMT) override;
   LLVMTypeRef getRuntimeSizedArrayWrapperStruct(RuntimeSizedArrayT* rsaMT) override;
-  LLVMTypeRef getInterfaceRefStruct(InterfaceReferend* interfaceReferend) override;
-  LLVMTypeRef getInterfaceTableStruct(InterfaceReferend* interfaceReferend) override;
+  LLVMTypeRef getInterfaceRefStruct(InterfaceKind* interfaceKind) override;
+  LLVMTypeRef getInterfaceTableStruct(InterfaceKind* interfaceKind) override;
   LLVMTypeRef getStringWrapperStruct() override;
 
-  void defineStruct(StructReferend* structM, std::vector<LLVMTypeRef> membersLT) override;
-  void declareStruct(StructReferend* structM) override;
+  void defineStruct(StructKind* structM, std::vector<LLVMTypeRef> membersLT) override;
+  void declareStruct(StructKind* structM) override;
   void declareEdge(Edge* edge) override;
   void defineEdge(
       Edge* edge,
@@ -71,7 +71,7 @@ public:
 //      AreaAndFileAndLine checkerAFL,
 //      FunctionState* functionState,
 //      LLVMBuilderRef builder,
-//      Referend* referendM,
+//      Kind* kindM,
 //      LLVMValueRef controlBlockPtrLE) override;
 
   LLVMValueRef getStringBytesPtr(
@@ -87,14 +87,14 @@ public:
       AreaAndFileAndLine from,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       InterfaceFatPtrLE interfaceFatPtrLE) override;
 
   ControlBlockPtrLE getControlBlockPtrWithoutChecking(
       AreaAndFileAndLine from,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       InterfaceFatPtrLE interfaceFatPtrLE) override;
 
   ControlBlockPtrLE getControlBlockPtr(
@@ -123,7 +123,7 @@ public:
 
   LLVMValueRef getStructContentsPtr(
       LLVMBuilderRef builder,
-      Referend* referend,
+      Kind* kind,
       WrapperPtrLE wrapperPtrLE) override;
 
 
@@ -135,7 +135,7 @@ public:
 
   LLVMValueRef getObjIdFromControlBlockPtr(
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       ControlBlockPtrLE controlBlockPtr) override;
 
   LLVMValueRef getStrongRcPtrFromControlBlockPtr(
@@ -150,26 +150,26 @@ public:
 
 private:
   GlobalState* globalState = nullptr;
-  GetReferendStructsSource getReferendStructsSource;
+  GetKindStructsSource getKindStructsSource;
 };
 
 // This is a class that wraps three Structses into one, and routes calls to them based on the
-// referend's Mutability and Weakability.
+// kind's Mutability and Weakability.
 class WeakRefStructsRouter : public IWeakRefStructsSource {
 public:
   explicit WeakRefStructsRouter(GetWeakRefStructsSource getWeakRefStructsSource_)
     : getWeakRefStructsSource(getWeakRefStructsSource_) {}
 
-  LLVMTypeRef getStructWeakRefStruct(StructReferend* structReferend) override;
+  LLVMTypeRef getStructWeakRefStruct(StructKind* structKind) override;
   LLVMTypeRef getStaticSizedArrayWeakRefStruct(StaticSizedArrayT* ssaMT) override;
   LLVMTypeRef getRuntimeSizedArrayWeakRefStruct(RuntimeSizedArrayT* rsaMT) override;
-  LLVMTypeRef getInterfaceWeakRefStruct(InterfaceReferend* interfaceReferend) override;
+  LLVMTypeRef getInterfaceWeakRefStruct(InterfaceKind* interfaceKind) override;
   WeakFatPtrLE makeWeakFatPtr(Reference* referenceM_, LLVMValueRef ptrLE) override;
-  LLVMTypeRef getWeakRefHeaderStruct(Referend* referend) override;
-  LLVMTypeRef getWeakVoidRefStruct(Referend* referend) override;
+  LLVMTypeRef getWeakRefHeaderStruct(Kind* kind) override;
+  LLVMTypeRef getWeakVoidRefStruct(Kind* kind) override;
   WeakFatPtrLE downcastWeakFatPtr(
       LLVMBuilderRef builder,
-      StructReferend* targetStructReferend,
+      StructKind* targetStructKind,
       Reference* targetRefMT,
       LLVMValueRef sourceWeakFatPtrLE) override;
 

--- a/Midas/src/c-compiler/region/common/fatweaks/fatweaks.cpp
+++ b/Midas/src/c-compiler/region/common/fatweaks/fatweaks.cpp
@@ -104,7 +104,7 @@ WeakFatPtrLE FatWeaks::assembleVoidStructWeakRef(
           LLVMPointerType(LLVMInt8TypeInContext(globalState->context), 0),
           "objAsVoidPtr");
 
-  auto weakRefLE = LLVMGetUndef(weakRefStructsSource->getWeakVoidRefStruct(refM->referend));
+  auto weakRefLE = LLVMGetUndef(weakRefStructsSource->getWeakVoidRefStruct(refM->kind));
   weakRefLE = LLVMBuildInsertValue(builder, weakRefLE, headerLE, WEAK_REF_MEMBER_INDEX_FOR_HEADER, "");
   weakRefLE =
       LLVMBuildInsertValue(builder, weakRefLE, objVoidPtrLE, WEAK_REF_MEMBER_INDEX_FOR_OBJPTR, "");

--- a/Midas/src/c-compiler/region/common/hgm/hgm.h
+++ b/Midas/src/c-compiler/region/common/hgm/hgm.h
@@ -12,11 +12,11 @@ public:
   HybridGenerationalMemory(
       GlobalState* globalState_,
       ControlBlock* controlBlock_,
-      IReferendStructsSource* referendStructsSource_,
+      IKindStructsSource* kindStructsSource_,
       IWeakRefStructsSource* weakRefStructsSource_,
       bool elideChecksForKnownLive_,
       bool limitMode_,
-      StructReferend* anyMT);
+      StructKind* anyMT);
 
   void mainSetup(FunctionState* functionState, LLVMBuilderRef builder);
   void mainCleanup(FunctionState* functionState, LLVMBuilderRef builder);
@@ -33,9 +33,9 @@ public:
       FunctionState *functionState,
       LLVMBuilderRef builder,
       WeakFatPtrLE sourceRefLE,
-      StructReferend *sourceStructReferendM,
+      StructKind *sourceStructKindM,
       Reference *sourceStructTypeM,
-      InterfaceReferend *targetInterfaceReferendM,
+      InterfaceKind *targetInterfaceKindM,
       Reference *targetInterfaceTypeM);
 
   // Makes a non-weak interface ref into a weak interface ref
@@ -44,7 +44,7 @@ public:
       LLVMBuilderRef builder,
       Reference* sourceType,
       Reference* targetType,
-      InterfaceReferend* interfaceReferendM,
+      InterfaceKind* interfaceKindM,
       InterfaceFatPtrLE sourceInterfaceFatPtrLE);
 
   WeakFatPtrLE assembleStructWeakRef(
@@ -52,7 +52,7 @@ public:
       LLVMBuilderRef builder,
       Reference* structTypeM,
       Reference* targetTypeM,
-      StructReferend* structReferendM,
+      StructKind* structKindM,
       WrapperPtrLE objPtrLE);
 
   WeakFatPtrLE assembleStaticSizedArrayWeakRef(
@@ -117,7 +117,7 @@ public:
   LLVMValueRef fillWeakableControlBlock(
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       LLVMValueRef controlBlockLE);
 
   WeakFatPtrLE weakInterfaceRefToWeakStructRef(
@@ -148,7 +148,7 @@ private:
   LLVMValueRef getTargetGenFromWeakRef(
       LLVMBuilderRef builder,
       IWeakRefStructsSource* weakRefStructsSource,
-      Referend* referend,
+      Kind* kind,
       WeakFatPtrLE weakRefLE);
 
   Prototype* makeCleanupLoopFunction();
@@ -163,7 +163,7 @@ private:
   GlobalState* globalState = nullptr;
   ControlBlock* controlBlock = nullptr;
   FatWeaks fatWeaks;
-  IReferendStructsSource* referendStructsSource;
+  IKindStructsSource* kindStructsSource;
   IWeakRefStructsSource* weakRefStructsSource;
 
   LLVMBuilderRef setupBuilder = nullptr;
@@ -184,9 +184,9 @@ private:
   // This is so we have an object whose tethered bit we can modify but no other part of it.
   LLVMValueRef halfProtectedI8PtrPtrLE = nullptr;
 
-  StructReferend* anyMT = nullptr;
+  StructKind* anyMT = nullptr;
 
-  std::unordered_map<Referend*, LLVMValueRef, AddressHasher<Referend*>> globalNullPtrPtrByReferend;
+  std::unordered_map<Kind*, LLVMValueRef, AddressHasher<Kind*>> globalNullPtrPtrByKind;
 };
 
 #endif

--- a/Midas/src/c-compiler/region/common/lgtweaks/lgtweaks.cpp
+++ b/Midas/src/c-compiler/region/common/lgtweaks/lgtweaks.cpp
@@ -14,12 +14,12 @@ constexpr int WEAK_REF_HEADER_MEMBER_INDEX_FOR_LGTI = 1;
 LLVMValueRef LgtWeaks::getTargetGenFromWeakRef(
     LLVMBuilderRef builder,
     IWeakRefStructsSource* weakRefStructsSource,
-    Referend* referend,
+    Kind* kind,
     WeakFatPtrLE weakRefLE) {
   assert(globalState->opt->regionOverride == RegionOverride::RESILIENT_V3 ||
          globalState->opt->regionOverride == RegionOverride::RESILIENT_V4);
   auto headerLE = fatWeaks_.getHeaderFromWeakRef(builder, weakRefLE);
-  assert(LLVMTypeOf(headerLE) == weakRefStructsSource->getWeakRefHeaderStruct(referend));
+  assert(LLVMTypeOf(headerLE) == weakRefStructsSource->getWeakRefHeaderStruct(kind));
   return LLVMBuildExtractValue(builder, headerLE, WEAK_REF_HEADER_MEMBER_INDEX_FOR_TARGET_GEN, "actualGeni");
 }
 
@@ -53,11 +53,11 @@ static LLVMValueRef makeLgtiHeader(
     GlobalState* globalState,
     IWeakRefStructsSource* weakRefStructsSource,
     LLVMBuilderRef builder,
-    Referend* referend,
+    Kind* kind,
     LLVMValueRef lgtiLE,
     LLVMValueRef targetGenLE) {
 //  assert(globalState->opt->regionOverride == RegionOverride::RESILIENT_V1);
-  auto headerLE = LLVMGetUndef(weakRefStructsSource->getWeakRefHeaderStruct(referend));
+  auto headerLE = LLVMGetUndef(weakRefStructsSource->getWeakRefHeaderStruct(kind));
   headerLE = LLVMBuildInsertValue(builder, headerLE, lgtiLE, WEAK_REF_HEADER_MEMBER_INDEX_FOR_LGTI, "headerWithLgti");
   headerLE = LLVMBuildInsertValue(builder, headerLE, targetGenLE, WEAK_REF_HEADER_MEMBER_INDEX_FOR_TARGET_GEN, "header");
   return headerLE;
@@ -98,7 +98,7 @@ LLVMValueRef LgtWeaks::getActualGenFromLGT(
 static LLVMValueRef getLgtiFromControlBlockPtr(
     GlobalState* globalState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* structs,
+    IKindStructsSource* structs,
     Reference* refM,
     ControlBlockPtrLE controlBlockPtr) {
 //  assert(globalState->opt->regionOverride == RegionOverride::RESILIENT_V1);
@@ -112,7 +112,7 @@ static LLVMValueRef getLgtiFromControlBlockPtr(
         LLVMBuildStructGEP(
             builder,
             controlBlockPtr.refLE,
-            structs->getControlBlock(refM->referend)->getMemberIndex(ControlBlockMember::LGTI),
+            structs->getControlBlock(refM->kind)->getMemberIndex(ControlBlockMember::LGTI),
             "lgtiPtr");
     return LLVMBuildLoad(builder, lgtiPtrLE, "lgti");
   }
@@ -120,12 +120,12 @@ static LLVMValueRef getLgtiFromControlBlockPtr(
 
 LgtWeaks::LgtWeaks(
     GlobalState* globalState_,
-    IReferendStructsSource* referendStructsSource_,
+    IKindStructsSource* kindStructsSource_,
     IWeakRefStructsSource* weakRefStructsSource_,
     bool elideChecksForKnownLive_)
   : globalState(globalState_),
     fatWeaks_(globalState_, weakRefStructsSource_),
-    referendStructsSource(referendStructsSource_),
+    kindStructsSource(kindStructsSource_),
     weakRefStructsSource(weakRefStructsSource_),
     elideChecksForKnownLive(elideChecksForKnownLive_) {
 //  auto voidLT = LLVMVoidTypeInContext(globalState->context);
@@ -175,9 +175,9 @@ WeakFatPtrLE LgtWeaks::weakStructPtrToLgtiWeakInterfacePtr(
     FunctionState* functionState,
     LLVMBuilderRef builder,
     WeakFatPtrLE sourceRefLE,
-    StructReferend* sourceStructReferendM,
+    StructKind* sourceStructKindM,
     Reference* sourceStructTypeM,
-    InterfaceReferend* targetInterfaceReferendM,
+    InterfaceKind* targetInterfaceKindM,
     Reference* targetInterfaceTypeM) {
   switch (globalState->opt->regionOverride) {
     case RegionOverride::FAST:
@@ -194,21 +194,21 @@ WeakFatPtrLE LgtWeaks::weakStructPtrToLgtiWeakInterfacePtr(
 //  checkValidReference(
 //      FL(), globalState, functionState, builder, sourceStructTypeM, sourceRefLE);
   auto controlBlockPtr =
-      referendStructsSource->getConcreteControlBlockPtr(
+      kindStructsSource->getConcreteControlBlockPtr(
           FL(), functionState, builder, sourceStructTypeM,
-          referendStructsSource->makeWrapperPtr(
+          kindStructsSource->makeWrapperPtr(
               FL(), functionState, builder, sourceStructTypeM,
               fatWeaks_.getInnerRefFromWeakRef(
                   functionState, builder, sourceStructTypeM, sourceRefLE)));
 
   auto interfaceRefLT =
       weakRefStructsSource->getInterfaceWeakRefStruct(
-          targetInterfaceReferendM);
+          targetInterfaceKindM);
   auto headerLE = fatWeaks_.getHeaderFromWeakRef(builder, sourceRefLE);
 
   auto innerRefLE =
       makeInterfaceRefStruct(
-          globalState, functionState, builder, referendStructsSource, sourceStructReferendM, targetInterfaceReferendM, controlBlockPtr);
+          globalState, functionState, builder, kindStructsSource, sourceStructKindM, targetInterfaceKindM, controlBlockPtr);
 
   return fatWeaks_.assembleWeakFatPtr(
       functionState, builder, targetInterfaceTypeM, interfaceRefLT, headerLE, innerRefLE);
@@ -221,21 +221,21 @@ WeakFatPtrLE LgtWeaks::assembleInterfaceWeakRef(
     LLVMBuilderRef builder,
     Reference* sourceType,
     Reference* targetType,
-    InterfaceReferend* interfaceReferendM,
+    InterfaceKind* interfaceKindM,
     InterfaceFatPtrLE sourceInterfaceFatPtrLE) {
   assert(sourceType->ownership == Ownership::OWN || sourceType->ownership == Ownership::SHARE);
   // curious, if its a borrow, do we just return sourceRefLE?
 
   auto controlBlockPtrLE =
-      referendStructsSource->getControlBlockPtr(
-          FL(), functionState, builder, interfaceReferendM, sourceInterfaceFatPtrLE);
-  auto lgtiLE = getLgtiFromControlBlockPtr(globalState, builder, referendStructsSource, sourceType,
+      kindStructsSource->getControlBlockPtr(
+          FL(), functionState, builder, interfaceKindM, sourceInterfaceFatPtrLE);
+  auto lgtiLE = getLgtiFromControlBlockPtr(globalState, builder, kindStructsSource, sourceType,
       controlBlockPtrLE);
   auto currentGenLE = getActualGenFromLGT(functionState, builder, lgtiLE);
-  auto headerLE = makeLgtiHeader(globalState, weakRefStructsSource, builder, interfaceReferendM, lgtiLE, currentGenLE);
+  auto headerLE = makeLgtiHeader(globalState, weakRefStructsSource, builder, interfaceKindM, lgtiLE, currentGenLE);
 
   auto weakRefStructLT =
-      weakRefStructsSource->getInterfaceWeakRefStruct(interfaceReferendM);
+      weakRefStructsSource->getInterfaceWeakRefStruct(interfaceKindM);
 
   return fatWeaks_.assembleWeakFatPtr(
       functionState, builder, targetType, weakRefStructLT, headerLE, sourceInterfaceFatPtrLE.refLE);
@@ -246,20 +246,20 @@ WeakFatPtrLE LgtWeaks::assembleStructWeakRef(
     LLVMBuilderRef builder,
     Reference* structTypeM,
     Reference* targetTypeM,
-    StructReferend* structReferendM,
+    StructKind* structKindM,
     WrapperPtrLE objPtrLE) {
   assert(structTypeM->ownership == Ownership::OWN || structTypeM->ownership == Ownership::SHARE);
   // curious, if its a borrow, do we just return sourceRefLE?
 
   auto controlBlockPtrLE =
-      referendStructsSource->getConcreteControlBlockPtr(
+      kindStructsSource->getConcreteControlBlockPtr(
           FL(), functionState, builder, structTypeM, objPtrLE);
-  auto lgtiLE = getLgtiFromControlBlockPtr(globalState, builder, referendStructsSource, structTypeM, controlBlockPtrLE);
+  auto lgtiLE = getLgtiFromControlBlockPtr(globalState, builder, kindStructsSource, structTypeM, controlBlockPtrLE);
   buildFlare(FL(), globalState, functionState, builder, lgtiLE);
   auto currentGenLE = getActualGenFromLGT(functionState, builder, lgtiLE);
-  auto headerLE = makeLgtiHeader(globalState, weakRefStructsSource, builder, structReferendM, lgtiLE, currentGenLE);
+  auto headerLE = makeLgtiHeader(globalState, weakRefStructsSource, builder, structKindM, lgtiLE, currentGenLE);
   auto weakRefStructLT =
-      weakRefStructsSource->getStructWeakRefStruct(structReferendM);
+      weakRefStructsSource->getStructWeakRefStruct(structKindM);
   return fatWeaks_.assembleWeakFatPtr(
       functionState, builder, targetTypeM, weakRefStructLT, headerLE, objPtrLE.refLE);
 }
@@ -284,9 +284,9 @@ WeakFatPtrLE LgtWeaks::assembleRuntimeSizedArrayWeakRef(
     Reference* targetRSAWeakRefMT,
     WrapperPtrLE sourceRefLE) {
   auto controlBlockPtrLE =
-      referendStructsSource->getConcreteControlBlockPtr(
+      kindStructsSource->getConcreteControlBlockPtr(
           FL(), functionState, builder, sourceType, sourceRefLE);
-  auto lgtiLE = getLgtiFromControlBlockPtr(globalState, builder, referendStructsSource, sourceType, controlBlockPtrLE);
+  auto lgtiLE = getLgtiFromControlBlockPtr(globalState, builder, kindStructsSource, sourceType, controlBlockPtrLE);
   auto targetGenLE = getActualGenFromLGT(functionState, builder, lgtiLE);
   auto headerLE = makeLgtiHeader(globalState, weakRefStructsSource, builder, runtimeSizedArrayMT, lgtiLE, targetGenLE);
 
@@ -385,7 +385,7 @@ void LgtWeaks::innerNoteWeakableDestroyed(
     LLVMBuilderRef builder,
     Reference* concreteRefM,
     ControlBlockPtrLE controlBlockPtrLE) {
-  auto lgtiLE = getLgtiFromControlBlockPtr(globalState, builder, referendStructsSource, concreteRefM,
+  auto lgtiLE = getLgtiFromControlBlockPtr(globalState, builder, kindStructsSource, concreteRefM,
       controlBlockPtrLE);
   auto ptrToActualGenLE = getLGTEntryGenPtr(functionState, builder, lgtiLE);
   adjustCounter(globalState, builder, ptrToActualGenLE, 1);
@@ -432,7 +432,7 @@ LLVMValueRef LgtWeaks::getIsAliveFromWeakFatPtr(
     return LLVMConstInt(LLVMInt1TypeInContext(globalState->context), 1, false);
   } else {
     // Get target generation from the ref
-    auto targetGenLE = getTargetGenFromWeakRef(builder, weakRefStructsSource, weakRefM->referend, weakFatPtrLE);
+    auto targetGenLE = getTargetGenFromWeakRef(builder, weakRefStructsSource, weakRefM->kind, weakFatPtrLE);
 
     // Get actual generation from the table
     auto lgtiLE = getLgtiFromWeakRef(builder, weakFatPtrLE);
@@ -479,15 +479,15 @@ Ref LgtWeaks::getIsAliveFromWeakRef(
 LLVMValueRef LgtWeaks::fillWeakableControlBlock(
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* structs,
-    Referend* referendM,
+    IKindStructsSource* structs,
+    Kind* kindM,
     LLVMValueRef controlBlockLE) {
   auto geniLE = getNewLgti(functionState, builder);
   return LLVMBuildInsertValue(
       builder,
       controlBlockLE,
       geniLE,
-      structs->getControlBlock(referendM)->getMemberIndex(ControlBlockMember::LGTI),
+      structs->getControlBlock(kindM)->getMemberIndex(ControlBlockMember::LGTI),
       "controlBlockWithLgti");
 }
 
@@ -500,7 +500,7 @@ WeakFatPtrLE LgtWeaks::weakInterfaceRefToWeakStructRef(
 
   // The object might not exist, so skip the check.
   auto interfaceFatPtrLE =
-      referendStructsSource->makeInterfaceFatPtrWithoutChecking(
+      kindStructsSource->makeInterfaceFatPtrWithoutChecking(
           FL(), functionState, builder,
           weakInterfaceRefMT, // It's still conceptually weak even though its not in a weak pointer.
           fatWeaks_.getInnerRefFromWeakRef(
@@ -509,8 +509,8 @@ WeakFatPtrLE LgtWeaks::weakInterfaceRefToWeakStructRef(
               weakInterfaceRefMT,
               weakInterfaceFatPtrLE));
   auto controlBlockPtrLE =
-      referendStructsSource->getControlBlockPtrWithoutChecking(
-          FL(), functionState, builder, weakInterfaceRefMT->referend, interfaceFatPtrLE);
+      kindStructsSource->getControlBlockPtrWithoutChecking(
+          FL(), functionState, builder, weakInterfaceRefMT->kind, interfaceFatPtrLE);
 
   // Now, reassemble a weak void* ref to the struct.
   auto weakVoidStructRefLE =
@@ -545,13 +545,13 @@ void LgtWeaks::buildCheckWeakRef(
   buildCheckLgti(builder, lgtiLE);
   // We check that the generation is <= to what's in the actual object.
   auto actualGen = getActualGenFromLGT(functionState, builder, lgtiLE);
-  auto targetGen = getTargetGenFromWeakRef(builder, weakRefStructsSource, weakRefM->referend, weakFatPtrLE);
+  auto targetGen = getTargetGenFromWeakRef(builder, weakRefStructsSource, weakRefM->kind, weakFatPtrLE);
   buildCheckGen(globalState, functionState, builder, targetGen, actualGen);
 
   // This will also run for objects which have since died, which is fine.
-  if (auto interfaceReferendM = dynamic_cast<InterfaceReferend *>(weakRefM->referend)) {
+  if (auto interfaceKindM = dynamic_cast<InterfaceKind *>(weakRefM->kind)) {
     auto interfaceFatPtrLE =
-        referendStructsSource->makeInterfaceFatPtrWithoutChecking(
+        kindStructsSource->makeInterfaceFatPtrWithoutChecking(
             checkerAFL, functionState, builder, weakRefM, innerLE);
     auto itablePtrLE = getTablePtrFromInterfaceRef(builder, interfaceFatPtrLE);
     buildAssertCensusContains(checkerAFL, globalState, functionState, builder, itablePtrLE);
@@ -565,30 +565,30 @@ Ref LgtWeaks::assembleWeakRef(
     Reference* targetType,
     Ref sourceRef) {
   // Now we need to package it up into a weak ref.
-  if (auto structReferend = dynamic_cast<StructReferend*>(sourceType->referend)) {
+  if (auto structKind = dynamic_cast<StructKind*>(sourceType->kind)) {
     auto sourceRefLE = globalState->getRegion(sourceType)->checkValidReference(FL(), functionState, builder, sourceType, sourceRef);
-    auto sourceWrapperPtrLE = referendStructsSource->makeWrapperPtr(FL(), functionState, builder, sourceType, sourceRefLE);
+    auto sourceWrapperPtrLE = kindStructsSource->makeWrapperPtr(FL(), functionState, builder, sourceType, sourceRefLE);
     auto resultLE =
         assembleStructWeakRef(
-            functionState, builder, sourceType, targetType, structReferend, sourceWrapperPtrLE);
+            functionState, builder, sourceType, targetType, structKind, sourceWrapperPtrLE);
     return wrap(globalState->getRegion(targetType), targetType, resultLE);
-  } else if (auto interfaceReferendM = dynamic_cast<InterfaceReferend*>(sourceType->referend)) {
+  } else if (auto interfaceKindM = dynamic_cast<InterfaceKind*>(sourceType->kind)) {
     auto sourceRefLE = globalState->getRegion(sourceType)->checkValidReference(FL(), functionState, builder, sourceType, sourceRef);
-    auto sourceInterfaceFatPtrLE = referendStructsSource->makeInterfaceFatPtr(FL(), functionState, builder, sourceType, sourceRefLE);
+    auto sourceInterfaceFatPtrLE = kindStructsSource->makeInterfaceFatPtr(FL(), functionState, builder, sourceType, sourceRefLE);
     auto resultLE =
         assembleInterfaceWeakRef(
-            functionState, builder, sourceType, targetType, interfaceReferendM, sourceInterfaceFatPtrLE);
+            functionState, builder, sourceType, targetType, interfaceKindM, sourceInterfaceFatPtrLE);
     return wrap(globalState->getRegion(targetType), targetType, resultLE);
-  } else if (auto staticSizedArray = dynamic_cast<StaticSizedArrayT*>(sourceType->referend)) {
+  } else if (auto staticSizedArray = dynamic_cast<StaticSizedArrayT*>(sourceType->kind)) {
     auto sourceRefLE = globalState->getRegion(sourceType)->checkValidReference(FL(), functionState, builder, sourceType, sourceRef);
-    auto sourceWrapperPtrLE = referendStructsSource->makeWrapperPtr(FL(), functionState, builder, sourceType, sourceRefLE);
+    auto sourceWrapperPtrLE = kindStructsSource->makeWrapperPtr(FL(), functionState, builder, sourceType, sourceRefLE);
     auto resultLE =
         assembleStaticSizedArrayWeakRef(
             functionState, builder, sourceType, staticSizedArray, targetType, sourceWrapperPtrLE);
     return wrap(globalState->getRegion(targetType), targetType, resultLE);
-  } else if (auto runtimeSizedArray = dynamic_cast<RuntimeSizedArrayT*>(sourceType->referend)) {
+  } else if (auto runtimeSizedArray = dynamic_cast<RuntimeSizedArrayT*>(sourceType->kind)) {
     auto sourceRefLE = globalState->getRegion(sourceType)->checkValidReference(FL(), functionState, builder, sourceType, sourceRef);
-    auto sourceWrapperPtrLE = referendStructsSource->makeWrapperPtr(FL(), functionState, builder, sourceType, sourceRefLE);
+    auto sourceWrapperPtrLE = kindStructsSource->makeWrapperPtr(FL(), functionState, builder, sourceType, sourceRefLE);
     auto resultLE =
         assembleRuntimeSizedArrayWeakRef(
             functionState, builder, sourceType, runtimeSizedArray, targetType, sourceWrapperPtrLE);

--- a/Midas/src/c-compiler/region/common/lgtweaks/lgtweaks.h
+++ b/Midas/src/c-compiler/region/common/lgtweaks/lgtweaks.h
@@ -11,7 +11,7 @@ class LgtWeaks {
 public:
   LgtWeaks(
       GlobalState* globalState,
-      IReferendStructsSource* referendStructsSource,
+      IKindStructsSource* kindStructsSource,
       IWeakRefStructsSource* weakRefStructsSource,
       bool elideChecksForKnownLive);
 
@@ -26,9 +26,9 @@ public:
       FunctionState *functionState,
       LLVMBuilderRef builder,
       WeakFatPtrLE sourceRefLE,
-      StructReferend *sourceStructReferendM,
+      StructKind *sourceStructKindM,
       Reference *sourceStructTypeM,
-      InterfaceReferend *targetInterfaceReferendM,
+      InterfaceKind *targetInterfaceKindM,
       Reference *targetInterfaceTypeM);
 
   // Makes a non-weak interface ref into a weak interface ref
@@ -37,7 +37,7 @@ public:
       LLVMBuilderRef builder,
       Reference* sourceType,
       Reference* targetType,
-      InterfaceReferend* interfaceReferendM,
+      InterfaceKind* interfaceKindM,
       InterfaceFatPtrLE sourceInterfaceFatPtrLE);
 
   WeakFatPtrLE assembleStructWeakRef(
@@ -45,7 +45,7 @@ public:
       LLVMBuilderRef builder,
       Reference* structTypeM,
       Reference* targetTypeM,
-      StructReferend* structReferendM,
+      StructKind* structKindM,
       WrapperPtrLE objPtrLE);
 
   WeakFatPtrLE assembleStaticSizedArrayWeakRef(
@@ -110,8 +110,8 @@ public:
   LLVMValueRef fillWeakableControlBlock(
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      IReferendStructsSource* structs,
-      Referend* referendM,
+      IKindStructsSource* structs,
+      Kind* kindM,
       LLVMValueRef controlBlockLE);
 
   WeakFatPtrLE weakInterfaceRefToWeakStructRef(
@@ -137,7 +137,7 @@ private:
   LLVMValueRef getTargetGenFromWeakRef(
       LLVMBuilderRef builder,
       IWeakRefStructsSource* weakRefStructsSource,
-      Referend* referend,
+      Kind* kind,
       WeakFatPtrLE weakRefLE);
 
   LLVMValueRef getLgtiFromWeakRef(
@@ -168,7 +168,7 @@ private:
 
   GlobalState* globalState = nullptr;
   FatWeaks fatWeaks_;
-  IReferendStructsSource* referendStructsSource;
+  IKindStructsSource* kindStructsSource;
   IWeakRefStructsSource* weakRefStructsSource;
   bool elideChecksForKnownLive;
 

--- a/Midas/src/c-compiler/region/common/primitives.h
+++ b/Midas/src/c-compiler/region/common/primitives.h
@@ -13,22 +13,22 @@ public:
 
 
   bool isPrimitive(Reference* referenceM) {
-    return dynamic_cast<Int *>(referenceM->referend) != nullptr ||
-        dynamic_cast<Bool *>(referenceM->referend) != nullptr ||
-        dynamic_cast<Float *>(referenceM->referend) != nullptr;
+    return dynamic_cast<Int *>(referenceM->kind) != nullptr ||
+        dynamic_cast<Bool *>(referenceM->kind) != nullptr ||
+        dynamic_cast<Float *>(referenceM->kind) != nullptr;
   }
 
   LLVMTypeRef translatePrimitive(GlobalState* globalState, Reference* referenceM) {
-    if (dynamic_cast<Int*>(referenceM->referend) != nullptr) {
+    if (dynamic_cast<Int*>(referenceM->kind) != nullptr) {
       assert(referenceM->ownership == Ownership::SHARE);
       return LLVMInt64TypeInContext(globalState->context);
-    } else if (dynamic_cast<Bool*>(referenceM->referend) != nullptr) {
+    } else if (dynamic_cast<Bool*>(referenceM->kind) != nullptr) {
       assert(referenceM->ownership == Ownership::SHARE);
       return LLVMInt1TypeInContext(globalState->context);
-    } else if (dynamic_cast<Float*>(referenceM->referend) != nullptr) {
+    } else if (dynamic_cast<Float*>(referenceM->kind) != nullptr) {
       assert(referenceM->ownership == Ownership::SHARE);
       return LLVMDoubleTypeInContext(globalState->context);
-    } else if (dynamic_cast<Never*>(referenceM->referend) != nullptr) {
+    } else if (dynamic_cast<Never*>(referenceM->kind) != nullptr) {
       return LLVMArrayType(LLVMIntTypeInContext(globalState->context, NEVER_INT_BITS), 0);
     } else {
       assert(false);

--- a/Midas/src/c-compiler/region/common/wrcweaks/wrcweaks.cpp
+++ b/Midas/src/c-compiler/region/common/wrcweaks/wrcweaks.cpp
@@ -16,9 +16,9 @@ constexpr uint32_t WRC_INITIAL_VALUE = WRC_ALIVE_BIT;
 static LLVMValueRef makeWrciHeader(
     LLVMBuilderRef builder,
     IWeakRefStructsSource* weakRefStructs,
-    Referend* referend,
+    Kind* kind,
     LLVMValueRef wrciLE) {
-  auto headerLE = LLVMGetUndef(weakRefStructs->getWeakRefHeaderStruct(referend));
+  auto headerLE = LLVMGetUndef(weakRefStructs->getWeakRefHeaderStruct(kind));
   return LLVMBuildInsertValue(builder, headerLE, wrciLE, WEAK_REF_HEADER_MEMBER_INDEX_FOR_WRCI, "header");
 }
 
@@ -79,7 +79,7 @@ void WrcWeaks::maybeReleaseWrc(
 static LLVMValueRef getWrciFromControlBlockPtr(
     GlobalState* globalState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* structs,
+    IKindStructsSource* structs,
     Reference* refM,
     ControlBlockPtrLE controlBlockPtr) {
 //  assert(globalState->opt->regionOverride != RegionOverride::RESILIENT_V1);
@@ -93,7 +93,7 @@ static LLVMValueRef getWrciFromControlBlockPtr(
         LLVMBuildStructGEP(
             builder,
             controlBlockPtr.refLE,
-            structs->getControlBlock(refM->referend)->getMemberIndex(ControlBlockMember::WRCI),
+            structs->getControlBlock(refM->kind)->getMemberIndex(ControlBlockMember::WRCI),
             "wrciPtr");
     return LLVMBuildLoad(builder, wrciPtrLE, "wrci");
   }
@@ -109,10 +109,10 @@ LLVMValueRef WrcWeaks::getWrcPtr(
   return ptrToWrcLE;
 }
 
-WrcWeaks::WrcWeaks(GlobalState *globalState_, IReferendStructsSource* referendStructsSource_, IWeakRefStructsSource* weakRefStructsSource_)
+WrcWeaks::WrcWeaks(GlobalState *globalState_, IKindStructsSource* kindStructsSource_, IWeakRefStructsSource* weakRefStructsSource_)
   : globalState(globalState_),
     fatWeaks_(globalState_, weakRefStructsSource_),
-    referendStructsSource(referendStructsSource_),
+    kindStructsSource(kindStructsSource_),
     weakRefStructsSource(weakRefStructsSource_) {
 //  auto voidLT = LLVMVoidTypeInContext(globalState->context);
   auto int1LT = LLVMInt1TypeInContext(globalState->context);
@@ -171,9 +171,9 @@ WeakFatPtrLE WrcWeaks::weakStructPtrToWrciWeakInterfacePtr(
     FunctionState* functionState,
     LLVMBuilderRef builder,
     WeakFatPtrLE sourceWeakStructFatPtrLE,
-    StructReferend* sourceStructReferendM,
+    StructKind* sourceStructKindM,
     Reference* sourceStructTypeM,
-    InterfaceReferend* targetInterfaceReferendM,
+    InterfaceKind* targetInterfaceKindM,
     Reference* targetInterfaceTypeM) {
 
   switch (globalState->opt->regionOverride) {
@@ -193,25 +193,25 @@ WeakFatPtrLE WrcWeaks::weakStructPtrToWrciWeakInterfacePtr(
 //  checkValidReference(
 //      FL(), globalState, functionState, builder, sourceStructTypeM, sourceRefLE);
   auto controlBlockPtr =
-      referendStructsSource->getConcreteControlBlockPtr(
+      kindStructsSource->getConcreteControlBlockPtr(
           FL(),
           functionState,
           builder,
           sourceStructTypeM,
-          referendStructsSource->makeWrapperPtr(
+          kindStructsSource->makeWrapperPtr(
               FL(), functionState, builder, sourceStructTypeM,
               fatWeaks_.getInnerRefFromWeakRef(
                   functionState, builder, sourceStructTypeM, sourceWeakStructFatPtrLE)));
 
   auto interfaceRefLT =
-      weakRefStructsSource->getInterfaceWeakRefStruct(targetInterfaceReferendM);
+      weakRefStructsSource->getInterfaceWeakRefStruct(targetInterfaceKindM);
   auto wrciLE = getWrciFromWeakRef(builder, sourceWeakStructFatPtrLE);
-  auto headerLE = makeWrciHeader(builder, weakRefStructsSource, targetInterfaceReferendM, wrciLE);
+  auto headerLE = makeWrciHeader(builder, weakRefStructsSource, targetInterfaceKindM, wrciLE);
 
   auto innerRefLE =
       makeInterfaceRefStruct(
-          globalState, functionState, builder, referendStructsSource, sourceStructReferendM,
-          targetInterfaceReferendM,
+          globalState, functionState, builder, kindStructsSource, sourceStructKindM,
+          targetInterfaceKindM,
           controlBlockPtr);
 
   return fatWeaks_.assembleWeakFatPtr(
@@ -224,7 +224,7 @@ WeakFatPtrLE WrcWeaks::assembleInterfaceWeakRef(
     LLVMBuilderRef builder,
     Reference* sourceType,
     Reference* targetType,
-    InterfaceReferend* interfaceReferendM,
+    InterfaceKind* interfaceKindM,
     InterfaceFatPtrLE sourceInterfaceFatPtrLE) {
 //  if (globalState->opt->regionOverride == RegionOverride::RESILIENT_V0) {
 //    if (sourceType->ownership == Ownership::BORROW) {
@@ -234,15 +234,15 @@ WeakFatPtrLE WrcWeaks::assembleInterfaceWeakRef(
 //  }
 
   auto controlBlockPtrLE =
-      referendStructsSource->getControlBlockPtr(
-          FL(), functionState, builder, interfaceReferendM, sourceInterfaceFatPtrLE);
-  auto wrciLE = getWrciFromControlBlockPtr(globalState, builder, referendStructsSource, sourceType,
+      kindStructsSource->getControlBlockPtr(
+          FL(), functionState, builder, interfaceKindM, sourceInterfaceFatPtrLE);
+  auto wrciLE = getWrciFromControlBlockPtr(globalState, builder, kindStructsSource, sourceType,
       controlBlockPtrLE);
-  auto headerLE = LLVMGetUndef(weakRefStructsSource->getWeakRefHeaderStruct(interfaceReferendM));
+  auto headerLE = LLVMGetUndef(weakRefStructsSource->getWeakRefHeaderStruct(interfaceKindM));
   headerLE = LLVMBuildInsertValue(builder, headerLE, wrciLE, WEAK_REF_HEADER_MEMBER_INDEX_FOR_WRCI, "header");
 
   auto weakRefStructLT =
-      weakRefStructsSource->getInterfaceWeakRefStruct(interfaceReferendM);
+      weakRefStructsSource->getInterfaceWeakRefStruct(interfaceKindM);
 
   return fatWeaks_.assembleWeakFatPtr(
       functionState, builder, targetType, weakRefStructLT, headerLE, sourceInterfaceFatPtrLE.refLE);
@@ -253,7 +253,7 @@ WeakFatPtrLE WrcWeaks::assembleStructWeakRef(
     LLVMBuilderRef builder,
     Reference* structTypeM,
     Reference* targetTypeM,
-    StructReferend* structReferendM,
+    StructKind* structKindM,
     WrapperPtrLE objPtrLE) {
 //  if (globalState->opt->regionOverride == RegionOverride::RESILIENT_V0) {
 //    assert(structTypeM->ownership == Ownership::OWN || structTypeM->ownership == Ownership::SHARE);
@@ -264,12 +264,12 @@ WeakFatPtrLE WrcWeaks::assembleStructWeakRef(
     assert(structTypeM->ownership == Ownership::OWN || structTypeM->ownership == Ownership::SHARE || structTypeM->ownership == Ownership::BORROW);
   } else assert(false);
 
-  auto controlBlockPtrLE = referendStructsSource->getConcreteControlBlockPtr(FL(), functionState, builder, structTypeM, objPtrLE);
-  auto wrciLE = getWrciFromControlBlockPtr(globalState, builder, referendStructsSource, structTypeM, controlBlockPtrLE);
-  auto headerLE = makeWrciHeader(builder, weakRefStructsSource, structReferendM, wrciLE);
+  auto controlBlockPtrLE = kindStructsSource->getConcreteControlBlockPtr(FL(), functionState, builder, structTypeM, objPtrLE);
+  auto wrciLE = getWrciFromControlBlockPtr(globalState, builder, kindStructsSource, structTypeM, controlBlockPtrLE);
+  auto headerLE = makeWrciHeader(builder, weakRefStructsSource, structKindM, wrciLE);
 
   auto weakRefStructLT =
-      weakRefStructsSource->getStructWeakRefStruct(structReferendM);
+      weakRefStructsSource->getStructWeakRefStruct(structKindM);
 
   return fatWeaks_.assembleWeakFatPtr(
       functionState, builder, targetTypeM, weakRefStructLT, headerLE, objPtrLE.refLE);
@@ -282,8 +282,8 @@ WeakFatPtrLE WrcWeaks::assembleStaticSizedArrayWeakRef(
     StaticSizedArrayT* staticSizedArrayMT,
     Reference* targetSSAWeakRefMT,
     WrapperPtrLE objPtrLE) {
-  auto controlBlockPtrLE = referendStructsSource->getConcreteControlBlockPtr(FL(), functionState, builder, sourceSSAMT, objPtrLE);
-  auto wrciLE = getWrciFromControlBlockPtr(globalState, builder, referendStructsSource, sourceSSAMT, controlBlockPtrLE);
+  auto controlBlockPtrLE = kindStructsSource->getConcreteControlBlockPtr(FL(), functionState, builder, sourceSSAMT, objPtrLE);
+  auto wrciLE = getWrciFromControlBlockPtr(globalState, builder, kindStructsSource, sourceSSAMT, controlBlockPtrLE);
   auto headerLE = makeWrciHeader(builder, weakRefStructsSource, staticSizedArrayMT, wrciLE);
 
   auto weakRefStructLT =
@@ -300,8 +300,8 @@ WeakFatPtrLE WrcWeaks::assembleRuntimeSizedArrayWeakRef(
     RuntimeSizedArrayT* runtimeSizedArrayMT,
     Reference* targetRSAWeakRefMT,
     WrapperPtrLE sourceRefLE) {
-  auto controlBlockPtrLE = referendStructsSource->getConcreteControlBlockPtr(FL(), functionState, builder, sourceType, sourceRefLE);
-  auto wrciLE = getWrciFromControlBlockPtr(globalState, builder, referendStructsSource, sourceType, controlBlockPtrLE);
+  auto controlBlockPtrLE = kindStructsSource->getConcreteControlBlockPtr(FL(), functionState, builder, sourceType, sourceRefLE);
+  auto wrciLE = getWrciFromControlBlockPtr(globalState, builder, kindStructsSource, sourceType, controlBlockPtrLE);
   auto headerLE = makeWrciHeader(builder, weakRefStructsSource, runtimeSizedArrayMT, wrciLE);
 
   auto weakRefStructLT =
@@ -390,7 +390,7 @@ void WrcWeaks::innerNoteWeakableDestroyed(
     LLVMBuilderRef builder,
     Reference* concreteRefM,
     ControlBlockPtrLE controlBlockPtrLE) {
-  auto wrciLE = getWrciFromControlBlockPtr(globalState, builder, referendStructsSource, concreteRefM,
+  auto wrciLE = getWrciFromControlBlockPtr(globalState, builder, kindStructsSource, concreteRefM,
       controlBlockPtrLE);
 
   //  LLVMBuildCall(builder, globalState->noteWeakableDestroyed, &wrciLE, 1, "");
@@ -518,15 +518,15 @@ Ref WrcWeaks::getIsAliveFromWeakRef(
 LLVMValueRef WrcWeaks::fillWeakableControlBlock(
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* structs,
-    Referend* referendM,
+    IKindStructsSource* structs,
+    Kind* kindM,
     LLVMValueRef controlBlockLE) {
   auto wrciLE = getNewWrci(functionState, builder);
   return LLVMBuildInsertValue(
       builder,
       controlBlockLE,
       wrciLE,
-      structs->getControlBlock(referendM)->getMemberIndex(ControlBlockMember::WRCI),
+      structs->getControlBlock(kindM)->getMemberIndex(ControlBlockMember::WRCI),
       "weakableControlBlockWithWrci");
 }
 
@@ -539,7 +539,7 @@ WeakFatPtrLE WrcWeaks::weakInterfaceRefToWeakStructRef(
   auto wrciLE = getWrciFromWeakRef(builder, weakInterfaceFatPtrLE);
   // The object might not exist, so skip the check.
   auto interfaceRefLE =
-      referendStructsSource->makeInterfaceFatPtrWithoutChecking(FL(), functionState, builder,
+      kindStructsSource->makeInterfaceFatPtrWithoutChecking(FL(), functionState, builder,
           weakInterfaceRefMT, // It's still conceptually weak even though its not in a weak pointer.
           fatWeaks_.getInnerRefFromWeakRef(
               functionState,
@@ -547,10 +547,10 @@ WeakFatPtrLE WrcWeaks::weakInterfaceRefToWeakStructRef(
               weakInterfaceRefMT,
               weakInterfaceFatPtrLE));
   auto controlBlockPtrLE =
-      referendStructsSource->getControlBlockPtrWithoutChecking(
-          FL(), functionState, builder, weakInterfaceRefMT->referend, interfaceRefLE);
+      kindStructsSource->getControlBlockPtrWithoutChecking(
+          FL(), functionState, builder, weakInterfaceRefMT->kind, interfaceRefLE);
 
-  auto headerLE = makeWrciHeader(builder, weakRefStructsSource, weakInterfaceRefMT->referend, wrciLE);
+  auto headerLE = makeWrciHeader(builder, weakRefStructsSource, weakInterfaceRefMT->kind, wrciLE);
 
   // Now, reassemble a weak void* ref to the struct.
   auto weakVoidStructRefLE =
@@ -592,8 +592,8 @@ void WrcWeaks::buildCheckWeakRef(
   buildCheckWrc(builder, wrciLE);
 
   // This will also run for objects which have since died, which is fine.
-  if (auto interfaceReferendM = dynamic_cast<InterfaceReferend*>(weakRefM->referend)) {
-    auto interfaceFatPtrLE = referendStructsSource->makeInterfaceFatPtrWithoutChecking(checkerAFL, functionState, builder, weakRefM, innerLE);
+  if (auto interfaceKindM = dynamic_cast<InterfaceKind*>(weakRefM->kind)) {
+    auto interfaceFatPtrLE = kindStructsSource->makeInterfaceFatPtrWithoutChecking(checkerAFL, functionState, builder, weakRefM, innerLE);
     auto itablePtrLE = getTablePtrFromInterfaceRef(builder, interfaceFatPtrLE);
     buildAssertCensusContains(checkerAFL, globalState, functionState, builder, itablePtrLE);
   }
@@ -606,30 +606,30 @@ Ref WrcWeaks::assembleWeakRef(
     Reference* targetType,
     Ref sourceRef) {
   // Now we need to package it up into a weak ref.
-  if (auto structReferend = dynamic_cast<StructReferend*>(sourceType->referend)) {
+  if (auto structKind = dynamic_cast<StructKind*>(sourceType->kind)) {
     auto sourceRefLE = globalState->getRegion(sourceType)->checkValidReference(FL(), functionState, builder, sourceType, sourceRef);
-    auto sourceWrapperPtrLE = referendStructsSource->makeWrapperPtr(FL(), functionState, builder, sourceType, sourceRefLE);
+    auto sourceWrapperPtrLE = kindStructsSource->makeWrapperPtr(FL(), functionState, builder, sourceType, sourceRefLE);
     auto resultLE =
         assembleStructWeakRef(
-            functionState, builder, sourceType, targetType, structReferend, sourceWrapperPtrLE);
+            functionState, builder, sourceType, targetType, structKind, sourceWrapperPtrLE);
     return wrap(globalState->getRegion(targetType), targetType, resultLE);
-  } else if (auto interfaceReferendM = dynamic_cast<InterfaceReferend*>(sourceType->referend)) {
+  } else if (auto interfaceKindM = dynamic_cast<InterfaceKind*>(sourceType->kind)) {
     auto sourceRefLE = globalState->getRegion(sourceType)->checkValidReference(FL(), functionState, builder, sourceType, sourceRef);
-    auto sourceInterfaceFatPtrLE = referendStructsSource->makeInterfaceFatPtr(FL(), functionState, builder, sourceType, sourceRefLE);
+    auto sourceInterfaceFatPtrLE = kindStructsSource->makeInterfaceFatPtr(FL(), functionState, builder, sourceType, sourceRefLE);
     auto resultLE =
         assembleInterfaceWeakRef(
-            functionState, builder, sourceType, targetType, interfaceReferendM, sourceInterfaceFatPtrLE);
+            functionState, builder, sourceType, targetType, interfaceKindM, sourceInterfaceFatPtrLE);
     return wrap(globalState->getRegion(targetType), targetType, resultLE);
-  } else if (auto staticSizedArray = dynamic_cast<StaticSizedArrayT*>(sourceType->referend)) {
+  } else if (auto staticSizedArray = dynamic_cast<StaticSizedArrayT*>(sourceType->kind)) {
     auto sourceRefLE = globalState->getRegion(sourceType)->checkValidReference(FL(), functionState, builder, sourceType, sourceRef);
-    auto sourceWrapperPtrLE = referendStructsSource->makeWrapperPtr(FL(), functionState, builder, sourceType, sourceRefLE);
+    auto sourceWrapperPtrLE = kindStructsSource->makeWrapperPtr(FL(), functionState, builder, sourceType, sourceRefLE);
     auto resultLE =
         assembleStaticSizedArrayWeakRef(
             functionState, builder, sourceType, staticSizedArray, targetType, sourceWrapperPtrLE);
     return wrap(globalState->getRegion(targetType), targetType, resultLE);
-  } else if (auto runtimeSizedArray = dynamic_cast<RuntimeSizedArrayT*>(sourceType->referend)) {
+  } else if (auto runtimeSizedArray = dynamic_cast<RuntimeSizedArrayT*>(sourceType->kind)) {
     auto sourceRefLE = globalState->getRegion(sourceType)->checkValidReference(FL(), functionState, builder, sourceType, sourceRef);
-    auto sourceWrapperPtrLE = referendStructsSource->makeWrapperPtr(FL(), functionState, builder, sourceType, sourceRefLE);
+    auto sourceWrapperPtrLE = kindStructsSource->makeWrapperPtr(FL(), functionState, builder, sourceType, sourceRefLE);
     auto resultLE =
         assembleRuntimeSizedArrayWeakRef(
             functionState, builder, sourceType, runtimeSizedArray, targetType, sourceWrapperPtrLE);

--- a/Midas/src/c-compiler/region/common/wrcweaks/wrcweaks.h
+++ b/Midas/src/c-compiler/region/common/wrcweaks/wrcweaks.h
@@ -8,16 +8,16 @@
 
 class WrcWeaks {
 public:
-  WrcWeaks(GlobalState* globalState, IReferendStructsSource* referendStructsSource, IWeakRefStructsSource* weakRefStructsSource);
+  WrcWeaks(GlobalState* globalState, IKindStructsSource* kindStructsSource, IWeakRefStructsSource* weakRefStructsSource);
 
   WeakFatPtrLE weakStructPtrToWrciWeakInterfacePtr(
       GlobalState *globalState,
       FunctionState *functionState,
       LLVMBuilderRef builder,
       WeakFatPtrLE sourceRefLE,
-      StructReferend *sourceStructReferendM,
+      StructKind *sourceStructKindM,
       Reference *sourceStructTypeM,
-      InterfaceReferend *targetInterfaceReferendM,
+      InterfaceKind *targetInterfaceKindM,
       Reference *targetInterfaceTypeM);
 
   Ref assembleWeakRef(
@@ -33,7 +33,7 @@ public:
       LLVMBuilderRef builder,
       Reference* sourceType,
       Reference* targetType,
-      InterfaceReferend* interfaceReferendM,
+      InterfaceKind* interfaceKindM,
       InterfaceFatPtrLE sourceInterfaceFatPtrLE);
 
   WeakFatPtrLE assembleStructWeakRef(
@@ -41,7 +41,7 @@ public:
       LLVMBuilderRef builder,
       Reference* structTypeM,
       Reference* targetTypeM,
-      StructReferend* structReferendM,
+      StructKind* structKindM,
       WrapperPtrLE objPtrLE);
 
   WeakFatPtrLE assembleStaticSizedArrayWeakRef(
@@ -83,8 +83,8 @@ public:
   LLVMValueRef fillWeakableControlBlock(
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      IReferendStructsSource* structs,
-      Referend* referendM,
+      IKindStructsSource* structs,
+      Kind* kindM,
       LLVMValueRef controlBlockLE);
 
   WeakFatPtrLE weakInterfaceRefToWeakStructRef(
@@ -158,7 +158,7 @@ private:
 
   GlobalState* globalState = nullptr;
   FatWeaks fatWeaks_;
-  IReferendStructsSource* referendStructsSource;
+  IKindStructsSource* kindStructsSource;
   IWeakRefStructsSource* weakRefStructsSource;
 
   LLVMValueRef wrcTablePtrLE = nullptr;

--- a/Midas/src/c-compiler/region/iregion.h
+++ b/Midas/src/c-compiler/region/iregion.h
@@ -165,7 +165,8 @@ public:
 
   virtual std::string getExportName(
       Package* package,
-      Reference* reference) = 0;
+      Reference* reference,
+      bool includeProjectName) = 0;
 
 //  virtual std::string getMemberArbitraryRefNameCSeeMMEDT(
 //      Reference* refMT) = 0;

--- a/Midas/src/c-compiler/region/iregion.h
+++ b/Midas/src/c-compiler/region/iregion.h
@@ -89,9 +89,9 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       WeakFatPtrLE sourceRefLE,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Reference* sourceStructTypeM,
-      InterfaceReferend* targetInterfaceReferendM,
+      InterfaceKind* targetInterfaceKindM,
       Reference* targetInterfaceTypeM) = 0;
 
   virtual Ref upcast(
@@ -99,11 +99,11 @@ public:
       LLVMBuilderRef builder,
 
       Reference* sourceStructMT,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Ref sourceRefLE,
 
       Reference* targetInterfaceTypeM,
-      InterfaceReferend* targetInterfaceReferendM) = 0;
+      InterfaceKind* targetInterfaceKindM) = 0;
 
   virtual Ref lockWeak(
       FunctionState* functionState,
@@ -128,7 +128,7 @@ public:
       Reference* sourceInterfaceRefMT,
       Ref sourceInterfaceRefLE,
       bool sourceRefKnownLive,
-      Referend* targetReferend,
+      Kind* targetKind,
       std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
       std::function<Ref(LLVMBuilderRef)> buildElse) = 0;
 
@@ -137,7 +137,7 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       Reference* referenceM,
-      StaticSizedArrayT* referendM) = 0;
+      StaticSizedArrayT* kindM) = 0;
 
   virtual Ref getRuntimeSizedArrayLength(
       FunctionState* functionState,
@@ -162,16 +162,25 @@ public:
 
   virtual LLVMTypeRef translateType(Reference* referenceM) = 0;
 
-  virtual std::string getMemberArbitraryRefNameCSeeMMEDT(
-      Reference* refMT) = 0;
-  virtual void generateStructDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StructDefinition* refMT) = 0;
-  virtual void generateInterfaceDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, InterfaceDefinition* refMT) = 0;
-  virtual void generateStaticSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StaticSizedArrayDefinitionT* ssaDefM) = 0;
-  virtual void generateRuntimeSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, RuntimeSizedArrayDefinitionT* rsaDefM) = 0;
+
+  virtual std::string getExportName(
+      Package* package,
+      Reference* reference) = 0;
+
+//  virtual std::string getMemberArbitraryRefNameCSeeMMEDT(
+//      Reference* refMT) = 0;
+  virtual std::string generateStructDefsC(
+    Package* currentPackage,
+      StructDefinition* refMT) = 0;
+  virtual std::string generateInterfaceDefsC(
+    Package* currentPackage,
+      InterfaceDefinition* refMT) = 0;
+  virtual std::string generateStaticSizedArrayDefsC(
+    Package* currentPackage,
+      StaticSizedArrayDefinitionT* ssaDefM) = 0;
+  virtual std::string generateRuntimeSizedArrayDefsC(
+    Package* currentPackage,
+      RuntimeSizedArrayDefinitionT* rsaDefM) = 0;
 
   virtual void declareStruct(StructDefinition* structM) = 0;
   virtual void declareStructExtraFunctions(StructDefinition* structM) = 0;
@@ -394,7 +403,7 @@ public:
 
   virtual RegionId* getRegionId() = 0;
 
-  virtual Weakability getReferendWeakability(Referend* referend) = 0;
+  virtual Weakability getKindWeakability(Kind* kind) = 0;
 
   virtual LLVMValueRef stackify(
       FunctionState* functionState, LLVMBuilderRef builder, Local* local, Ref refToStore,

--- a/Midas/src/c-compiler/region/linear/linear.cpp
+++ b/Midas/src/c-compiler/region/linear/linear.cpp
@@ -1058,7 +1058,7 @@ std::string Linear::getExportName(Package* currentPackage, Reference* hostRefMT)
       return baseName + "*";
     }
   } else {
-    std::cerr << "Unimplemented type in immutables' getMemberArbitraryRefNameCSeeMMEDT: "
+    std::cerr << "Unimplemented type in immutables' getExportName: "
               << typeid(*hostRefMT->kind).name() << std::endl;
     assert(false);
   }

--- a/Midas/src/c-compiler/region/linear/linear.cpp
+++ b/Midas/src/c-compiler/region/linear/linear.cpp
@@ -12,12 +12,6 @@
 #include "translatetype.h"
 #include "region/rcimm/rcimm.h"
 
-#define BUILTIN_RELEASE_MESSAGE_FUNC_NAME "ValeReleaseMessage"
-// This might become obsolete and a no-op in future versions, when we serialize this data onto the
-// stack for C externs.
-const char builtinReleaseFuncHeader[] = "#define " BUILTIN_RELEASE_MESSAGE_FUNC_NAME "(msg) (free(*((void**)(msg) - 2)))";
-
-
 Ref unsafeCast(
     GlobalState* globalState,
     FunctionState* functionState,
@@ -57,18 +51,19 @@ LLVMValueRef lowerAndHexRoundDownPointer(
 Linear::Linear(GlobalState* globalState_)
   : globalState(globalState_),
     structs(globalState_),
-    hostReferendByValeReferend(0, globalState->addressNumberer->makeHasher<Referend*>()),
-    valeReferendByHostReferend(0, globalState->addressNumberer->makeHasher<Referend*>()) {
+    hostKindByValeKind(0, globalState->addressNumberer->makeHasher<Kind*>()),
+    valeKindByHostKind(0, globalState->addressNumberer->makeHasher<Kind*>()) {
 
-  regionReferend =
-      globalState->metalCache->getStructReferend(
-          globalState->metalCache->getName(namePrefix + "_Region"));
+  regionKind =
+      globalState->metalCache->getStructKind(
+          globalState->metalCache->getName(
+              globalState->metalCache->builtinPackageCoord, namePrefix + "_Region"));
   regionRefMT =
       globalState->metalCache->getReference(
-          Ownership::BORROW, Location::YONDER, regionReferend);
-  globalState->regionIdByReferend.emplace(regionReferend, globalState->metalCache->linearRegionId);
-  structs.declareStruct(regionReferend);
-  structs.defineStruct(regionReferend, {
+          Ownership::BORROW, Location::YONDER, regionKind);
+  globalState->regionIdByKind.emplace(regionKind, globalState->metalCache->linearRegionId);
+  structs.declareStruct(regionKind);
+  structs.defineStruct(regionKind, {
       // Pointer to the beginning of the destination buffer
       LLVMPointerType(LLVMInt8TypeInContext(globalState->context), 0),
       // Offset into the destination buffer to write to
@@ -77,15 +72,16 @@ Linear::Linear(GlobalState* globalState_)
       LLVMInt64TypeInContext(globalState->context),
   });
 
-  startMetadataReferend =
-      globalState->metalCache->getStructReferend(
-          globalState->metalCache->getName(namePrefix + "_StartMetadata"));
+  startMetadataKind =
+      globalState->metalCache->getStructKind(
+          globalState->metalCache->getName(
+              globalState->metalCache->builtinPackageCoord, namePrefix + "_StartMetadata"));
   startMetadataRefMT =
       globalState->metalCache->getReference(
-          Ownership::BORROW, Location::YONDER, startMetadataReferend);
-  globalState->regionIdByReferend.emplace(startMetadataReferend, globalState->metalCache->linearRegionId);
-  structs.declareStruct(startMetadataReferend);
-  structs.defineStruct(startMetadataReferend, {
+          Ownership::BORROW, Location::YONDER, startMetadataKind);
+  globalState->regionIdByKind.emplace(startMetadataKind, globalState->metalCache->linearRegionId);
+  structs.declareStruct(startMetadataKind);
+  structs.defineStruct(startMetadataKind, {
       // Size
       LLVMInt64TypeInContext(globalState->context),
       // Start address, to subtract from all pointers
@@ -94,15 +90,16 @@ Linear::Linear(GlobalState* globalState_)
       LLVMInt64TypeInContext(globalState->context),
   });
 
-  rootMetadataReferend =
-      globalState->metalCache->getStructReferend(
-          globalState->metalCache->getName(namePrefix + "_RootMetadata"));
+  rootMetadataKind =
+      globalState->metalCache->getStructKind(
+          globalState->metalCache->getName(
+              globalState->metalCache->builtinPackageCoord, namePrefix + "_RootMetadata"));
   rootMetadataRefMT =
       globalState->metalCache->getReference(
-          Ownership::BORROW, Location::YONDER, rootMetadataReferend);
-  globalState->regionIdByReferend.emplace(rootMetadataReferend, globalState->metalCache->linearRegionId);
-  structs.declareStruct(rootMetadataReferend);
-  structs.defineStruct(rootMetadataReferend, {
+          Ownership::BORROW, Location::YONDER, rootMetadataKind);
+  globalState->regionIdByKind.emplace(rootMetadataKind, globalState->metalCache->linearRegionId);
+  structs.declareStruct(rootMetadataKind);
+  structs.defineStruct(rootMetadataKind, {
       LLVMInt64TypeInContext(globalState->context),
       LLVMInt64TypeInContext(globalState->context),
   });
@@ -112,11 +109,11 @@ Linear::Linear(GlobalState* globalState_)
       globalState->metalCache->getReference(
           Ownership::SHARE, Location::YONDER, linearStr);
 
-  addMappedReferend(globalState->metalCache->innt, globalState->metalCache->getInt(getRegionId()));
-  addMappedReferend(globalState->metalCache->boool, globalState->metalCache->getBool(getRegionId()));
-  addMappedReferend(globalState->metalCache->flooat, globalState->metalCache->getFloat(getRegionId()));
-  addMappedReferend(globalState->metalCache->str, linearStr);
-  addMappedReferend(globalState->metalCache->never, globalState->metalCache->getNever(getRegionId()));
+  addMappedKind(globalState->metalCache->innt, globalState->metalCache->getInt(getRegionId()));
+  addMappedKind(globalState->metalCache->boool, globalState->metalCache->getBool(getRegionId()));
+  addMappedKind(globalState->metalCache->flooat, globalState->metalCache->getFloat(getRegionId()));
+  addMappedKind(globalState->metalCache->str, linearStr);
+  addMappedKind(globalState->metalCache->never, globalState->metalCache->getNever(getRegionId()));
 }
 
 void Linear::declareExtraFunctions() {
@@ -191,59 +188,59 @@ Ref Linear::asSubtype(
     Reference* sourceInterfaceRefMT,
     Ref sourceInterfaceRef,
     bool sourceRefKnownLive,
-    Referend* targetReferend,
+    Kind* targetKind,
     std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
     std::function<Ref(LLVMBuilderRef)> buildElse) {
   assert(false);
 }
 
 LLVMTypeRef Linear::translateType(Reference* referenceM) {
-  if (dynamic_cast<Int*>(referenceM->referend) != nullptr) {
+  if (dynamic_cast<Int*>(referenceM->kind) != nullptr) {
     assert(referenceM->ownership == Ownership::SHARE);
     return LLVMInt64TypeInContext(globalState->context);
-  } else if (dynamic_cast<Bool*>(referenceM->referend) != nullptr) {
+  } else if (dynamic_cast<Bool*>(referenceM->kind) != nullptr) {
     assert(referenceM->ownership == Ownership::SHARE);
     return LLVMInt8TypeInContext(globalState->context);
-  } else if (dynamic_cast<Float*>(referenceM->referend) != nullptr) {
+  } else if (dynamic_cast<Float*>(referenceM->kind) != nullptr) {
     assert(referenceM->ownership == Ownership::SHARE);
     return LLVMDoubleTypeInContext(globalState->context);
-  } else if (dynamic_cast<Never*>(referenceM->referend) != nullptr) {
+  } else if (dynamic_cast<Never*>(referenceM->kind) != nullptr) {
     return LLVMArrayType(LLVMIntTypeInContext(globalState->context, NEVER_INT_BITS), 0);
-  } else if (dynamic_cast<Str *>(referenceM->referend) != nullptr) {
+  } else if (dynamic_cast<Str *>(referenceM->kind) != nullptr) {
     assert(referenceM->location != Location::INLINE);
     assert(referenceM->ownership == Ownership::SHARE);
     return LLVMPointerType(structs.getStringStruct(), 0);
-  } else if (auto staticSizedArrayMT = dynamic_cast<StaticSizedArrayT *>(referenceM->referend)) {
+  } else if (auto staticSizedArrayMT = dynamic_cast<StaticSizedArrayT *>(referenceM->kind)) {
     assert(referenceM->location != Location::INLINE);
     auto staticSizedArrayCountedStructLT = structs.getStaticSizedArrayStruct(staticSizedArrayMT);
     return LLVMPointerType(staticSizedArrayCountedStructLT, 0);
   } else if (auto runtimeSizedArrayMT =
-      dynamic_cast<RuntimeSizedArrayT *>(referenceM->referend)) {
+      dynamic_cast<RuntimeSizedArrayT *>(referenceM->kind)) {
     assert(referenceM->location != Location::INLINE);
     auto runtimeSizedArrayCountedStructLT =
         structs.getRuntimeSizedArrayStruct(runtimeSizedArrayMT);
     return LLVMPointerType(runtimeSizedArrayCountedStructLT, 0);
-  } else if (auto structReferend =
-      dynamic_cast<StructReferend *>(referenceM->referend)) {
+  } else if (auto structKind =
+      dynamic_cast<StructKind *>(referenceM->kind)) {
     if (referenceM->location == Location::INLINE) {
-      auto innerStructL = structs.getStructStruct(structReferend);
+      auto innerStructL = structs.getStructStruct(structKind);
       return innerStructL;
     } else {
-      auto countedStructL = structs.getStructStruct(structReferend);
+      auto countedStructL = structs.getStructStruct(structKind);
       return LLVMPointerType(countedStructL, 0);
     }
-  } else if (auto interfaceReferend =
-      dynamic_cast<InterfaceReferend *>(referenceM->referend)) {
+  } else if (auto interfaceKind =
+      dynamic_cast<InterfaceKind *>(referenceM->kind)) {
     assert(referenceM->location != Location::INLINE);
     auto interfaceRefStructL =
-        structs.getInterfaceRefStruct(interfaceReferend);
+        structs.getInterfaceRefStruct(interfaceKind);
     return interfaceRefStructL;
-  } else if (dynamic_cast<Never*>(referenceM->referend)) {
+  } else if (dynamic_cast<Never*>(referenceM->kind)) {
     auto result = LLVMPointerType(makeNeverType(globalState), 0);
     assert(LLVMTypeOf(globalState->neverPtr) == result);
     return result;
   } else {
-    std::cerr << "Unimplemented type: " << typeid(*referenceM->referend).name() << std::endl;
+    std::cerr << "Unimplemented type: " << typeid(*referenceM->kind).name() << std::endl;
     assert(false);
     return nullptr;
   }
@@ -262,9 +259,9 @@ Ref Linear::upcastWeak(
     FunctionState* functionState,
     LLVMBuilderRef builder,
     WeakFatPtrLE sourceRefLE,
-    StructReferend* sourceStructReferendM,
+    StructKind* sourceStructKindM,
     Reference* sourceStructTypeM,
-    InterfaceReferend* targetInterfaceReferendM,
+    InterfaceKind* targetInterfaceKindM,
     Reference* targetInterfaceTypeM) {
   assert(false);
   exit(1);
@@ -273,44 +270,48 @@ Ref Linear::upcastWeak(
 void Linear::declareStaticSizedArray(
     StaticSizedArrayDefinitionT* ssaDefM) {
 
-  auto hostName = globalState->metalCache->getName(namePrefix + "_" + ssaDefM->name->name);
-  auto hostReferend = globalState->metalCache->getStaticSizedArray(hostName);
-  addMappedReferend(ssaDefM->referend, hostReferend);
-  globalState->regionIdByReferend.emplace(hostReferend, getRegionId());
+  auto hostName =
+      globalState->metalCache->getName(
+          globalState->metalCache->builtinPackageCoord, namePrefix + "_" + ssaDefM->name->name);
+  auto hostKind = globalState->metalCache->getStaticSizedArray(hostName);
+  addMappedKind(ssaDefM->kind, hostKind);
+  globalState->regionIdByKind.emplace(hostKind, getRegionId());
 
-  structs.declareStaticSizedArray(hostReferend);
+  structs.declareStaticSizedArray(hostKind);
 }
 
 void Linear::defineStaticSizedArray(
     StaticSizedArrayDefinitionT* staticSizedArrayMT) {
-  auto ssaDef = globalState->program->getStaticSizedArray(staticSizedArrayMT->name);
+  auto ssaDef = globalState->program->getStaticSizedArray(staticSizedArrayMT->kind);
   auto elementLT =
       translateType(
           linearizeReference(
               staticSizedArrayMT->rawArray->elementType));
-  auto hostReferend = hostReferendByValeReferend.find(staticSizedArrayMT->referend)->second;
-  auto hostKsaMT = dynamic_cast<StaticSizedArrayT*>(hostReferend);
+  auto hostKind = hostKindByValeKind.find(staticSizedArrayMT->kind)->second;
+  auto hostKsaMT = dynamic_cast<StaticSizedArrayT*>(hostKind);
   assert(hostKsaMT);
 
   structs.defineStaticSizedArray(hostKsaMT, ssaDef->size, elementLT);
 }
 
 void Linear::declareStaticSizedArrayExtraFunctions(StaticSizedArrayDefinitionT* ssaDef) {
-  declareConcreteSerializeFunction(ssaDef->referend);
+  declareConcreteSerializeFunction(ssaDef->kind);
 }
 
 void Linear::defineStaticSizedArrayExtraFunctions(StaticSizedArrayDefinitionT* ssaDef) {
-  defineConcreteSerializeFunction(ssaDef->referend);
+  defineConcreteSerializeFunction(ssaDef->kind);
 }
 
 void Linear::declareRuntimeSizedArray(
     RuntimeSizedArrayDefinitionT* rsaDefM) {
-  auto hostName = globalState->metalCache->getName(namePrefix + "_" + rsaDefM->name->name);
-  auto hostReferend = globalState->metalCache->getRuntimeSizedArray(hostName);
-  addMappedReferend(rsaDefM->referend, hostReferend);
-  globalState->regionIdByReferend.emplace(hostReferend, getRegionId());
+  auto hostName =
+      globalState->metalCache->getName(
+          globalState->metalCache->builtinPackageCoord, namePrefix + "_" + rsaDefM->name->name);
+  auto hostKind = globalState->metalCache->getRuntimeSizedArray(hostName);
+  addMappedKind(rsaDefM->kind, hostKind);
+  globalState->regionIdByKind.emplace(hostKind, getRegionId());
 
-  structs.declareRuntimeSizedArray(hostReferend);
+  structs.declareRuntimeSizedArray(hostKind);
 }
 
 void Linear::defineRuntimeSizedArray(
@@ -319,39 +320,41 @@ void Linear::defineRuntimeSizedArray(
       translateType(
           linearizeReference(
               runtimeSizedArrayMT->rawArray->elementType));
-  auto hostReferend = hostReferendByValeReferend.find(runtimeSizedArrayMT->referend)->second;
-  auto hostUsaMT = dynamic_cast<RuntimeSizedArrayT*>(hostReferend);
+  auto hostKind = hostKindByValeKind.find(runtimeSizedArrayMT->kind)->second;
+  auto hostUsaMT = dynamic_cast<RuntimeSizedArrayT*>(hostKind);
   assert(hostUsaMT);
   structs.defineRuntimeSizedArray(hostUsaMT, elementLT);
 }
 
 void Linear::declareRuntimeSizedArrayExtraFunctions(RuntimeSizedArrayDefinitionT* rsaDefM) {
-  declareConcreteSerializeFunction(rsaDefM->referend);
+  declareConcreteSerializeFunction(rsaDefM->kind);
 }
 
 void Linear::defineRuntimeSizedArrayExtraFunctions(RuntimeSizedArrayDefinitionT* rsaDefM) {
-  defineConcreteSerializeFunction(rsaDefM->referend);
+  defineConcreteSerializeFunction(rsaDefM->kind);
 }
 
 void Linear::declareStruct(
     StructDefinition* structM) {
 
-  auto hostName = globalState->metalCache->getName(namePrefix + "_" + structM->name->name);
-  auto hostReferend = globalState->metalCache->getStructReferend(hostName);
-  addMappedReferend(structM->referend, hostReferend);
-  globalState->regionIdByReferend.emplace(hostReferend, getRegionId());
+  auto hostName =
+      globalState->metalCache->getName(
+          globalState->metalCache->builtinPackageCoord, namePrefix + "_" + structM->name->name);
+  auto hostKind = globalState->metalCache->getStructKind(hostName);
+  addMappedKind(structM->kind, hostKind);
+  globalState->regionIdByKind.emplace(hostKind, getRegionId());
 
-  structs.declareStruct(hostReferend);
+  structs.declareStruct(hostKind);
 }
 
 void Linear::declareStructExtraFunctions(StructDefinition* structDefM) {
-  declareConcreteSerializeFunction(structDefM->referend);
+  declareConcreteSerializeFunction(structDefM->kind);
 }
 
 void Linear::defineStruct(
     StructDefinition* structM) {
-  auto hostReferend = hostReferendByValeReferend.find(structM->referend)->second;
-  auto hostStructMT = dynamic_cast<StructReferend*>(hostReferend);
+  auto hostKind = hostKindByValeKind.find(structM->kind)->second;
+  auto hostStructMT = dynamic_cast<StructKind*>(hostKind);
   assert(hostStructMT);
 
   std::vector<LLVMTypeRef> innerStructMemberTypesL;
@@ -363,14 +366,14 @@ void Linear::defineStruct(
 }
 
 void Linear::defineStructExtraFunctions(StructDefinition* structDefM) {
-  defineConcreteSerializeFunction(structDefM->referend);
+  defineConcreteSerializeFunction(structDefM->kind);
 }
 
 void Linear::declareEdge(Edge* edge) {
-  auto hostStructReferend = linearizeStructReferend(edge->structName);
-  auto hostInterfaceReferend = linearizeInterfaceReferend(edge->interfaceName);
+  auto hostStructKind = linearizeStructKind(edge->structName);
+  auto hostInterfaceKind = linearizeInterfaceKind(edge->interfaceName);
 
-  structs.declareEdge(hostStructReferend, hostInterfaceReferend);
+  structs.declareEdge(hostStructKind, hostInterfaceKind);
 
   auto interfaceMethod = getSerializeInterfaceMethod(edge->interfaceName);
   auto thunkPrototype = getSerializeThunkPrototype(edge->structName, edge->interfaceName);
@@ -406,45 +409,47 @@ void Linear::defineEdgeSerializeFunction(Edge* edge) {
 
         auto structRef = buildCall(globalState, functionState, builder, structPrototype, {regionInstanceRef, valeObjectRef, dryRunBoolRef});
 
-        auto hostInterfaceReferend = dynamic_cast<InterfaceReferend*>(thunkPrototype->returnType->referend);
-        assert(hostInterfaceReferend);
-        auto hostStructReferend = dynamic_cast<StructReferend*>(structPrototype->returnType->referend);
-        assert(hostStructReferend);
+        auto hostInterfaceKind = dynamic_cast<InterfaceKind*>(thunkPrototype->returnType->kind);
+        assert(hostInterfaceKind);
+        auto hostStructKind = dynamic_cast<StructKind*>(structPrototype->returnType->kind);
+        assert(hostStructKind);
 
         auto interfaceRef =
             upcast(
-                functionState, builder, structPrototype->returnType, hostStructReferend,
-                structRef, thunkPrototype->returnType, hostInterfaceReferend);
+                functionState, builder, structPrototype->returnType, hostStructKind,
+                structRef, thunkPrototype->returnType, hostInterfaceKind);
         auto interfaceRefLE = checkValidReference(FL(), functionState, builder, thunkPrototype->returnType, interfaceRef);
         LLVMBuildRet(builder, interfaceRefLE);
       });
 }
 
 void Linear::declareInterface(InterfaceDefinition* interfaceM) {
-  auto hostName = globalState->metalCache->getName(namePrefix + "_" + interfaceM->name->name);
-  auto hostReferend = globalState->metalCache->getInterfaceReferend(hostName);
-  addMappedReferend(interfaceM->referend, hostReferend);
-  globalState->regionIdByReferend.emplace(hostReferend, getRegionId());
+  auto hostName =
+      globalState->metalCache->getName(
+          globalState->metalCache->builtinPackageCoord, namePrefix + "_" + interfaceM->name->name);
+  auto hostKind = globalState->metalCache->getInterfaceKind(hostName);
+  addMappedKind(interfaceM->kind, hostKind);
+  globalState->regionIdByKind.emplace(hostKind, getRegionId());
 
-  structs.declareInterface(hostReferend);
+  structs.declareInterface(hostKind);
 }
 
 void Linear::defineInterface(InterfaceDefinition* interfaceM) {
-  auto hostReferend = hostReferendByValeReferend.find(interfaceM->referend)->second;
-  auto hostInterfaceMT = dynamic_cast<InterfaceReferend*>(hostReferend);
+  auto hostKind = hostKindByValeKind.find(interfaceM->kind)->second;
+  auto hostInterfaceMT = dynamic_cast<InterfaceKind*>(hostKind);
   assert(hostInterfaceMT);
 
-  auto interfaceMethodTypesL = globalState->getInterfaceFunctionTypes(interfaceM->referend);
+  auto interfaceMethodTypesL = globalState->getInterfaceFunctionTypes(interfaceM->kind);
   structs.defineInterface(hostInterfaceMT);
 }
 
-void Linear::declareInterfaceSerializeFunction(InterfaceReferend* valeInterface) {
+void Linear::declareInterfaceSerializeFunction(InterfaceKind* valeInterface) {
   auto interfaceMethod = getSerializeInterfaceMethod(valeInterface);
   globalState->addInterfaceExtraMethod(valeInterface, interfaceMethod);
 }
 
 void Linear::declareInterfaceExtraFunctions(InterfaceDefinition* interfaceDefM) {
-  declareInterfaceSerializeFunction(interfaceDefM->referend);
+  declareInterfaceSerializeFunction(interfaceDefM->kind);
 }
 
 void Linear::defineInterfaceExtraFunctions(InterfaceDefinition* interfaceDefM) {
@@ -581,7 +586,7 @@ Ref Linear::innerAllocate(
 
   // We reserve some space for it before we serialize its members
   LLVMValueRef substructSizeIntLE =
-      predictShallowSize(builder, hostStructRefMT->referend, constI64LE(globalState, 0));
+      predictShallowSize(builder, hostStructRefMT->kind, constI64LE(globalState, 0));
   bumpDestinationOffset(functionState, builder, regionInstanceRef, substructSizeIntLE);
   buildFlare(FL(), globalState, functionState, builder);
   auto destinationStructRef = getDestinationRef(functionState, builder, regionInstanceRef, hostStructRefMT);
@@ -590,9 +595,9 @@ Ref Linear::innerAllocate(
   auto boolMT = globalState->metalCache->boolRef;
 
   auto valeStructRefMT = unlinearizeReference(hostStructRefMT);
-  auto desiredValeStructMT = dynamic_cast<StructReferend*>(valeStructRefMT->referend);
+  auto desiredValeStructMT = dynamic_cast<StructKind*>(valeStructRefMT->kind);
   assert(desiredValeStructMT);
-  auto valeStructDefM = globalState->program->getStruct(desiredValeStructMT->fullName);
+  auto valeStructDefM = globalState->program->getStruct(desiredValeStructMT);
 
   auto destinationPtrLE = checkValidReference(FL(), functionState, builder, hostStructRefMT, destinationStructRef);
 
@@ -606,26 +611,26 @@ Ref Linear::upcast(
     LLVMBuilderRef builder,
 
     Reference* sourceStructMT,
-    StructReferend* sourceStructReferendM,
+    StructKind* sourceStructKindM,
     Ref sourceRef,
 
     Reference* targetInterfaceTypeM,
-    InterfaceReferend* targetInterfaceReferendM) {
-  assert(valeReferendByHostReferend.find(sourceStructMT->referend) != valeReferendByHostReferend.end());
-  assert(valeReferendByHostReferend.find(sourceStructReferendM) != valeReferendByHostReferend.end());
-  assert(valeReferendByHostReferend.find(targetInterfaceTypeM->referend) != valeReferendByHostReferend.end());
-  assert(valeReferendByHostReferend.find(targetInterfaceReferendM) != valeReferendByHostReferend.end());
+    InterfaceKind* targetInterfaceKindM) {
+  assert(valeKindByHostKind.find(sourceStructMT->kind) != valeKindByHostKind.end());
+  assert(valeKindByHostKind.find(sourceStructKindM) != valeKindByHostKind.end());
+  assert(valeKindByHostKind.find(targetInterfaceTypeM->kind) != valeKindByHostKind.end());
+  assert(valeKindByHostKind.find(targetInterfaceKindM) != valeKindByHostKind.end());
 
   auto i8PtrLT = LLVMPointerType(LLVMInt8TypeInContext(globalState->context), 0);
 
   auto structRefLE = checkValidReference(FL(), functionState, builder, sourceStructMT, sourceRef);
   auto structI8PtrLE = LLVMBuildPointerCast(builder, structRefLE, i8PtrLT, "objAsVoidPtr");
 
-  auto interfaceRefLT = structs.getInterfaceRefStruct(targetInterfaceReferendM);
+  auto interfaceRefLT = structs.getInterfaceRefStruct(targetInterfaceKindM);
 
   auto interfaceRefLE = LLVMGetUndef(interfaceRefLT);
   interfaceRefLE = LLVMBuildInsertValue(builder, interfaceRefLE, structI8PtrLE, 0, "interfaceRefWithOnlyObj");
-  auto edgeNumber = structs.getEdgeNumber(targetInterfaceReferendM, sourceStructReferendM);
+  auto edgeNumber = structs.getEdgeNumber(targetInterfaceKindM, sourceStructKindM);
   LLVMValueRef edgeNumberLE = constI64LE(globalState, edgeNumber);
   interfaceRefLE = LLVMBuildInsertValue(builder, interfaceRefLE, edgeNumberLE, 1, "interfaceRef");
 
@@ -698,9 +703,9 @@ void Linear::checkInlineStructType(
     Reference* refMT,
     Ref ref) {
   auto argLE = checkValidReference(FL(), functionState, builder, refMT, ref);
-  auto structReferend = dynamic_cast<StructReferend*>(refMT->referend);
-  assert(structReferend);
-  assert(LLVMTypeOf(argLE) == structs.getStructStruct(structReferend));
+  auto structKind = dynamic_cast<StructKind*>(refMT->kind);
+  assert(structKind);
+  assert(LLVMTypeOf(argLE) == structs.getStructStruct(structKind));
 }
 
 LoadResult Linear::loadElementFromSSA(
@@ -716,7 +721,7 @@ LoadResult Linear::loadElementFromSSA(
   auto elementsPtrLE = LLVMBuildStructGEP(builder, arrayRefLE, 0, "ssaElemsPtr");
 
   auto valeKsaMT = unlinearizeSSA(hostKsaMT);
-  auto valeKsaMD = globalState->program->getStaticSizedArray(valeKsaMT->name);
+  auto valeKsaMD = globalState->program->getStaticSizedArray(valeKsaMT);
   auto valeMemberRefMT = valeKsaMD->rawArray->elementType;
   auto hostMemberRefMT = linearizeReference(valeMemberRefMT);
   return loadElementFromSSAInner(
@@ -739,10 +744,10 @@ LoadResult Linear::loadElementFromRSA(
   auto elementsPtrLE = LLVMBuildStructGEP(builder, arrayRefLE, 1, "rsaElemsPtr");
 
   auto valeUsaRefMT = unlinearizeReference(hostUsaRefMT);
-  auto valeUsaMT = dynamic_cast<RuntimeSizedArrayT*>(valeUsaRefMT->referend);
+  auto valeUsaMT = dynamic_cast<RuntimeSizedArrayT*>(valeUsaRefMT->kind);
   assert(valeUsaMT);
 
-  auto rsaDef = globalState->program->getRuntimeSizedArray(valeUsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(valeUsaMT);
   auto hostElementType = linearizeReference(rsaDef->rawArray->elementType);
 
   buildFlare(FL(), globalState, functionState, builder);
@@ -815,14 +820,14 @@ Ref Linear::innerConstructStaticSizedArray(
   auto boolMT = globalState->metalCache->boolRef;
   auto intRefMT = globalState->metalCache->intRef;
 
-  assert(ssaRefMT->referend == hostKsaMT);
+  assert(ssaRefMT->kind == hostKsaMT);
   assert(globalState->getRegion(hostKsaMT) == this);
 
-  auto valeReferendMT = valeReferendByHostReferend.find(hostKsaMT)->second;
-  auto valeKsaMT = dynamic_cast<StaticSizedArrayT*>(valeReferendMT);
+  auto valeKindMT = valeKindByHostKind.find(hostKsaMT)->second;
+  auto valeKsaMT = dynamic_cast<StaticSizedArrayT*>(valeKindMT);
   assert(valeKsaMT);
 
-  auto valeKsaDefM = globalState->program->getStaticSizedArray(valeKsaMT->name);
+  auto valeKsaDefM = globalState->program->getStaticSizedArray(valeKsaMT);
   auto sizeLE = predictShallowSize(builder, hostKsaMT, constI64LE(globalState, valeKsaDefM->size));
   bumpDestinationOffset(functionState, builder, regionInstanceRef, sizeLE);
   buildFlare(FL(), globalState, functionState, builder);
@@ -866,7 +871,7 @@ Ref Linear::innerConstructRuntimeSizedArray(
   auto boolMT = globalState->metalCache->boolRef;
   auto intRefMT = globalState->metalCache->intRef;
 
-  assert(rsaRefMT->referend == rsaMT);
+  assert(rsaRefMT->kind == rsaMT);
   assert(globalState->getRegion(rsaMT) == this);
 
   auto lenLE = globalState->getRegion(intRefMT)->checkValidReference(FL(), functionState, builder, intRefMT, sizeRef);
@@ -990,16 +995,22 @@ void Linear::checkValidReference(
     AreaAndFileAndLine checkerAFL,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    IReferendStructsSource* referendStructs,
+    IKindStructsSource* kindStructs,
     Reference* refM,
     LLVMValueRef refLE) {
-  regularCheckValidReference(checkerAFL, globalState, functionState, builder, referendStructs, refM, refLE);
+  regularCheckValidReference(checkerAFL, globalState, functionState, builder, kindStructs, refM, refLE);
 }
 
-std::string Linear::getMemberArbitraryRefNameCSeeMMEDT(Reference* hostRefMT) {
-  assert(valeReferendByHostReferend.find(hostRefMT->referend) != valeReferendByHostReferend.end());
+//std::string Linear::getExportName(
+//    Package* package,
+//    Reference* reference) {
+//  return package->getKindExportName(reference->kind) + (reference->location == Location::YONDER ? "Ref" : "");
+//}
 
-  auto hostMT = hostRefMT->referend;
+std::string Linear::getExportName(Package* currentPackage, Reference* hostRefMT) {
+  assert(valeKindByHostKind.find(hostRefMT->kind) != valeKindByHostKind.end());
+
+  auto hostMT = hostRefMT->kind;
   if (dynamic_cast<Int *>(hostMT)) {
     return "int64_t";
   } else if (dynamic_cast<Bool *>(hostMT)) {
@@ -1008,25 +1019,25 @@ std::string Linear::getMemberArbitraryRefNameCSeeMMEDT(Reference* hostRefMT) {
     return "double";
   } else if (dynamic_cast<Str *>(hostMT)) {
     return "ValeStr*";
-  } else if (auto hostInterfaceMT = dynamic_cast<InterfaceReferend *>(hostMT)) {
-    auto valeMT = valeReferendByHostReferend.find(hostMT)->second;
-    auto valeInterfaceMT = dynamic_cast<InterfaceReferend*>(valeMT);
+  } else if (auto hostInterfaceMT = dynamic_cast<InterfaceKind *>(hostMT)) {
+    auto valeMT = valeKindByHostKind.find(hostMT)->second;
+    auto valeInterfaceMT = dynamic_cast<InterfaceKind*>(valeMT);
     assert(valeInterfaceMT);
-    auto baseName = globalState->program->getMemberArbitraryExportNameSeeMMEDT(valeInterfaceMT->fullName);
+    auto baseName = currentPackage->getKindExportName(valeInterfaceMT);
     assert(hostRefMT->ownership == Ownership::SHARE);
 //    if (hostRefMT->location == Location::INLINE) {
       return baseName;
 //    } else {
 //      return baseName + "*";
 //    };
-  } else if (auto hostStructMT = dynamic_cast<StructReferend *>(hostMT)) {
-    auto valeMT = valeReferendByHostReferend.find(hostMT)->second;
-    auto valeStructMT = dynamic_cast<StructReferend*>(valeMT);
+  } else if (auto hostStructMT = dynamic_cast<StructKind *>(hostMT)) {
+    auto valeMT = valeKindByHostKind.find(hostMT)->second;
+    auto valeStructMT = dynamic_cast<StructKind*>(valeMT);
     assert(valeStructMT);
     if (valeStructMT == globalState->metalCache->emptyTupleStruct) {
       return "void";
     }
-    auto baseName = globalState->program->getMemberArbitraryExportNameSeeMMEDT(valeStructMT->fullName);
+    auto baseName = currentPackage->getKindExportName(valeStructMT);
     assert(hostRefMT->ownership == Ownership::SHARE);
     if (hostRefMT->location == Location::INLINE) {
       return baseName;
@@ -1036,10 +1047,10 @@ std::string Linear::getMemberArbitraryRefNameCSeeMMEDT(Reference* hostRefMT) {
   } else if (dynamic_cast<StaticSizedArrayT *>(hostMT)) {
     assert(false);
   } else if (auto hostUsaMT = dynamic_cast<RuntimeSizedArrayT *>(hostMT)) {
-    auto valeMT = valeReferendByHostReferend.find(hostMT)->second;
+    auto valeMT = valeKindByHostKind.find(hostMT)->second;
     auto valeUsaMT = dynamic_cast<RuntimeSizedArrayT*>(valeMT);
     assert(valeUsaMT);
-    auto baseName = globalState->program->getMemberArbitraryExportNameSeeMMEDT(valeUsaMT->name);
+    auto baseName = currentPackage->getKindExportName(valeUsaMT);
     assert(hostRefMT->ownership == Ownership::SHARE);
     if (hostRefMT->location == Location::INLINE) {
       return baseName;
@@ -1048,84 +1059,82 @@ std::string Linear::getMemberArbitraryRefNameCSeeMMEDT(Reference* hostRefMT) {
     }
   } else {
     std::cerr << "Unimplemented type in immutables' getMemberArbitraryRefNameCSeeMMEDT: "
-              << typeid(*hostRefMT->referend).name() << std::endl;
+              << typeid(*hostRefMT->kind).name() << std::endl;
     assert(false);
   }
 }
 
-void Linear::generateStructDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName,
+std::string Linear::generateStructDefsC(
+    Package* currentPackage,
     StructDefinition* structDefM) {
-  for (auto name : globalState->program->getExportedNames(structDefM->referend->fullName)) {
-    std::stringstream s;
-    s << "typedef struct " << name << " {" << std::endl;
-    for (int i = 0; i < structDefM->members.size(); i++) {
-      auto member = structDefM->members[i];
-      auto hostMT = hostReferendByValeReferend.find(member->type->referend)->second;
-      auto hostRefMT = globalState->metalCache->getReference(member->type->ownership, member->type->location, hostMT);
-      s << "  " << getMemberArbitraryRefNameCSeeMMEDT(hostRefMT) << " " << member->name << ";" << std::endl;
-    }
-    s << "} " << name << ";" << std::endl;
-    s << builtinReleaseFuncHeader << std::endl;
-
-    cByExportedName->insert(std::make_pair(name, s.str()));
+  auto name = currentPackage->getKindExportName(structDefM->kind);
+  std::stringstream s;
+  s << "typedef struct " << name << " { " << std::endl;
+  for (int i = 0; i < structDefM->members.size(); i++) {
+    auto member = structDefM->members[i];
+    auto hostMT = hostKindByValeKind.find(member->type->kind)->second;
+    auto hostRefMT = globalState->metalCache->getReference(member->type->ownership, member->type->location, hostMT);
+    s << "  " << getExportName(currentPackage, hostRefMT) << " " << member->name << ";" << std::endl;
   }
+  s << "} " << name << ";" << std::endl;
+  return s.str();
 }
 
-void Linear::generateInterfaceDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName,
+std::string Linear::generateInterfaceDefsC(
+    Package* currentPackage,
     InterfaceDefinition* interfaceDefM) {
-  for (auto name : globalState->program->getExportedNames(interfaceDefM->referend->fullName)) {
     std::stringstream s;
 
-    auto hostReferend = hostReferendByValeReferend.find(interfaceDefM->referend)->second;
-    auto hostInterfaceReferend = dynamic_cast<InterfaceReferend*>(hostReferend);
-    assert(hostInterfaceReferend);
+  auto interfaceName = currentPackage->getKindExportName(interfaceDefM->kind);
 
-    s << "typedef enum " << name << "_Type {" << std::endl;
-    for (auto hostStructReferend : structs.getOrderedSubstructs(hostInterfaceReferend)) {
-      auto valeReferend = valeReferendByHostReferend.find(hostStructReferend)->second;
-      auto valeStructReferend = dynamic_cast<StructReferend*>(valeReferend);
-      assert(valeStructReferend);
-      s << "  " << name << "_" << globalState->program->getMemberArbitraryExportNameSeeMMEDT(valeStructReferend->fullName) << "," << std::endl;
-    }
-    s << "} " << name << "_Type;" << std::endl;
+  auto hostKind = hostKindByValeKind.find(interfaceDefM->kind)->second;
+  auto hostInterfaceKind = dynamic_cast<InterfaceKind*>(hostKind);
+  assert(hostInterfaceKind);
 
-    s << "typedef struct " << name << " { void* obj; " << name << "_Type type; } " << name << ";" << std::endl;
-
-    s << builtinReleaseFuncHeader << std::endl;
-
-    cByExportedName->insert(std::make_pair(name, s.str()));
+  s << "typedef enum " << interfaceName << "_" << "Type {" << std::endl;
+  for (auto hostStructKind : structs.getOrderedSubstructs(hostInterfaceKind)) {
+    auto valeKind = valeKindByHostKind.find(hostStructKind)->second;
+    auto valeStructKind = dynamic_cast<StructKind*>(valeKind);
+    assert(valeStructKind);
+    s << "  " << interfaceName << "_Type_" << currentPackage->getKindExportName(valeStructKind) << "," << std::endl;
   }
+  s << "} " << interfaceName << "_Type;" << std::endl;
+  s << "typedef struct " << interfaceName << " {" << std::endl;
+  s << "void* obj; " << interfaceName << "_Type type;" << std::endl;
+  s << "} " << interfaceName << ";" << std::endl;
+
+  return s.str();
 }
 
-void Linear::generateRuntimeSizedArrayDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName,
+std::string Linear::generateRuntimeSizedArrayDefsC(
+    Package* currentPackage,
     RuntimeSizedArrayDefinitionT* rsaDefM) {
-  auto names = globalState->program->getExportedNames(rsaDefM->name);
-  assert(names.size() > 0);
-  // In the future, we should make this choose the name that was exported
-  // by this module itself. See MMEDT.
-  auto name = names[0];
+//  auto names = globalState->program->getExportedNames(rsaDefM->name);
+//  assert(names.size() > 0);
+//  // In the future, we should make this choose the name that was exported
+//  // by this module itself. See MMEDT.
+//  auto name = names[0];
+
+  auto rsaName = currentPackage->getKindExportName(rsaDefM->kind);
 
   auto valeMemberRefMT = rsaDefM->rawArray->elementType;
   auto hostMemberRefMT = linearizeReference(valeMemberRefMT);
-  auto hostMemberRefName = getMemberArbitraryRefNameCSeeMMEDT(hostMemberRefMT);
+//  auto hostMemberRefName = getMemberArbitraryRefNameCSeeMMEDT(hostMemberRefMT);
 
   std::stringstream s;
-  s << "typedef struct " << name << " {" << std::endl;
+  s << "typedef struct " << rsaName << " {" << std::endl;
   s << "  uint64_t length;" << std::endl;
-  s << "  " << hostMemberRefName << " elements[0];" << std::endl;
-  s << "} " << name << ";" << std::endl;
-
-  s << builtinReleaseFuncHeader << std::endl;
-
-  cByExportedName->insert(std::make_pair(name, s.str()));
+//  s << "  " << currentPackage->getKindExportName(hostMemberRefMT->kind) << " elements[0];" << std::endl;
+  s << "  " << getExportName(currentPackage, hostMemberRefMT) << " elements[0];" << std::endl;
+  s << "} " << rsaName << ";" << std::endl;
+  return s.str();
 }
 
-void Linear::generateStaticSizedArrayDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName,
+std::string Linear::generateStaticSizedArrayDefsC(
+    Package* currentPackage,
     StaticSizedArrayDefinitionT* rsaDefM) {
+  assert(false);
+  return "";
 }
 
 Reference* Linear::getExternalType(Reference* refMT) {
@@ -1135,16 +1144,16 @@ Reference* Linear::getExternalType(Reference* refMT) {
 Ref Linear::topLevelSerialize(
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    Referend* valeReferend,
+    Kind* valeKind,
     Ref ref) {
   auto rootMetadataSize =
-      LLVMABISizeOfType(globalState->dataLayout, structs.getStructStruct(rootMetadataReferend));
+      LLVMABISizeOfType(globalState->dataLayout, structs.getStructStruct(rootMetadataKind));
   auto startMetadataSize =
-      LLVMABISizeOfType(globalState->dataLayout, structs.getStructStruct(startMetadataReferend));
+      LLVMABISizeOfType(globalState->dataLayout, structs.getStructStruct(startMetadataKind));
 
   auto valeRefMT =
       globalState->metalCache->getReference(
-          Ownership::SHARE, Location::YONDER, valeReferend);
+          Ownership::SHARE, Location::YONDER, valeKind);
   auto hostRefMT = linearizeReference(valeRefMT);
 
   auto nullLT = LLVMConstNull(LLVMPointerType(LLVMInt8TypeInContext(globalState->context), 0));
@@ -1154,7 +1163,7 @@ Ref Linear::topLevelSerialize(
   // We'll keep subtracting from this (similar to how a program stack works) and the final address
   // will be subtracted from this number to find the needed size.
 
-  auto regionLT = structs.getStructStruct(regionReferend);
+  auto regionLT = structs.getStructStruct(regionKind);
 
   auto dryRunInitialRegionStructLE = LLVMGetUndef(regionLT);
   dryRunInitialRegionStructLE = LLVMBuildInsertValue(builder, dryRunInitialRegionStructLE, nullLT, 0, "regionStruct");
@@ -1163,7 +1172,7 @@ Ref Linear::topLevelSerialize(
   auto dryRunRegionInstancePtrLE = makeMidasLocal(functionState, builder, regionLT, "region", dryRunInitialRegionStructLE);
   auto dryRunRegionInstanceRef = wrap(this, regionRefMT, dryRunRegionInstancePtrLE);
 
-  callSerialize(functionState, builder, valeReferend, dryRunRegionInstanceRef, ref, globalState->constI1(true));
+  callSerialize(functionState, builder, valeKind, dryRunRegionInstanceRef, ref, globalState->constI1(true));
 
   // Reserve some space for the beginning metadata block
   bumpDestinationOffset(functionState, builder, dryRunRegionInstanceRef, constI64LE(globalState, startMetadataSize));
@@ -1188,15 +1197,15 @@ Ref Linear::topLevelSerialize(
 //      LLVMBuildPointerCast(
 //          builder,
 //          trailingBeginPtrI8PtrLE,
-//          LLVMPointerType(LLVMPointerType(structs.getStructStruct(rootMetadataReferend), 0), 0),
+//          LLVMPointerType(LLVMPointerType(structs.getStructStruct(rootMetadataKind), 0), 0),
 //          "trailingBeginPtrPtr");
 
   auto resultRef =
       callSerialize(
-          functionState, builder, valeReferend, regionInstanceRef, ref, globalState->constI1(false));
+          functionState, builder, valeKind, regionInstanceRef, ref, globalState->constI1(false));
 
   auto rootObjectPtrLE =
-      (dynamic_cast<InterfaceReferend*>(valeReferend) != nullptr ?
+      (dynamic_cast<InterfaceKind*>(valeKind) != nullptr ?
           std::get<1>(explodeInterfaceRef(functionState, builder, hostRefMT, resultRef)) :
           checkValidReference(FL(), functionState, builder, hostRefMT, resultRef));
   auto rootMetadataPtrLE =
@@ -1247,18 +1256,18 @@ Ref Linear::receiveUnencryptedAlienReference(
       globalState->getRegion(sourceRefMT)
           ->checkValidReference(FL(), functionState, builder, sourceRefMT, sourceRef);
 
-  if (dynamic_cast<Int*>(sourceRefMT->referend)) {
+  if (dynamic_cast<Int*>(sourceRefMT->kind)) {
     return wrap(globalState->getRegion(sourceRefMT), targetRefMT, sourceRefLE);
-  } else if (dynamic_cast<Bool*>(sourceRefMT->referend)) {
+  } else if (dynamic_cast<Bool*>(sourceRefMT->kind)) {
     auto resultLE = LLVMBuildZExt(builder, sourceRefLE, LLVMInt8TypeInContext(globalState->context), "boolAsI8");
     return wrap(globalState->getRegion(sourceRefMT), targetRefMT, resultLE);
-  } else if (dynamic_cast<Float*>(sourceRefMT->referend)) {
+  } else if (dynamic_cast<Float*>(sourceRefMT->kind)) {
     return wrap(globalState->getRegion(sourceRefMT), targetRefMT, sourceRefLE);
-  } else if (dynamic_cast<Str*>(sourceRefMT->referend) ||
-      dynamic_cast<StructReferend*>(sourceRefMT->referend) ||
-      dynamic_cast<InterfaceReferend*>(sourceRefMT->referend) ||
-      dynamic_cast<StaticSizedArrayT*>(sourceRefMT->referend) ||
-      dynamic_cast<RuntimeSizedArrayT*>(sourceRefMT->referend)) {
+  } else if (dynamic_cast<Str*>(sourceRefMT->kind) ||
+      dynamic_cast<StructKind*>(sourceRefMT->kind) ||
+      dynamic_cast<InterfaceKind*>(sourceRefMT->kind) ||
+      dynamic_cast<StaticSizedArrayT*>(sourceRefMT->kind) ||
+      dynamic_cast<RuntimeSizedArrayT*>(sourceRefMT->kind)) {
     if (sourceRefMT->location == Location::INLINE) {
       if (sourceRefMT == globalState->metalCache->emptyTupleStructRef) {
         auto emptyTupleRefMT = linearizeReference(globalState->metalCache->emptyTupleStructRef);
@@ -1267,7 +1276,7 @@ Ref Linear::receiveUnencryptedAlienReference(
         assert(false);
       }
     } else {
-      return topLevelSerialize(functionState, builder, sourceRefMT->referend, sourceRef);
+      return topLevelSerialize(functionState, builder, sourceRefMT->kind, sourceRef);
     }
   } else assert(false);
 
@@ -1278,23 +1287,23 @@ LLVMTypeRef Linear::getInterfaceMethodVirtualParamAnyType(Reference* reference) 
   return LLVMPointerType(LLVMInt8TypeInContext(globalState->context), 0);
 }
 
-LLVMValueRef Linear::predictShallowSize(LLVMBuilderRef builder, Referend* referend, LLVMValueRef lenIntLE) {
-  assert(globalState->getRegion(referend) == this);
-  if (auto structReferend = dynamic_cast<StructReferend*>(referend)) {
-    return constI64LE(globalState, LLVMABISizeOfType(globalState->dataLayout, structs.getStructStruct(structReferend)));
-  } else if (referend == linearStr) {
+LLVMValueRef Linear::predictShallowSize(LLVMBuilderRef builder, Kind* kind, LLVMValueRef lenIntLE) {
+  assert(globalState->getRegion(kind) == this);
+  if (auto structKind = dynamic_cast<StructKind*>(kind)) {
+    return constI64LE(globalState, LLVMABISizeOfType(globalState->dataLayout, structs.getStructStruct(structKind)));
+  } else if (kind == linearStr) {
     auto headerBytesLE =
         constI64LE(globalState, LLVMABISizeOfType(globalState->dataLayout, structs.getStringStruct()));
     auto lenAndNullTermLE = LLVMBuildAdd(builder, lenIntLE, constI64LE(globalState, 1), "lenAndNullTerm");
     return LLVMBuildAdd(builder, headerBytesLE, lenAndNullTermLE, "sum");
-  } else if (auto hostUsaMT = dynamic_cast<RuntimeSizedArrayT*>(referend)) {
+  } else if (auto hostUsaMT = dynamic_cast<RuntimeSizedArrayT*>(kind)) {
     auto headerBytesLE =
         constI64LE(globalState, LLVMABISizeOfType(globalState->dataLayout, structs.getRuntimeSizedArrayStruct(hostUsaMT)));
 
-    auto valeReferendMT = valeReferendByHostReferend.find(hostUsaMT)->second;
-    auto valeUsaMT = dynamic_cast<RuntimeSizedArrayT*>(valeReferendMT);
+    auto valeKindMT = valeKindByHostKind.find(hostUsaMT)->second;
+    auto valeUsaMT = dynamic_cast<RuntimeSizedArrayT*>(valeKindMT);
     assert(valeUsaMT);
-    auto valeElementRefMT = globalState->program->getRuntimeSizedArray(valeUsaMT->name)->rawArray->elementType;
+    auto valeElementRefMT = globalState->program->getRuntimeSizedArray(valeUsaMT)->rawArray->elementType;
     auto hostElementRefMT = linearizeReference(valeElementRefMT);
     auto hostElementRefLT = translateType(hostElementRefMT);
 
@@ -1305,14 +1314,14 @@ LLVMValueRef Linear::predictShallowSize(LLVMBuilderRef builder, Referend* refere
     auto elementsSizeLE = LLVMBuildMul(builder, constI64LE(globalState, sizePerElement), lenIntLE, "elementsSize");
 
     return LLVMBuildAdd(builder, headerBytesLE, elementsSizeLE, "sum");
-  } else if (auto hostKsaMT = dynamic_cast<StaticSizedArrayT*>(referend)) {
+  } else if (auto hostKsaMT = dynamic_cast<StaticSizedArrayT*>(kind)) {
     auto headerBytesLE =
         constI64LE(globalState, LLVMABISizeOfType(globalState->dataLayout, structs.getStaticSizedArrayStruct(hostKsaMT)));
 
-    auto valeReferendMT = valeReferendByHostReferend.find(hostKsaMT)->second;
-    auto valeKsaMT = dynamic_cast<StaticSizedArrayT*>(valeReferendMT);
+    auto valeKindMT = valeKindByHostKind.find(hostKsaMT)->second;
+    auto valeKsaMT = dynamic_cast<StaticSizedArrayT*>(valeKindMT);
     assert(valeKsaMT);
-    auto valeElementRefMT = globalState->program->getStaticSizedArray(valeKsaMT->name)->rawArray->elementType;
+    auto valeElementRefMT = globalState->program->getStaticSizedArray(valeKsaMT)->rawArray->elementType;
     auto hostElementRefMT = linearizeReference(valeElementRefMT);
     auto hostElementRefLT = translateType(hostElementRefMT);
 
@@ -1344,22 +1353,22 @@ Ref Linear::encryptAndSendFamiliarReference(
   exit(1);
 }
 
-InterfaceMethod* Linear::getSerializeInterfaceMethod(Referend* valeReferend) {
+InterfaceMethod* Linear::getSerializeInterfaceMethod(Kind* valeKind) {
   return globalState->metalCache->getInterfaceMethod(
-      getSerializePrototype(valeReferend), 1);
+      getSerializePrototype(valeKind), 1);
 }
 
 Ref Linear::callSerialize(
     FunctionState *functionState,
     LLVMBuilderRef builder,
-    Referend* valeReferend,
+    Kind* valeKind,
     Ref regionInstanceRef,
     Ref objectRef,
     Ref dryRunBoolRef) {
-  auto prototype = getSerializePrototype(valeReferend);
-  if (auto interfaceReferend = dynamic_cast<InterfaceReferend*>(valeReferend)) {
+  auto prototype = getSerializePrototype(valeKind);
+  if (auto interfaceKind = dynamic_cast<InterfaceKind*>(valeKind)) {
     auto virtualArgRefMT = prototype->params[1];
-    int indexInEdge = globalState->getInterfaceMethodIndex(interfaceReferend, prototype);
+    int indexInEdge = globalState->getInterfaceMethodIndex(interfaceKind, prototype);
     auto methodFunctionPtrLE =
         globalState->getRegion(virtualArgRefMT)
             ->getInterfaceMethodFunctionPtr(functionState, builder, virtualArgRefMT, objectRef, indexInEdge);
@@ -1439,42 +1448,42 @@ Ref Linear::getDestinationRef(
   return wrap(this, desiredRefMT, destinationPtr);
 }
 
-Prototype* Linear::getSerializePrototype(Referend* valeReferend) {
+Prototype* Linear::getSerializePrototype(Kind* valeKind) {
   auto boolMT = globalState->metalCache->boolRef;
   auto sourceStructRefMT =
       globalState->metalCache->getReference(
-          Ownership::SHARE, Location::YONDER, valeReferend);
+          Ownership::SHARE, Location::YONDER, valeKind);
   auto hostRefMT = linearizeReference(sourceStructRefMT);
   return globalState->metalCache->getPrototype(
       globalState->serializeName, hostRefMT,
       {regionRefMT, sourceStructRefMT, boolMT});
 }
 
-Prototype* Linear::getSerializeThunkPrototype(StructReferend* structReferend, InterfaceReferend* interfaceReferend) {
+Prototype* Linear::getSerializeThunkPrototype(StructKind* structKind, InterfaceKind* interfaceKind) {
   auto boolMT = globalState->metalCache->boolRef;
   auto valeStructRefMT =
       globalState->metalCache->getReference(
-          Ownership::SHARE, Location::YONDER, structReferend);
+          Ownership::SHARE, Location::YONDER, structKind);
   auto valeInterfaceRefMT =
       globalState->metalCache->getReference(
-          Ownership::SHARE, Location::YONDER, interfaceReferend);
+          Ownership::SHARE, Location::YONDER, interfaceKind);
   auto hostRefMT = linearizeReference(valeInterfaceRefMT);
   return globalState->metalCache->getPrototype(
       globalState->serializeThunkName, hostRefMT,
       {regionRefMT, valeStructRefMT, boolMT});
 }
 
-void Linear::declareConcreteSerializeFunction(Referend* valeReferend) {
-  auto prototype = getSerializePrototype(valeReferend);
-  auto nameL = globalState->serializeName->name + "__" + globalState->getReferendName(valeReferend)->name;
+void Linear::declareConcreteSerializeFunction(Kind* valeKind) {
+  auto prototype = getSerializePrototype(valeKind);
+  auto nameL = globalState->serializeName->name + "__" + globalState->getKindName(valeKind)->name;
   declareExtraFunction(globalState, prototype, nameL);
 }
 
-void Linear::defineConcreteSerializeFunction(Referend* valeReferend) {
+void Linear::defineConcreteSerializeFunction(Kind* valeKind) {
   auto intMT = globalState->metalCache->intRef;
   auto boolMT = globalState->metalCache->boolRef;
 
-  auto prototype = getSerializePrototype(valeReferend);
+  auto prototype = getSerializePrototype(valeKind);
 
   auto serializeMemberOrElement =
       [this](
@@ -1497,14 +1506,14 @@ void Linear::defineConcreteSerializeFunction(Referend* valeReferend) {
         } else if (sourceMemberRefMT == globalState->metalCache->floatRef) {
           return wrap(globalState->getRegion(targetMemberRefMT), targetMemberRefMT, sourceMemberLE);
         } else if (
-            dynamic_cast<Str*>(sourceMemberRefMT->referend) ||
-            dynamic_cast<StructReferend*>(sourceMemberRefMT->referend) ||
-            dynamic_cast<InterfaceReferend*>(sourceMemberRefMT->referend) ||
-            dynamic_cast<StaticSizedArrayT*>(sourceMemberRefMT->referend) ||
-            dynamic_cast<RuntimeSizedArrayT*>(sourceMemberRefMT->referend)) {
+            dynamic_cast<Str*>(sourceMemberRefMT->kind) ||
+            dynamic_cast<StructKind*>(sourceMemberRefMT->kind) ||
+            dynamic_cast<InterfaceKind*>(sourceMemberRefMT->kind) ||
+            dynamic_cast<StaticSizedArrayT*>(sourceMemberRefMT->kind) ||
+            dynamic_cast<RuntimeSizedArrayT*>(sourceMemberRefMT->kind)) {
           auto destinationMemberRef =
               callSerialize(
-                  functionState, builder, sourceMemberRefMT->referend, regionInstanceRef, sourceMemberRef, dryRunBoolRef);
+                  functionState, builder, sourceMemberRefMT->kind, regionInstanceRef, sourceMemberRef, dryRunBoolRef);
           return destinationMemberRef;
         } else assert(false);
       };
@@ -1519,11 +1528,11 @@ void Linear::defineConcreteSerializeFunction(Referend* valeReferend) {
         auto valeObjectRef = wrap(globalState->getRegion(valeObjectRefMT), valeObjectRefMT, LLVMGetParam(functionState->containingFuncL, 1));
         auto dryRunBoolRef = wrap(globalState->getRegion(boolMT), boolMT, LLVMGetParam(functionState->containingFuncL, 2));
 
-        if (auto valeStructReferend = dynamic_cast<StructReferend*>(valeObjectRefMT->referend)) {
-          auto hostReferend = hostReferendByValeReferend.find(valeStructReferend)->second;
-          auto hostStructReferend = dynamic_cast<StructReferend*>(hostReferend);
-          assert(hostStructReferend);
-          auto valeStructDefM = globalState->program->getStruct(valeStructReferend->fullName);
+        if (auto valeStructKind = dynamic_cast<StructKind*>(valeObjectRefMT->kind)) {
+          auto hostKind = hostKindByValeKind.find(valeStructKind)->second;
+          auto hostStructKind = dynamic_cast<StructKind*>(hostKind);
+          assert(hostStructKind);
+          auto valeStructDefM = globalState->program->getStruct(valeStructKind);
 
           auto hostObjectRef = innerAllocate(regionInstanceRef, FL(), functionState, builder, hostObjectRefMT);
           auto innerStructPtrLE = checkValidReference(FL(), functionState, builder, hostObjectRefMT, hostObjectRef);
@@ -1565,7 +1574,7 @@ void Linear::defineConcreteSerializeFunction(Referend* valeReferend) {
           auto hostObjectRefLE = checkValidReference(FL(), functionState, builder, hostObjectRefMT, hostObjectRef);
 
           LLVMBuildRet(builder, hostObjectRefLE);
-        } else if (dynamic_cast<Str*>(valeObjectRefMT->referend)) {
+        } else if (dynamic_cast<Str*>(valeObjectRefMT->kind)) {
           auto lengthLE = globalState->getRegion(valeObjectRefMT)->getStringLen(functionState, builder, valeObjectRef);
           auto sourceBytesPtrLE = globalState->getRegion(valeObjectRefMT)->getStringBytesPtr(functionState, builder, valeObjectRef);
 
@@ -1574,14 +1583,14 @@ void Linear::defineConcreteSerializeFunction(Referend* valeReferend) {
           buildFlare(FL(), globalState, functionState, builder, "Returning from serialize function!");
 
           LLVMBuildRet(builder, checkValidReference(FL(), functionState, builder, linearStrRefMT, strRef));
-        } else if (auto valeUsaMT = dynamic_cast<RuntimeSizedArrayT*>(valeObjectRefMT->referend)) {
+        } else if (auto valeUsaMT = dynamic_cast<RuntimeSizedArrayT*>(valeObjectRefMT->kind)) {
 
           buildFlare(FL(), globalState, functionState, builder, "In RSA serialize!");
 
-          auto hostReferendMT = hostReferendByValeReferend.find(valeUsaMT)->second;
-          auto hostUsaMT = dynamic_cast<RuntimeSizedArrayT*>(hostReferendMT);
+          auto hostKindMT = hostKindByValeKind.find(valeUsaMT)->second;
+          auto hostUsaMT = dynamic_cast<RuntimeSizedArrayT*>(hostKindMT);
           assert(hostUsaMT);
-          auto hostUsaRefMT = globalState->metalCache->getReference(Ownership::SHARE, Location::YONDER, hostReferendMT);
+          auto hostUsaRefMT = globalState->metalCache->getReference(Ownership::SHARE, Location::YONDER, hostKindMT);
 
           auto lengthRef = globalState->getRegion(valeObjectRefMT)->getRuntimeSizedArrayLength(functionState, builder, valeObjectRefMT, valeObjectRef, true);
 
@@ -1591,7 +1600,7 @@ void Linear::defineConcreteSerializeFunction(Referend* valeReferend) {
               innerConstructRuntimeSizedArray(
                   regionInstanceRef,
                   functionState, builder, hostUsaRefMT, hostUsaMT, lengthRef, "serializedrsa", dryRunBoolRef);
-          auto valeMemberRefMT = globalState->program->getRuntimeSizedArray(valeUsaMT->name)->rawArray->elementType;
+          auto valeMemberRefMT = globalState->program->getRuntimeSizedArray(valeUsaMT)->rawArray->elementType;
 
           buildFlare(FL(), globalState, functionState, builder);
 
@@ -1624,17 +1633,17 @@ void Linear::defineConcreteSerializeFunction(Referend* valeReferend) {
           buildFlare(FL(), globalState, functionState, builder, "Returning from serialize function!");
 
           LLVMBuildRet(builder, checkValidReference(FL(), functionState, builder, hostUsaRefMT, hostUsaRef));
-        } else if (auto valeKsaMT = dynamic_cast<StaticSizedArrayT*>(valeObjectRefMT->referend)) {
-          auto hostReferendMT = hostReferendByValeReferend.find(valeKsaMT)->second;
-          auto hostKsaMT = dynamic_cast<StaticSizedArrayT*>(hostReferendMT);
+        } else if (auto valeKsaMT = dynamic_cast<StaticSizedArrayT*>(valeObjectRefMT->kind)) {
+          auto hostKindMT = hostKindByValeKind.find(valeKsaMT)->second;
+          auto hostKsaMT = dynamic_cast<StaticSizedArrayT*>(hostKindMT);
           assert(hostKsaMT);
-          auto hostKsaRefMT = globalState->metalCache->getReference(Ownership::SHARE, Location::YONDER, hostReferendMT);
+          auto hostKsaRefMT = globalState->metalCache->getReference(Ownership::SHARE, Location::YONDER, hostKindMT);
 
           auto hostKsaRef =
               innerConstructStaticSizedArray(
                   regionInstanceRef,
                   functionState, builder, hostKsaRefMT, hostKsaMT, dryRunBoolRef);
-          auto valeKsaDefM = globalState->program->getStaticSizedArray(valeKsaMT->name);
+          auto valeKsaDefM = globalState->program->getStaticSizedArray(valeKsaMT);
           int length = valeKsaDefM->size;
           auto valeMemberRefMT = valeKsaDefM->rawArray->elementType;
 
@@ -1666,58 +1675,58 @@ void Linear::defineConcreteSerializeFunction(Referend* valeReferend) {
       });
 }
 
-Referend* Linear::linearizeReferend(Referend* referendMT) {
-  assert(globalState->getRegion(referendMT) == globalState->rcImm);
-  return hostReferendByValeReferend.find(referendMT)->second;
+Kind* Linear::linearizeKind(Kind* kindMT) {
+  assert(globalState->getRegion(kindMT) == globalState->rcImm);
+  return hostKindByValeKind.find(kindMT)->second;
 }
 
-StructReferend* Linear::linearizeStructReferend(StructReferend* referendMT) {
-  assert(globalState->getRegion(referendMT) == globalState->rcImm);
-  auto referend = hostReferendByValeReferend.find(referendMT)->second;
-  auto structReferend = dynamic_cast<StructReferend*>(referend);
-  return structReferend;
+StructKind* Linear::linearizeStructKind(StructKind* kindMT) {
+  assert(globalState->getRegion(kindMT) == globalState->rcImm);
+  auto kind = hostKindByValeKind.find(kindMT)->second;
+  auto structKind = dynamic_cast<StructKind*>(kind);
+  return structKind;
 }
 
-StaticSizedArrayT* Linear::unlinearizeSSA(StaticSizedArrayT *referendMT) {
-  assert(globalState->getRegion(referendMT) == globalState->linearRegion);
-  auto referend = valeReferendByHostReferend.find(referendMT)->second;
-  auto ssaMT = dynamic_cast<StaticSizedArrayT*>(referend);
+StaticSizedArrayT* Linear::unlinearizeSSA(StaticSizedArrayT *kindMT) {
+  assert(globalState->getRegion(kindMT) == globalState->linearRegion);
+  auto kind = valeKindByHostKind.find(kindMT)->second;
+  auto ssaMT = dynamic_cast<StaticSizedArrayT*>(kind);
   return ssaMT;
 }
 
-StructReferend* Linear::unlinearizeStructReferend(StructReferend* referendMT) {
-  assert(globalState->getRegion(referendMT) == globalState->linearRegion);
-  auto referend = valeReferendByHostReferend.find(referendMT)->second;
-  auto structReferend = dynamic_cast<StructReferend*>(referend);
-  return structReferend;
+StructKind* Linear::unlinearizeStructKind(StructKind* kindMT) {
+  assert(globalState->getRegion(kindMT) == globalState->linearRegion);
+  auto kind = valeKindByHostKind.find(kindMT)->second;
+  auto structKind = dynamic_cast<StructKind*>(kind);
+  return structKind;
 }
 
-InterfaceReferend* Linear::unlinearizeInterfaceReferend(InterfaceReferend* referendMT) {
-  assert(globalState->getRegion(referendMT) == globalState->linearRegion);
-  auto referend = valeReferendByHostReferend.find(referendMT)->second;
-  auto interfaceReferend = dynamic_cast<InterfaceReferend*>(referend);
-  return interfaceReferend;
+InterfaceKind* Linear::unlinearizeInterfaceKind(InterfaceKind* kindMT) {
+  assert(globalState->getRegion(kindMT) == globalState->linearRegion);
+  auto kind = valeKindByHostKind.find(kindMT)->second;
+  auto interfaceKind = dynamic_cast<InterfaceKind*>(kind);
+  return interfaceKind;
 }
 
-InterfaceReferend* Linear::linearizeInterfaceReferend(InterfaceReferend* referendMT) {
-  assert(globalState->getRegion(referendMT) == globalState->rcImm);
-  auto referend = hostReferendByValeReferend.find(referendMT)->second;
-  auto interfaceReferend = dynamic_cast<InterfaceReferend*>(referend);
-  return interfaceReferend;
+InterfaceKind* Linear::linearizeInterfaceKind(InterfaceKind* kindMT) {
+  assert(globalState->getRegion(kindMT) == globalState->rcImm);
+  auto kind = hostKindByValeKind.find(kindMT)->second;
+  auto interfaceKind = dynamic_cast<InterfaceKind*>(kind);
+  return interfaceKind;
 }
 
 Reference* Linear::linearizeReference(Reference* immRcRefMT) {
   assert(globalState->getRegion(immRcRefMT) == globalState->rcImm);
-  auto hostReferend = hostReferendByValeReferend.find(immRcRefMT->referend)->second;
+  auto hostKind = hostKindByValeKind.find(immRcRefMT->kind)->second;
   return globalState->metalCache->getReference(
-      immRcRefMT->ownership, immRcRefMT->location, hostReferend);
+      immRcRefMT->ownership, immRcRefMT->location, hostKind);
 }
 
 Reference* Linear::unlinearizeReference(Reference* hostRefMT) {
   assert(globalState->getRegion(hostRefMT) == globalState->linearRegion);
-  auto valeReferend = valeReferendByHostReferend.find(hostRefMT->referend)->second;
+  auto valeKind = valeKindByHostKind.find(hostRefMT->kind)->second;
   return globalState->metalCache->getReference(
-      hostRefMT->ownership, hostRefMT->location, valeReferend);
+      hostRefMT->ownership, hostRefMT->location, valeKind);
 }
 
 void Linear::initializeElementInRSA(
@@ -1730,14 +1739,14 @@ void Linear::initializeElementInRSA(
     Ref indexRef,
     Ref elementRef) {
   buildFlare(FL(), globalState, functionState, builder);
-  assert(hostUsaRefMT->referend == hostUsaMT);
+  assert(hostUsaRefMT->kind == hostUsaMT);
   assert(globalState->getRegion(hostUsaMT) == this);
 
   buildFlare(FL(), globalState, functionState, builder);
-  auto valeReferendMT = valeReferendByHostReferend.find(hostUsaMT)->second;
-  auto valeUsaMT = dynamic_cast<RuntimeSizedArrayT*>(valeReferendMT);
+  auto valeKindMT = valeKindByHostKind.find(hostUsaMT)->second;
+  auto valeUsaMT = dynamic_cast<RuntimeSizedArrayT*>(valeKindMT);
   assert(valeUsaMT);
-  auto valeElementRefMT = globalState->program->getRuntimeSizedArray(valeUsaMT->name)->rawArray->elementType;
+  auto valeElementRefMT = globalState->program->getRuntimeSizedArray(valeUsaMT)->rawArray->elementType;
   auto hostElementRefMT = linearizeReference(valeElementRefMT);
   auto elementRefLE = globalState->getRegion(hostElementRefMT)->checkValidReference(FL(), functionState, builder, hostElementRefMT, elementRef);
 
@@ -1783,13 +1792,13 @@ void Linear::initializeElementInSSA(
     Ref indexRef,
     Ref elementRef) {
 
-  assert(hostKsaRefMT->referend == hostKsaMT);
+  assert(hostKsaRefMT->kind == hostKsaMT);
   assert(globalState->getRegion(hostKsaMT) == this);
 
-  auto valeReferendMT = valeReferendByHostReferend.find(hostKsaMT)->second;
-  auto valeKsaMT = dynamic_cast<StaticSizedArrayT*>(valeReferendMT);
+  auto valeKindMT = valeKindByHostKind.find(hostKsaMT)->second;
+  auto valeKsaMT = dynamic_cast<StaticSizedArrayT*>(valeKindMT);
   assert(valeKsaMT);
-  auto valeElementRefMT = globalState->program->getStaticSizedArray(valeKsaMT->name)->rawArray->elementType;
+  auto valeElementRefMT = globalState->program->getStaticSizedArray(valeKsaMT)->rawArray->elementType;
   auto hostElementRefMT = linearizeReference(valeElementRefMT);
   auto elementRefLE = globalState->getRegion(hostElementRefMT)->checkValidReference(FL(), functionState, builder, hostElementRefMT, elementRef);
 
@@ -1815,7 +1824,7 @@ Ref Linear::deinitializeElementFromSSA(
   exit(1);
 }
 
-Weakability Linear::getReferendWeakability(Referend* referend) {
+Weakability Linear::getKindWeakability(Kind* kind) {
   return Weakability::NON_WEAKABLE;
 }
 
@@ -1828,9 +1837,9 @@ LLVMValueRef Linear::getInterfaceMethodFunctionPtr(
 
   assert(indexInEdge == 0); // All the below is special cased for just the unserialize method.
 
-  auto hostInterfaceMT = dynamic_cast<InterfaceReferend*>(virtualParamMT->referend);
+  auto hostInterfaceMT = dynamic_cast<InterfaceKind*>(virtualParamMT->kind);
   assert(hostInterfaceMT);
-  auto valeInterfaceMT = unlinearizeInterfaceReferend(hostInterfaceMT);
+  auto valeInterfaceMT = unlinearizeInterfaceKind(hostInterfaceMT);
 
   LLVMValueRef edgeNumLE = nullptr;
   LLVMValueRef newVirtualArgLE = nullptr;
@@ -1860,7 +1869,7 @@ LLVMValueRef Linear::getInterfaceMethodFunctionPtr(
   auto fftablePtrLE = makeMidasLocal(functionState, builder, fftableLT, "arrays", LLVMGetUndef(fftableLT));
   for (int i = 0; i < orderedSubstructs.size(); i++) {
     auto hostStructMT = orderedSubstructs[i];
-    auto valeStructMT = unlinearizeStructReferend(hostStructMT);
+    auto valeStructMT = unlinearizeStructKind(hostStructMT);
     auto prototype = globalState->rcImm->getUnserializeThunkPrototype(valeStructMT, valeInterfaceMT);
     auto funcLE = globalState->lookupFunction(prototype);
     auto bitcastedFuncLE = LLVMBuildPointerCast(builder, funcLE, functionLT, "bitcastedFunc");

--- a/Midas/src/c-compiler/region/linear/linear.h
+++ b/Midas/src/c-compiler/region/linear/linear.h
@@ -355,7 +355,7 @@ public:
 
   LLVMValueRef getStringLen(FunctionState* functionState, LLVMBuilderRef builder, Ref ref) override;
 
-  std::string getExportName(Package* currentPackage, Reference* refMT) override;
+  std::string getExportName(Package* currentPackage, Reference* refMT, bool includeProjectName) override;
 
   std::string generateStructDefsC(
     Package* currentPackage,

--- a/Midas/src/c-compiler/region/linear/linear.h
+++ b/Midas/src/c-compiler/region/linear/linear.h
@@ -53,7 +53,7 @@ public:
       Reference* sourceInterfaceRefMT,
       Ref sourceInterfaceRef,
       bool sourceRefKnownLive,
-      Referend* targetReferend,
+      Kind* targetKind,
       std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
       std::function<Ref(LLVMBuilderRef)> buildElse) override;
 
@@ -70,9 +70,9 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       WeakFatPtrLE sourceRefLE,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Reference* sourceStructTypeM,
-      InterfaceReferend* targetInterfaceReferendM,
+      InterfaceKind* targetInterfaceKindM,
       Reference* targetInterfaceTypeM) override;
 
   void declareStaticSizedArray(StaticSizedArrayDefinitionT* ssaDefM) override;
@@ -181,11 +181,11 @@ public:
       LLVMBuilderRef builder,
 
       Reference* sourceStructMT,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Ref sourceRefLE,
 
       Reference* targetInterfaceTypeM,
-      InterfaceReferend* targetInterfaceReferendM) override;
+      InterfaceKind* targetInterfaceKindM) override;
 
   WrapperPtrLE lockWeakRef(
       AreaAndFileAndLine from,
@@ -202,7 +202,7 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       Reference* referenceM,
-      StaticSizedArrayT* referendM) override;
+      StaticSizedArrayT* kindM) override;
 
   // should expose a dereference thing instead
 //  LLVMValueRef getStaticSizedArrayElementsPtr(
@@ -350,21 +350,25 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       Reference* referenceM,
-      StaticSizedArrayT* referendM,
+      StaticSizedArrayT* kindM,
       Ref dryRunBoolRef);
 
   LLVMValueRef getStringLen(FunctionState* functionState, LLVMBuilderRef builder, Ref ref) override;
 
-  std::string getMemberArbitraryRefNameCSeeMMEDT(
-      Reference* refMT) override;
-  void generateStructDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StructDefinition* refMT) override;
-  void generateInterfaceDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, InterfaceDefinition* refMT) override;
-  void generateStaticSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StaticSizedArrayDefinitionT* ssaDefM) override;
-  void generateRuntimeSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, RuntimeSizedArrayDefinitionT* rsaDefM) override;
+  std::string getExportName(Package* currentPackage, Reference* refMT) override;
+
+  std::string generateStructDefsC(
+    Package* currentPackage,
+      StructDefinition* refMT) override;
+  std::string generateInterfaceDefsC(
+    Package* currentPackage,
+      InterfaceDefinition* refMT) override;
+  std::string generateStaticSizedArrayDefsC(
+    Package* currentPackage,
+      StaticSizedArrayDefinitionT* ssaDefM) override;
+  std::string generateRuntimeSizedArrayDefsC(
+    Package* currentPackage,
+      RuntimeSizedArrayDefinitionT* rsaDefM) override;
 
 
   Reference* getExternalType(
@@ -403,7 +407,7 @@ public:
       AreaAndFileAndLine checkerAFL,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      IReferendStructsSource* referendStructs,
+      IKindStructsSource* kindStructs,
       Reference* refM,
       LLVMValueRef refLE);
 
@@ -415,16 +419,16 @@ public:
   void defineExtraFunctions() override;
 
   // Temporary, gets the corresponding Linear type reference.
-  Referend* linearizeReferend(Referend* referendMT);
-  StaticSizedArrayT* unlinearizeSSA(StaticSizedArrayT* referendMT);
-  StructReferend* unlinearizeStructReferend(StructReferend* referendMT);
-  InterfaceReferend* unlinearizeInterfaceReferend(InterfaceReferend* referendMT);
-  StructReferend* linearizeStructReferend(StructReferend* referendMT);
-  InterfaceReferend* linearizeInterfaceReferend(InterfaceReferend* referendMT);
+  Kind* linearizeKind(Kind* kindMT);
+  StaticSizedArrayT* unlinearizeSSA(StaticSizedArrayT* kindMT);
+  StructKind* unlinearizeStructKind(StructKind* kindMT);
+  InterfaceKind* unlinearizeInterfaceKind(InterfaceKind* kindMT);
+  StructKind* linearizeStructKind(StructKind* kindMT);
+  InterfaceKind* linearizeInterfaceKind(InterfaceKind* kindMT);
   Reference* linearizeReference(Reference* immRcRefMT);
   Reference* unlinearizeReference(Reference* hostRefMT);
 
-  Weakability getReferendWeakability(Referend* referend) override;
+  Weakability getKindWeakability(Kind* kind) override;
 
   LLVMValueRef getInterfaceMethodFunctionPtr(
       FunctionState* functionState,
@@ -451,9 +455,9 @@ public:
   void mainCleanup(FunctionState* functionState, LLVMBuilderRef builder) override {}
 
 private:
-  void declareConcreteSerializeFunction(Referend* valeReferendM);
-  void defineConcreteSerializeFunction(Referend* valeReferendM);
-  void declareInterfaceSerializeFunction(InterfaceReferend* valeReferend);
+  void declareConcreteSerializeFunction(Kind* valeKindM);
+  void defineConcreteSerializeFunction(Kind* valeKindM);
+  void declareInterfaceSerializeFunction(InterfaceKind* valeKind);
   void defineEdgeSerializeFunction(Edge* edge);
 
 
@@ -467,13 +471,13 @@ private:
       const std::string& typeName,
       Ref dryRunBoolRef);
 
-  Prototype* getSerializePrototype(Referend* valeReferend);
-  Prototype* getSerializeThunkPrototype(StructReferend* structReferend, InterfaceReferend* interfaceReferend);
+  Prototype* getSerializePrototype(Kind* valeKind);
+  Prototype* getSerializeThunkPrototype(StructKind* structKind, InterfaceKind* interfaceKind);
 
   LLVMValueRef predictShallowSize(
       LLVMBuilderRef builder,
-      Referend* referend,
-      // Ignored if referend isn't an array or string.
+      Kind* kind,
+      // Ignored if kind isn't an array or string.
       // If it's a string, this will be the length of the string.
       // If it's an array, this will be the number of elements.
       LLVMValueRef lenIntLE);
@@ -485,12 +489,12 @@ private:
       LLVMBuilderRef builder,
       Reference* desiredStructMT);
 
-  InterfaceMethod* getSerializeInterfaceMethod(Referend* valeReferend);
+  InterfaceMethod* getSerializeInterfaceMethod(Kind* valeKind);
 
   Ref callSerialize(
       FunctionState *functionState,
       LLVMBuilderRef builder,
-      Referend* valeReferend,
+      Kind* valeKind,
       Ref regionInstanceRef,
       Ref objectRef,
       Ref dryRunBoolRef);
@@ -500,7 +504,7 @@ private:
   Ref topLevelSerialize(
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* valeReferend,
+      Kind* valeKind,
       Ref ref);
 
   void bumpDestinationOffset(
@@ -529,9 +533,9 @@ private:
       LLVMBuilderRef builder,
       LLVMValueRef regionInstancePtrLE);
 
-  void addMappedReferend(Referend* valeReferend, Referend* hostReferend) {
-    hostReferendByValeReferend.emplace(valeReferend, hostReferend);
-    valeReferendByHostReferend.emplace(hostReferend, valeReferend);
+  void addMappedKind(Kind* valeKind, Kind* hostKind) {
+    hostKindByValeKind.emplace(valeKind, hostKind);
+    valeKindByHostKind.emplace(hostKind, valeKind);
   }
 
   GlobalState* globalState = nullptr;
@@ -539,23 +543,23 @@ private:
   LinearStructs structs;
 
   std::unordered_map<
-      Referend*,
-      Referend*,
-      AddressHasher<Referend*>> hostReferendByValeReferend;
+      Kind*,
+      Kind*,
+      AddressHasher<Kind*>> hostKindByValeKind;
   std::unordered_map<
-      Referend*,
-      Referend*,
-      AddressHasher<Referend*>> valeReferendByHostReferend;
+      Kind*,
+      Kind*,
+      AddressHasher<Kind*>> valeKindByHostKind;
 
   std::string namePrefix = "__Linear";
 
-  StructReferend* regionReferend = nullptr;
+  StructKind* regionKind = nullptr;
   Reference* regionRefMT = nullptr;
 
-  StructReferend* startMetadataReferend = nullptr;
+  StructKind* startMetadataKind = nullptr;
   Reference* startMetadataRefMT = nullptr;
 
-  StructReferend* rootMetadataReferend = nullptr;
+  StructKind* rootMetadataKind = nullptr;
   Reference* rootMetadataRefMT = nullptr;
 
   Str* linearStr = nullptr;

--- a/Midas/src/c-compiler/region/linear/linearstructs.h
+++ b/Midas/src/c-compiler/region/linear/linearstructs.h
@@ -14,23 +14,23 @@ class LinearStructs {
 public:
   LinearStructs(GlobalState* globalState_);
 
-  LLVMTypeRef getStructStruct(StructReferend* structReferend);
+  LLVMTypeRef getStructStruct(StructKind* structKind);
   LLVMTypeRef getStaticSizedArrayStruct(StaticSizedArrayT* ssaMT);
   LLVMTypeRef getRuntimeSizedArrayStruct(RuntimeSizedArrayT* rsaMT);
-  LLVMTypeRef getInterfaceRefStruct(InterfaceReferend* interfaceReferend);
+  LLVMTypeRef getInterfaceRefStruct(InterfaceKind* interfaceKind);
   LLVMTypeRef getStringStruct();
 
   void defineStruct(
-      StructReferend* struuct,
+      StructKind* struuct,
       std::vector<LLVMTypeRef> membersLT) ;
-  void declareStruct(StructReferend* structM);
-  void declareEdge(StructReferend* structReferend, InterfaceReferend* interfaceReferend);
+  void declareStruct(StructKind* structM);
+  void declareEdge(StructKind* structKind, InterfaceKind* interfaceKind);
   void defineEdge(
       Edge* edge,
       std::vector<LLVMTypeRef> interfaceFunctionsLT,
       std::vector<LLVMValueRef> functions);
-  void declareInterface(InterfaceReferend* interface);
-  void defineInterface(InterfaceReferend* interface);
+  void declareInterface(InterfaceKind* interface);
+  void defineInterface(InterfaceKind* interface);
   void declareStaticSizedArray(
       StaticSizedArrayT* staticSizedArrayMT);
   void declareRuntimeSizedArray(
@@ -68,14 +68,14 @@ public:
       Reference* virtualParamMT,
       InterfaceFatPtrLE virtualArgLE);
 
-  int getEdgeNumber(InterfaceReferend* interfaceReferend, StructReferend* structReferend) {
-    auto structs = orderedStructsByInterface.find(interfaceReferend)->second;
-    auto index = std::find(structs.begin(), structs.end(), structReferend) - structs.begin();
+  int getEdgeNumber(InterfaceKind* interfaceKind, StructKind* structKind) {
+    auto structs = orderedStructsByInterface.find(interfaceKind)->second;
+    auto index = std::find(structs.begin(), structs.end(), structKind) - structs.begin();
     assert(index < structs.size());
     return index;
   }
-  std::vector<StructReferend*> getOrderedSubstructs(InterfaceReferend* interfaceReferend) {
-    auto iter = orderedStructsByInterface.find(interfaceReferend);
+  std::vector<StructKind*> getOrderedSubstructs(InterfaceKind* interfaceKind) {
+    auto iter = orderedStructsByInterface.find(interfaceKind);
     assert(iter != orderedStructsByInterface.end());
     return iter->second;
   }
@@ -84,13 +84,13 @@ private:
   GlobalState* globalState = nullptr;
 
   LLVMTypeRef stringStructLT = nullptr;
-  std::unordered_map<InterfaceReferend*, LLVMTypeRef, AddressHasher<InterfaceReferend*>> interfaceRefStructsL;
-  std::unordered_map<StructReferend*, LLVMTypeRef, AddressHasher<StructReferend*>> structStructsL;
+  std::unordered_map<InterfaceKind*, LLVMTypeRef, AddressHasher<InterfaceKind*>> interfaceRefStructsL;
+  std::unordered_map<StructKind*, LLVMTypeRef, AddressHasher<StructKind*>> structStructsL;
   std::unordered_map<StaticSizedArrayT*, LLVMTypeRef, AddressHasher<StaticSizedArrayT*>> staticSizedArrayStructsL;
   std::unordered_map<RuntimeSizedArrayT*, LLVMTypeRef, AddressHasher<RuntimeSizedArrayT*>> runtimeSizedArrayStructsL;
 
   // The position in the vector is the integer that will be the tag for which actual substruct
   // is being pointed at by an interface ref.
-  std::unordered_map<InterfaceReferend*, std::vector<StructReferend*>, AddressHasher<InterfaceReferend*>> orderedStructsByInterface;
+  std::unordered_map<InterfaceKind*, std::vector<StructKind*>, AddressHasher<InterfaceKind*>> orderedStructsByInterface;
 };
 #endif

--- a/Midas/src/c-compiler/region/naiverc/naiverc.cpp
+++ b/Midas/src/c-compiler/region/naiverc/naiverc.cpp
@@ -832,7 +832,7 @@ std::string NaiveRC::generateRuntimeSizedArrayDefsC(
   if (rsaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(rsaDefM->kind);
+    auto name = currentPackage->getKindExportName(rsaDefM->kind, true);
     return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
@@ -843,7 +843,7 @@ std::string NaiveRC::generateStaticSizedArrayDefsC(
   if (ssaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(ssaDefM->kind);
+    auto name = currentPackage->getKindExportName(ssaDefM->kind, true);
     return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
@@ -854,7 +854,7 @@ std::string NaiveRC::generateStructDefsC(
   if (structDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(structDefM->kind);
+    auto name = currentPackage->getKindExportName(structDefM->kind, true);
     return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
@@ -1068,6 +1068,7 @@ Ref NaiveRC::localStore(FunctionState* functionState, LLVMBuilderRef builder, Lo
 
 std::string NaiveRC::getExportName(
     Package* package,
-    Reference* reference) {
-  return package->getKindExportName(reference->kind) + (reference->location == Location::YONDER ? "Ref" : "");
+    Reference* reference,
+    bool includeProjectName) {
+  return package->getKindExportName(reference->kind, includeProjectName) + (reference->location == Location::YONDER ? "Ref" : "");
 }

--- a/Midas/src/c-compiler/region/naiverc/naiverc.cpp
+++ b/Midas/src/c-compiler/region/naiverc/naiverc.cpp
@@ -22,25 +22,25 @@ NaiveRC::NaiveRC(GlobalState* globalState_, RegionId* regionId_) :
         globalState,
         makeAssistAndNaiveRCWeakableControlBlock(globalState),
         WrcWeaks::makeWeakRefHeaderStruct(globalState)),
-    referendStructs(
+    kindStructs(
         globalState,
-        [this](Referend* referend) -> IReferendStructsSource* {
-          if (globalState->getReferendWeakability(referend) == Weakability::NON_WEAKABLE) {
+        [this](Kind* kind) -> IKindStructsSource* {
+          if (globalState->getKindWeakability(kind) == Weakability::NON_WEAKABLE) {
             return &mutNonWeakableStructs;
           } else {
             return &mutWeakableStructs;
           }
         }),
     weakRefStructs(
-        [this](Referend* referend) -> IWeakRefStructsSource* {
-          if (globalState->getReferendWeakability(referend) == Weakability::NON_WEAKABLE) {
+        [this](Kind* kind) -> IWeakRefStructsSource* {
+          if (globalState->getKindWeakability(kind) == Weakability::NON_WEAKABLE) {
             assert(false);
           } else {
             return &mutWeakableStructs;
           }
         }),
     fatWeaks(globalState_, &weakRefStructs),
-    wrcWeaks(globalState_, &referendStructs, &weakRefStructs) {
+    wrcWeaks(globalState_, &kindStructs, &weakRefStructs) {
 }
 
 RegionId* NaiveRC::getRegionId() {
@@ -60,19 +60,19 @@ Ref NaiveRC::constructStaticSizedArray(
     FunctionState *functionState,
     LLVMBuilderRef builder,
     Reference *referenceM,
-    StaticSizedArrayT *referendM) {
-  auto ssaDef = globalState->program->getStaticSizedArray(referendM->name);
+    StaticSizedArrayT *kindM) {
+  auto ssaDef = globalState->program->getStaticSizedArray(kindM);
   auto resultRef =
       ::constructStaticSizedArray(
-          globalState, functionState, builder, referenceM, referendM, &referendStructs,
-          [this, functionState, referenceM, referendM](LLVMBuilderRef innerBuilder, ControlBlockPtrLE controlBlockPtrLE) {
+          globalState, functionState, builder, referenceM, kindM, &kindStructs,
+          [this, functionState, referenceM, kindM](LLVMBuilderRef innerBuilder, ControlBlockPtrLE controlBlockPtrLE) {
             fillControlBlock(
                 FL(),
                 functionState,
                 innerBuilder,
-                referenceM->referend,
+                referenceM->kind,
                 controlBlockPtrLE,
-                referendM->name->name);
+                kindM->name->name);
           });
   // We dont increment here, see SRCAO
   return resultRef;
@@ -95,14 +95,14 @@ Ref NaiveRC::allocate(
     LLVMBuilderRef builder,
     Reference* desiredReference,
     const std::vector<Ref>& memberRefs) {
-  auto structReferend = dynamic_cast<StructReferend*>(desiredReference->referend);
-  auto structM = globalState->program->getStruct(structReferend->fullName);
+  auto structKind = dynamic_cast<StructKind*>(desiredReference->kind);
+  auto structM = globalState->program->getStruct(structKind);
   auto resultRef =
       innerAllocate(
-          FL(), globalState, functionState, builder, desiredReference, &referendStructs, memberRefs, Weakability::WEAKABLE,
+          FL(), globalState, functionState, builder, desiredReference, &kindStructs, memberRefs, Weakability::WEAKABLE,
           [this, functionState, desiredReference, structM](LLVMBuilderRef innerBuilder, ControlBlockPtrLE controlBlockPtrLE) {
             fillControlBlock(
-                FL(), functionState, innerBuilder, desiredReference->referend,
+                FL(), functionState, innerBuilder, desiredReference->kind,
                 controlBlockPtrLE, structM->name->name);
           });
   return resultRef;
@@ -114,36 +114,36 @@ void NaiveRC::alias(
     LLVMBuilderRef builder,
     Reference* sourceRef,
     Ref expr) {
-  auto sourceRnd = sourceRef->referend;
+  auto sourceRnd = sourceRef->kind;
 
   if (dynamic_cast<Int *>(sourceRnd) ||
       dynamic_cast<Bool *>(sourceRnd) ||
       dynamic_cast<Float *>(sourceRnd)) {
     // Do nothing for these, they're always inlined and copied.
-  } else if (dynamic_cast<InterfaceReferend *>(sourceRnd) ||
-             dynamic_cast<StructReferend *>(sourceRnd) ||
+  } else if (dynamic_cast<InterfaceKind *>(sourceRnd) ||
+             dynamic_cast<StructKind *>(sourceRnd) ||
              dynamic_cast<StaticSizedArrayT *>(sourceRnd) ||
              dynamic_cast<RuntimeSizedArrayT *>(sourceRnd) ||
              dynamic_cast<Str *>(sourceRnd)) {
     if (sourceRef->ownership == Ownership::OWN) {
       // This can happen if we just allocated something. It's RC is already zero, and we want to
       // bump it to 1 for the owning reference.
-      adjustStrongRc(from, globalState, functionState, &referendStructs, builder, expr, sourceRef, 1);
+      adjustStrongRc(from, globalState, functionState, &kindStructs, builder, expr, sourceRef, 1);
     } else if (sourceRef->ownership == Ownership::BORROW) {
-      adjustStrongRc(from, globalState, functionState, &referendStructs, builder, expr, sourceRef, 1);
+      adjustStrongRc(from, globalState, functionState, &kindStructs, builder, expr, sourceRef, 1);
     } else if (sourceRef->ownership == Ownership::WEAK) {
       aliasWeakRef(from, functionState, builder, sourceRef, expr);
     } else if (sourceRef->ownership == Ownership::SHARE) {
       if (sourceRef->location == Location::INLINE) {
         // Do nothing, we can just let inline structs disappear
       } else {
-        adjustStrongRc(from, globalState, functionState, &referendStructs, builder, expr, sourceRef, 1);
+        adjustStrongRc(from, globalState, functionState, &kindStructs, builder, expr, sourceRef, 1);
       }
     } else
       assert(false);
   } else {
     std::cerr << "Unimplemented type in acquireReference: "
-              << typeid(*sourceRef->referend).name() << std::endl;
+              << typeid(*sourceRef->kind).name() << std::endl;
     assert(false);
   }
 }
@@ -154,7 +154,7 @@ void NaiveRC::dealias(
     LLVMBuilderRef builder,
     Reference* sourceMT,
     Ref sourceRef) {
-  auto sourceRnd = sourceMT->referend;
+  auto sourceRnd = sourceMT->kind;
 
   if (sourceMT->ownership == Ownership::SHARE) {
     assert(false);
@@ -162,7 +162,7 @@ void NaiveRC::dealias(
     // We can't discard owns, they must be destructured.
     assert(false); // impl
   } else if (sourceMT->ownership == Ownership::BORROW) {
-    auto rcLE = adjustStrongRc(from, globalState, functionState, &referendStructs, builder, sourceRef, sourceMT, -1);
+    auto rcLE = adjustStrongRc(from, globalState, functionState, &kindStructs, builder, sourceRef, sourceMT, -1);
     buildIf(
         globalState, functionState, builder, isZeroLE(builder, rcLE),
         [this, functionState, sourceRef, sourceMT](LLVMBuilderRef thenBuilder) {
@@ -175,7 +175,7 @@ void NaiveRC::dealias(
 
 Ref NaiveRC::weakAlias(FunctionState* functionState, LLVMBuilderRef builder, Reference* sourceRefMT, Reference* targetRefMT, Ref sourceRef) {
   assert(sourceRefMT->ownership == Ownership::BORROW);
-  return regularWeakAlias(globalState, functionState, &referendStructs, &wrcWeaks, builder, sourceRefMT, targetRefMT, sourceRef);
+  return regularWeakAlias(globalState, functionState, &kindStructs, &wrcWeaks, builder, sourceRefMT, targetRefMT, sourceRef);
 }
 
 // Doesn't return a constraint ref, returns a raw ref to the wrapper struct.
@@ -197,7 +197,7 @@ WrapperPtrLE NaiveRC::lockWeakRef(
           weakRefStructs.makeWeakFatPtr(
               refM,
               checkValidReference(FL(), functionState, builder, refM, weakRefLE));
-      return referendStructs.makeWrapperPtr(
+      return kindStructs.makeWrapperPtr(
           FL(), functionState, builder, refM,
           wrcWeaks.lockWrciFatPtr(from, functionState, builder, refM, weakFatPtrLE));
     }
@@ -242,12 +242,12 @@ Ref NaiveRC::asSubtype(
     Reference* sourceInterfaceRefMT,
     Ref sourceInterfaceRef,
     bool sourceRefKnownLive,
-    Referend* targetReferend,
+    Kind* targetKind,
     std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
     std::function<Ref(LLVMBuilderRef)> buildElse) {
   return regularDowncast(
       globalState, functionState, builder, thenResultIsNever, elseResultIsNever, resultOptTypeM, constraintRefM,
-      sourceInterfaceRefMT, sourceInterfaceRef, sourceRefKnownLive, targetReferend, buildThen, buildElse);
+      sourceInterfaceRefMT, sourceInterfaceRef, sourceRefKnownLive, targetKind, buildThen, buildElse);
 }
 
 LLVMTypeRef NaiveRC::translateType(Reference* referenceM) {
@@ -257,10 +257,10 @@ LLVMTypeRef NaiveRC::translateType(Reference* referenceM) {
     case Ownership::OWN:
     case Ownership::BORROW:
       assert(referenceM->location != Location::INLINE);
-      return translateReferenceSimple(globalState, &referendStructs, referenceM->referend);
+      return translateReferenceSimple(globalState, &kindStructs, referenceM->kind);
     case Ownership::WEAK:
       assert(referenceM->location != Location::INLINE);
-      return translateWeakReference(globalState, &weakRefStructs, referenceM->referend);
+      return translateWeakReference(globalState, &weakRefStructs, referenceM->kind);
     default:
       assert(false);
   }
@@ -270,29 +270,29 @@ Ref NaiveRC::upcastWeak(
     FunctionState* functionState,
     LLVMBuilderRef builder,
     WeakFatPtrLE sourceRefLE,
-    StructReferend* sourceStructReferendM,
+    StructKind* sourceStructKindM,
     Reference* sourceStructTypeM,
-    InterfaceReferend* targetInterfaceReferendM,
+    InterfaceKind* targetInterfaceKindM,
     Reference* targetInterfaceTypeM) {
   auto resultWeakInterfaceFatPtr =
       wrcWeaks.weakStructPtrToWrciWeakInterfacePtr(
-          globalState, functionState, builder, sourceRefLE, sourceStructReferendM,
-          sourceStructTypeM, targetInterfaceReferendM, targetInterfaceTypeM);
+          globalState, functionState, builder, sourceRefLE, sourceStructKindM,
+          sourceStructTypeM, targetInterfaceKindM, targetInterfaceTypeM);
   return wrap(this, targetInterfaceTypeM, resultWeakInterfaceFatPtr);
 }
 
 void NaiveRC::declareStaticSizedArray(
     StaticSizedArrayDefinitionT* staticSizedArrayMT) {
-  globalState->regionIdByReferend.emplace(staticSizedArrayMT->referend, getRegionId());
+  globalState->regionIdByKind.emplace(staticSizedArrayMT->kind, getRegionId());
 
-  referendStructs.declareStaticSizedArray(staticSizedArrayMT);
+  kindStructs.declareStaticSizedArray(staticSizedArrayMT);
 }
 
 void NaiveRC::declareRuntimeSizedArray(
     RuntimeSizedArrayDefinitionT* runtimeSizedArrayMT) {
-  globalState->regionIdByReferend.emplace(runtimeSizedArrayMT->referend, getRegionId());
+  globalState->regionIdByKind.emplace(runtimeSizedArrayMT->kind, getRegionId());
 
-  referendStructs.declareRuntimeSizedArray(runtimeSizedArrayMT);
+  kindStructs.declareRuntimeSizedArray(runtimeSizedArrayMT);
 }
 
 void NaiveRC::defineRuntimeSizedArray(
@@ -300,7 +300,7 @@ void NaiveRC::defineRuntimeSizedArray(
   auto elementLT =
       globalState->getRegion(runtimeSizedArrayMT->rawArray->elementType)
           ->translateType(runtimeSizedArrayMT->rawArray->elementType);
-  referendStructs.defineRuntimeSizedArray(runtimeSizedArrayMT, elementLT);
+  kindStructs.defineRuntimeSizedArray(runtimeSizedArrayMT, elementLT);
 }
 
 void NaiveRC::defineStaticSizedArray(
@@ -308,12 +308,12 @@ void NaiveRC::defineStaticSizedArray(
   auto elementLT =
       globalState->getRegion(staticSizedArrayMT->rawArray->elementType)
           ->translateType(staticSizedArrayMT->rawArray->elementType);
-  referendStructs.defineStaticSizedArray(staticSizedArrayMT, elementLT);
+  kindStructs.defineStaticSizedArray(staticSizedArrayMT, elementLT);
 }
 void NaiveRC::declareStruct(
     StructDefinition* structM) {
-  globalState->regionIdByReferend.emplace(structM->referend, getRegionId());
-  referendStructs.declareStruct(structM->referend);
+  globalState->regionIdByKind.emplace(structM->kind, getRegionId());
+  kindStructs.declareStruct(structM->kind);
 }
 
 void NaiveRC::defineStruct(StructDefinition* structM) {
@@ -323,27 +323,27 @@ void NaiveRC::defineStruct(StructDefinition* structM) {
         globalState->getRegion(structM->members[i]->type)
             ->translateType(structM->members[i]->type));
   }
-  referendStructs.defineStruct(structM->referend, innerStructMemberTypesL);
+  kindStructs.defineStruct(structM->kind, innerStructMemberTypesL);
 }
 
 void NaiveRC::declareEdge(Edge* edge) {
-  referendStructs.declareEdge(edge);
+  kindStructs.declareEdge(edge);
 }
 
 void NaiveRC::defineEdge(Edge* edge) {
   auto interfaceFunctionsLT = globalState->getInterfaceFunctionTypes(edge->interfaceName);
   auto edgeFunctionsL = globalState->getEdgeFunctions(edge);
-  referendStructs.defineEdge(edge, interfaceFunctionsLT, edgeFunctionsL);
+  kindStructs.defineEdge(edge, interfaceFunctionsLT, edgeFunctionsL);
 }
 
 void NaiveRC::declareInterface(InterfaceDefinition* interfaceM) {
-  globalState->regionIdByReferend.emplace(interfaceM->referend, getRegionId());
-  referendStructs.declareInterface(interfaceM);
+  globalState->regionIdByKind.emplace(interfaceM->kind, getRegionId());
+  kindStructs.declareInterface(interfaceM);
 }
 
 void NaiveRC::defineInterface(InterfaceDefinition* interfaceM) {
-  auto interfaceMethodTypesL = globalState->getInterfaceFunctionTypes(interfaceM->referend);
-  referendStructs.defineInterface(interfaceM, interfaceMethodTypesL);
+  auto interfaceMethodTypesL = globalState->getInterfaceFunctionTypes(interfaceM->kind);
+  kindStructs.defineInterface(interfaceM, interfaceMethodTypesL);
 }
 
 void NaiveRC::discardOwningRef(
@@ -356,7 +356,7 @@ void NaiveRC::discardOwningRef(
   auto rcLE =
       adjustStrongRc(
           AFL("Destroy decrementing the owning ref"),
-          globalState, functionState, &referendStructs, builder, sourceRef, sourceMT, -1);
+          globalState, functionState, &kindStructs, builder, sourceRef, sourceMT, -1);
   buildIf(
       globalState, functionState, builder, isZeroLE(builder, rcLE),
       [this, functionState, blockState, sourceRef, sourceMT](LLVMBuilderRef thenBuilder) {
@@ -370,13 +370,13 @@ void NaiveRC::noteWeakableDestroyed(
     Reference* refM,
     ControlBlockPtrLE controlBlockPtrLE) {
   // Dont need to assert that the strong RC is zero, thats the only way we'd get here.
-  if (auto structReferendM = dynamic_cast<StructReferend*>(refM->referend)) {
-    auto structM = globalState->program->getStruct(structReferendM->fullName);
+  if (auto structKindM = dynamic_cast<StructKind*>(refM->kind)) {
+    auto structM = globalState->program->getStruct(structKindM);
     if (structM->weakability == Weakability::WEAKABLE) {
       wrcWeaks.innerNoteWeakableDestroyed(functionState, builder, refM, controlBlockPtrLE);
     }
-  } else if (auto interfaceReferendM = dynamic_cast<InterfaceReferend*>(refM->referend)) {
-    auto interfaceM = globalState->program->getInterface(interfaceReferendM->fullName);
+  } else if (auto interfaceKindM = dynamic_cast<InterfaceKind*>(refM->kind)) {
+    auto interfaceM = globalState->program->getInterface(interfaceKindM);
     if (interfaceM->weakability == Weakability::WEAKABLE) {
       wrcWeaks.innerNoteWeakableDestroyed(functionState, builder, refM, controlBlockPtrLE);
     }
@@ -403,7 +403,7 @@ void NaiveRC::storeMember(
           globalState->getRegion(newMemberRefMT)->checkValidReference(
               FL(), functionState, builder, newMemberRefMT, newMemberRef);
       storeMemberStrong(
-          globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+          globalState, functionState, builder, &kindStructs, structRefMT, structRef,
           structKnownLive, memberIndex, memberName, newMemberLE);
       break;
     }
@@ -412,7 +412,7 @@ void NaiveRC::storeMember(
           globalState->getRegion(newMemberRefMT)->checkValidReference(
               FL(), functionState, builder, newMemberRefMT, newMemberRef);
       storeMemberWeak(
-          globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+          globalState, functionState, builder, &kindStructs, structRefMT, structRef,
           structKnownLive, memberIndex, memberName, newMemberLE);
       break;
     }
@@ -433,11 +433,11 @@ std::tuple<LLVMValueRef, LLVMValueRef> NaiveRC::explodeInterfaceRef(
     case Ownership::BORROW:
     case Ownership::SHARE: {
       return explodeStrongInterfaceRef(
-          globalState, functionState, builder, &referendStructs, virtualParamMT, virtualArgRef);
+          globalState, functionState, builder, &kindStructs, virtualParamMT, virtualArgRef);
     }
     case Ownership::WEAK: {
       return explodeWeakInterfaceRef(
-          globalState, functionState, builder, &referendStructs, &fatWeaks, &weakRefStructs,
+          globalState, functionState, builder, &kindStructs, &fatWeaks, &weakRefStructs,
           virtualParamMT, virtualArgRef,
           [this, functionState, builder, virtualParamMT](WeakFatPtrLE weakFatPtrLE) {
             return wrcWeaks.weakInterfaceRefToWeakStructRef(
@@ -455,7 +455,7 @@ Ref NaiveRC::getRuntimeSizedArrayLength(
     Reference* rsaRefMT,
     Ref arrayRef,
     bool arrayKnownLive) {
-  return getRuntimeSizedArrayLengthStrong(globalState, functionState, builder, &referendStructs, rsaRefMT, arrayRef);
+  return getRuntimeSizedArrayLengthStrong(globalState, functionState, builder, &kindStructs, rsaRefMT, arrayRef);
 }
 
 LLVMValueRef NaiveRC::checkValidReference(
@@ -473,13 +473,13 @@ LLVMValueRef NaiveRC::checkValidReference(
 
   if (globalState->opt->census) {
     if (refM->ownership == Ownership::OWN) {
-      regularCheckValidReference(checkerAFL, globalState, functionState, builder, &referendStructs, refM, refLE);
+      regularCheckValidReference(checkerAFL, globalState, functionState, builder, &kindStructs, refM, refLE);
     } else if (refM->ownership == Ownership::SHARE) {
       assert(false);
     } else {
       if (refM->ownership == Ownership::BORROW) {
         regularCheckValidReference(checkerAFL, globalState, functionState, builder,
-                                   &referendStructs, refM, refLE);
+                                   &kindStructs, refM, refLE);
       } else if (refM->ownership == Ownership::WEAK) {
         wrcWeaks.buildCheckWeakRef(checkerAFL, functionState, builder, refM, ref);
       } else
@@ -546,7 +546,7 @@ Ref NaiveRC::upgradeLoadResultToRefWithTargetOwnership(
       return sourceRef;
     } else if (targetOwnership == Ownership::WEAK) {
       // Making a weak ref from a constraint ref local.
-      assert(dynamic_cast<StructReferend*>(sourceType->referend) || dynamic_cast<InterfaceReferend*>(sourceType->referend));
+      assert(dynamic_cast<StructKind*>(sourceType->kind) || dynamic_cast<InterfaceKind*>(sourceType->kind));
       return wrcWeaks.assembleWeakRef(functionState, builder, sourceType, targetType, sourceRef);
     } else {
       assert(false);
@@ -584,8 +584,8 @@ LLVMValueRef NaiveRC::getCensusObjectId(
     Reference* refM,
     Ref ref) {
   auto controlBlockPtrLE =
-      referendStructs.getControlBlockPtr(checkerAFL, functionState, builder, ref, refM);
-  return referendStructs.getObjIdFromControlBlockPtr(builder, refM->referend, controlBlockPtrLE);
+      kindStructs.getControlBlockPtr(checkerAFL, functionState, builder, ref, refM);
+  return kindStructs.getObjIdFromControlBlockPtr(builder, refM->kind, controlBlockPtrLE);
 }
 
 Ref NaiveRC::getIsAliveFromWeakRef(
@@ -602,11 +602,11 @@ void NaiveRC::fillControlBlock(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     ControlBlockPtrLE controlBlockPtrLE,
     const std::string& typeName) {
   regularFillControlBlock(
-      from, globalState, functionState, &referendStructs, builder, referendM, controlBlockPtrLE,
+      from, globalState, functionState, &kindStructs, builder, kindM, controlBlockPtrLE,
       typeName, &wrcWeaks);
 }
 
@@ -618,9 +618,9 @@ LoadResult NaiveRC::loadElementFromSSA(
     Ref arrayRef,
     bool arrayKnownLive,
     Ref indexRef) {
-  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT->name);
+  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT);
   return regularloadElementFromSSA(
-      globalState, functionState, builder, ssaRefMT, ssaMT, ssaDef->rawArray->elementType, ssaDef->size, ssaDef->rawArray->mutability, arrayRef, arrayKnownLive, indexRef, &referendStructs);
+      globalState, functionState, builder, ssaRefMT, ssaMT, ssaDef->rawArray->elementType, ssaDef->size, ssaDef->rawArray->mutability, arrayRef, arrayKnownLive, indexRef, &kindStructs);
 }
 
 LoadResult NaiveRC::loadElementFromRSA(
@@ -631,9 +631,9 @@ LoadResult NaiveRC::loadElementFromRSA(
     Ref arrayRef,
     bool arrayKnownLive,
     Ref indexRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   return regularLoadElementFromRSAWithoutUpgrade(
-      globalState, functionState, builder, &referendStructs, rsaRefMT, rsaMT, rsaDef->rawArray->mutability, rsaDef->rawArray->elementType, arrayRef, arrayKnownLive, indexRef);
+      globalState, functionState, builder, &kindStructs, rsaRefMT, rsaMT, rsaDef->rawArray->mutability, rsaDef->rawArray->elementType, arrayRef, arrayKnownLive, indexRef);
 }
 
 Ref NaiveRC::storeElementInRSA(
@@ -645,9 +645,9 @@ Ref NaiveRC::storeElementInRSA(
     bool arrayKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   auto arrayWrapperPtrLE =
-      referendStructs.makeWrapperPtr(
+      kindStructs.makeWrapperPtr(
           FL(), functionState, builder, rsaRefMT,
           globalState->getRegion(rsaRefMT)->checkValidReference(FL(), functionState, builder, rsaRefMT, arrayRef));
   auto sizeRef = ::getRuntimeSizedArrayLength(globalState, functionState, builder, arrayWrapperPtrLE);
@@ -662,20 +662,20 @@ Ref NaiveRC::upcast(
     LLVMBuilderRef builder,
 
     Reference* sourceStructMT,
-    StructReferend* sourceStructReferendM,
+    StructKind* sourceStructKindM,
     Ref sourceRefLE,
 
     Reference* targetInterfaceTypeM,
-    InterfaceReferend* targetInterfaceReferendM) {
+    InterfaceKind* targetInterfaceKindM) {
 
   switch (sourceStructMT->ownership) {
     case Ownership::SHARE:
     case Ownership::OWN:
     case Ownership::BORROW: {
-      return upcastStrong(globalState, functionState, builder, &referendStructs, sourceStructMT, sourceStructReferendM, sourceRefLE, targetInterfaceTypeM, targetInterfaceReferendM);
+      return upcastStrong(globalState, functionState, builder, &kindStructs, sourceStructMT, sourceStructKindM, sourceRefLE, targetInterfaceTypeM, targetInterfaceKindM);
     }
     case Ownership::WEAK: {
-      return ::upcastWeak(globalState, functionState, builder, &weakRefStructs, sourceStructMT, sourceStructReferendM, sourceRefLE, targetInterfaceTypeM, targetInterfaceReferendM);
+      return ::upcastWeak(globalState, functionState, builder, &weakRefStructs, sourceStructMT, sourceStructKindM, sourceRefLE, targetInterfaceTypeM, targetInterfaceKindM);
     }
     default:
       assert(false);
@@ -689,7 +689,7 @@ void NaiveRC::deallocate(
     LLVMBuilderRef builder,
     Reference* refMT,
     Ref ref) {
-  innerDeallocate(from, globalState, functionState, &referendStructs, builder, refMT, ref);
+  innerDeallocate(from, globalState, functionState, &kindStructs, builder, refMT, ref);
 }
 
 Ref NaiveRC::constructRuntimeSizedArray(
@@ -701,13 +701,13 @@ Ref NaiveRC::constructRuntimeSizedArray(
     Ref sizeRef,
     const std::string& typeName) {
   auto rsaWrapperPtrLT =
-      referendStructs.getRuntimeSizedArrayWrapperStruct(runtimeSizedArrayT);
-  auto rsaDef = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT->name);
-  auto elementType = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT->name)->rawArray->elementType;
+      kindStructs.getRuntimeSizedArrayWrapperStruct(runtimeSizedArrayT);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT);
+  auto elementType = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT)->rawArray->elementType;
   auto rsaElementLT = globalState->getRegion(elementType)->translateType(elementType);
   auto resultRef =
       ::constructRuntimeSizedArray(
-          globalState, functionState, builder, &referendStructs, rsaMT, rsaDef->rawArray->elementType, runtimeSizedArrayT,
+          globalState, functionState, builder, &kindStructs, rsaMT, rsaDef->rawArray->elementType, runtimeSizedArrayT,
           rsaWrapperPtrLT, rsaElementLT, sizeRef, typeName,
           [this, functionState, runtimeSizedArrayT, typeName](
               LLVMBuilderRef innerBuilder, ControlBlockPtrLE controlBlockPtrLE) {
@@ -736,7 +736,7 @@ Ref NaiveRC::loadMember(
       } else {
         auto unupgradedMemberLE =
             regularLoadMember(
-                globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+                globalState, functionState, builder, &kindStructs, structRefMT, structRef,
                 memberIndex, expectedMemberType, targetType, memberName);
         return upgradeLoadResultToRefWithTargetOwnership(
             functionState, builder, expectedMemberType, targetType, unupgradedMemberLE);
@@ -758,7 +758,7 @@ Ref NaiveRC::loadMember(
             case Ownership::SHARE: {
               auto unupgradedMemberLE =
                   regularLoadMember(
-                      globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+                      globalState, functionState, builder, &kindStructs, structRefMT, structRef,
                       memberIndex, expectedMemberType, targetType, memberName);
               return upgradeLoadResultToRefWithTargetOwnership(
                   functionState, builder, expectedMemberType, targetType, unupgradedMemberLE);
@@ -767,7 +767,7 @@ Ref NaiveRC::loadMember(
             case Ownership::WEAK: {
               auto memberLE =
                   resilientLoadWeakMember(
-                      globalState, functionState, builder, &referendStructs, structRefMT,
+                      globalState, functionState, builder, &kindStructs, structRefMT,
                       structRef,
                       structKnownLive, memberIndex, expectedMemberType, memberName);
               auto resultRef =
@@ -792,121 +792,78 @@ void NaiveRC::checkInlineStructType(
     Reference* refMT,
     Ref ref) {
   auto argLE = checkValidReference(FL(), functionState, builder, refMT, ref);
-  auto structReferend = dynamic_cast<StructReferend*>(refMT->referend);
-  assert(structReferend);
-  assert(LLVMTypeOf(argLE) == referendStructs.getInnerStruct(structReferend));
+  auto structKind = dynamic_cast<StructKind*>(refMT->kind);
+  assert(structKind);
+  assert(LLVMTypeOf(argLE) == kindStructs.getInnerStruct(structKind));
 }
 
 
-std::string NaiveRC::getMemberArbitraryRefNameCSeeMMEDT(Reference* refMT) {
-  if (refMT->ownership == Ownership::SHARE) {
-    assert(false);
-  } else if (auto structRefMT = dynamic_cast<StructReferend*>(refMT->referend)) {
-    auto structMT = globalState->program->getStruct(structRefMT->fullName);
-    auto baseName = globalState->program->getMemberArbitraryExportNameSeeMMEDT(structRefMT->fullName);
-    if (structMT->mutability == Mutability::MUTABLE) {
-      assert(refMT->location != Location::INLINE);
-      return baseName + "Ref";
-    } else {
-      if (refMT->location == Location::INLINE) {
-        return baseName + "Inl";
-      } else {
-        return baseName + "Ref";
-      }
-    }
-  } else if (auto interfaceMT = dynamic_cast<InterfaceReferend*>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(interfaceMT->fullName) + "Ref";
-  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(rsaMT->name) + "Ref";
-  } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(ssaMT->name) + "Ref";
-  } else {
-    assert(false);
-  }
-}
+//std::string NaiveRC::getMemberArbitraryRefNameCSeeMMEDT(Reference* refMT) {
+//  if (refMT->ownership == Ownership::SHARE) {
+//    assert(false);
+//  } else if (auto structRefMT = dynamic_cast<StructKind*>(refMT->kind)) {
+//    auto structMT = globalState->program->getStruct(structRefMT);
+//    auto baseName = globalState->program->getMemberArbitraryExportNameSeeMMEDT(structRefMT->fullName);
+//    if (structMT->mutability == Mutability::MUTABLE) {
+//      assert(refMT->location != Location::INLINE);
+//      return baseName + "Ref";
+//    } else {
+//      if (refMT->location == Location::INLINE) {
+//        return baseName + "Inl";
+//      } else {
+//        return baseName + "Ref";
+//      }
+//    }
+//  } else if (auto interfaceMT = dynamic_cast<InterfaceKind*>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(interfaceMT->fullName) + "Ref";
+//  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(rsaMT->name) + "Ref";
+//  } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(ssaMT->name) + "Ref";
+//  } else {
+//    assert(false);
+//  }
+//}
 
-void NaiveRC::generateRuntimeSizedArrayDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName,
+std::string NaiveRC::generateRuntimeSizedArrayDefsC(
+    Package* currentPackage,
+
     RuntimeSizedArrayDefinitionT* rsaDefM) {
   if (rsaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto baseName : globalState->program->getExportedNames(rsaDefM->name)) {
-      auto refTypeName = baseName + "Ref";
-      std::stringstream s;
-      s << "typedef struct " << refTypeName << " { void* unused; } " << refTypeName << ";" << std::endl;
-      cByExportedName->insert(std::make_pair(baseName, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(rsaDefM->kind);
+    return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
 
-void NaiveRC::generateStaticSizedArrayDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName,
+std::string NaiveRC::generateStaticSizedArrayDefsC(
+    Package* currentPackage,
     StaticSizedArrayDefinitionT* ssaDefM) {
   if (ssaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto baseName : globalState->program->getExportedNames(ssaDefM->name)) {
-      auto refTypeName = baseName + "Ref";
-      std::stringstream s;
-      s << "typedef struct " << refTypeName << " { void* unused; } " << refTypeName << ";" << std::endl;
-      cByExportedName->insert(std::make_pair(baseName, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(ssaDefM->kind);
+    return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
 
-void NaiveRC::generateStructDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName, StructDefinition* structDefM) {
-  switch (globalState->opt->regionOverride) {
-    case RegionOverride::NAIVE_RC:
-      if (structDefM->mutability == Mutability::IMMUTABLE) {
-        assert(false);
-      } else {
-        for (auto baseName : globalState->program->getExportedNames(structDefM->referend->fullName)) {
-          auto refTypeName = baseName + "Ref";
-          std::stringstream s;
-          s << "typedef struct " << refTypeName << " { void* unused; } " << refTypeName << ";" << std::endl;
-          cByExportedName->insert(std::make_pair(baseName, s.str()));
-        }
-      }
-      break;
-    case RegionOverride::RESILIENT_V3: case RegionOverride::RESILIENT_V4:
-      if (structDefM->mutability == Mutability::IMMUTABLE) {
-        assert(false);
-      } else {
-        for (auto baseName : globalState->program->getExportedNames(structDefM->referend->fullName)) {
-          auto refTypeName = baseName + "Ref";
-          std::stringstream s;
-          s << "typedef struct " << refTypeName << " { uint64_t unused0; void* unused1; } " << refTypeName << ";" << std::endl;
-          cByExportedName->insert(std::make_pair(baseName, s.str()));
-        }
-      }
-      break;
-    default:
-      assert(false);
+std::string NaiveRC::generateStructDefsC(
+    Package* currentPackage,
+     StructDefinition* structDefM) {
+  if (structDefM->mutability == Mutability::IMMUTABLE) {
+    assert(false);
+  } else {
+    auto name = currentPackage->getKindExportName(structDefM->kind);
+    return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
 
-void NaiveRC::generateInterfaceDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName, InterfaceDefinition* interfaceDefM) {
-  switch (globalState->opt->regionOverride) {
-    case RegionOverride::NAIVE_RC:
-//      return "void* unused; void* unused;";
-      assert(false); // impl
-    case RegionOverride::RESILIENT_V3: case RegionOverride::RESILIENT_V4:
-      if (interfaceDefM->mutability == Mutability::IMMUTABLE) {
-        assert(false);
-      } else {
-        for (auto name : globalState->program->getExportedNames(interfaceDefM->referend->fullName)) {
-          std::stringstream s;
-          s << "typedef struct " << name << "Ref { uint64_t unused0; void* unused1; void* unused2; } " << name << "Ref;";
-          cByExportedName->insert(std::make_pair(name, s.str()));
-        }
-      }
-      break;
-    default:
-      assert(false);
-  }
+std::string NaiveRC::generateInterfaceDefsC(
+    Package* currentPackage,
+     InterfaceDefinition* interfaceDefM) {
+  assert(false); // impl
+  return "";
 }
 
 Reference* NaiveRC::getExternalType(Reference* refMT) {
@@ -955,7 +912,7 @@ LLVMTypeRef NaiveRC::getInterfaceMethodVirtualParamAnyType(Reference* reference)
         case Ownership::SHARE:
           return LLVMPointerType(LLVMInt8TypeInContext(globalState->context), 0);
         case Ownership::WEAK:
-          return weakRefStructs.getWeakVoidRefStruct(reference->referend);
+          return weakRefStructs.getWeakVoidRefStruct(reference->kind);
         default:
           assert(false);
       }
@@ -968,7 +925,7 @@ LLVMTypeRef NaiveRC::getInterfaceMethodVirtualParamAnyType(Reference* reference)
           return LLVMPointerType(LLVMInt8TypeInContext(globalState->context), 0);
         case Ownership::BORROW:
         case Ownership::WEAK:
-          return weakRefStructs.getWeakVoidRefStruct(reference->referend);
+          return weakRefStructs.getWeakVoidRefStruct(reference->kind);
       }
       break;
     }
@@ -1018,7 +975,7 @@ void NaiveRC::initializeElementInRSA(
     bool arrayRefKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  ::initializeElementInRSA(globalState, functionState, builder, &referendStructs, rsaMT, rsaRefMT, rsaRef, indexRef, elementRef);
+  ::initializeElementInRSA(globalState, functionState, builder, &kindStructs, rsaMT, rsaRefMT, rsaRef, indexRef, elementRef);
 }
 
 Ref NaiveRC::deinitializeElementFromRSA(
@@ -1029,9 +986,9 @@ Ref NaiveRC::deinitializeElementFromRSA(
     Ref arrayRef,
     bool arrayRefKnownLive,
     Ref indexRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   return regularLoadElementFromRSAWithoutUpgrade(
-      globalState, functionState, builder, &referendStructs, rsaRefMT, rsaMT, rsaDef->rawArray->mutability, rsaDef->rawArray->elementType, arrayRef, true, indexRef).move();
+      globalState, functionState, builder, &kindStructs, rsaRefMT, rsaMT, rsaDef->rawArray->mutability, rsaDef->rawArray->elementType, arrayRef, true, indexRef).move();
 }
 
 void NaiveRC::initializeElementInSSA(
@@ -1043,9 +1000,9 @@ void NaiveRC::initializeElementInSSA(
     bool arrayRefKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT->name);
+  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT);
   auto arrayWrapperPtrLE =
-      referendStructs.makeWrapperPtr(
+      kindStructs.makeWrapperPtr(
           FL(), functionState, builder, ssaRefMT,
           globalState->getRegion(ssaRefMT)->checkValidReference(FL(), functionState, builder, ssaRefMT, arrayRef));
   auto sizeRef = globalState->constI64(ssaDef->size);
@@ -1066,11 +1023,11 @@ Ref NaiveRC::deinitializeElementFromSSA(
   exit(1);
 }
 
-Weakability NaiveRC::getReferendWeakability(Referend* referend) {
-  if (auto structReferend = dynamic_cast<StructReferend*>(referend)) {
-    return globalState->lookupStruct(structReferend->fullName)->weakability;
-  } else if (auto interfaceReferend = dynamic_cast<InterfaceReferend*>(referend)) {
-    return globalState->lookupInterface(interfaceReferend->fullName)->weakability;
+Weakability NaiveRC::getKindWeakability(Kind* kind) {
+  if (auto structKind = dynamic_cast<StructKind*>(kind)) {
+    return globalState->lookupStruct(structKind)->weakability;
+  } else if (auto interfaceKind = dynamic_cast<InterfaceKind*>(kind)) {
+    return globalState->lookupInterface(interfaceKind)->weakability;
   } else {
     return Weakability::NON_WEAKABLE;
   }
@@ -1107,4 +1064,10 @@ Ref NaiveRC::loadLocal(FunctionState* functionState, LLVMBuilderRef builder, Loc
 
 Ref NaiveRC::localStore(FunctionState* functionState, LLVMBuilderRef builder, Local* local, LLVMValueRef localAddr, Ref refToStore, bool knownLive) {
   return normalLocalStore(globalState, functionState, builder, local, localAddr, refToStore);
+}
+
+std::string NaiveRC::getExportName(
+    Package* package,
+    Reference* reference) {
+  return package->getKindExportName(reference->kind) + (reference->location == Location::YONDER ? "Ref" : "");
 }

--- a/Midas/src/c-compiler/region/naiverc/naiverc.h
+++ b/Midas/src/c-compiler/region/naiverc/naiverc.h
@@ -43,9 +43,9 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       WeakFatPtrLE sourceRefLE,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Reference* sourceStructTypeM,
-      InterfaceReferend* targetInterfaceReferendM,
+      InterfaceKind* targetInterfaceKindM,
       Reference* targetInterfaceTypeM) override;
 
   Ref upcast(
@@ -53,11 +53,11 @@ public:
       LLVMBuilderRef builder,
 
       Reference* sourceStructMT,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Ref sourceRefLE,
 
       Reference* targetInterfaceTypeM,
-      InterfaceReferend* targetInterfaceReferendM) override;
+      InterfaceKind* targetInterfaceKindM) override;
 
 
   void defineStaticSizedArray(
@@ -105,7 +105,7 @@ public:
       Reference* sourceInterfaceRefMT,
       Ref sourceInterfaceRef,
       bool sourceRefKnownLive,
-      Referend* targetReferend,
+      Kind* targetKind,
       std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
       std::function<Ref(LLVMBuilderRef)> buildElse) override;
 
@@ -116,7 +116,7 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       Reference* referenceM,
-      StaticSizedArrayT* referendM) override;
+      StaticSizedArrayT* kindM) override;
 
   // should expose a dereference thing instead
 //  LLVMValueRef getStaticSizedArrayElementsPtr(
@@ -355,7 +355,7 @@ public:
 //      FunctionState* functionState,
 //      LLVMBuilderRef builder,
 //      Location location,
-//      LLVMTypeRef referendLT) override;
+//      LLVMTypeRef kindLT) override;
 
 //  LLVMValueRef mallocRuntimeSizedArray(
 //      LLVMBuilderRef builder,
@@ -368,58 +368,61 @@ public:
 //    return mutWeakableStructs.makeWeakFatPtr(referenceM_, ptrLE);
 //  }
   // TODO get rid of these once refactor is done
-//  ControlBlock* getControlBlock(Referend* referend) override {
-//    return referendStructs.getControlBlock(referend);
+//  ControlBlock* getControlBlock(Kind* kind) override {
+//    return kindStructs.getControlBlock(kind);
 //  }
-//  IReferendStructsSource* getReferendStructsSource() override {
-//    return &referendStructs;
+//  IKindStructsSource* getKindStructsSource() override {
+//    return &kindStructs;
 //  }
 //  IWeakRefStructsSource* getWeakRefStructsSource() override {
 //    return &weakRefStructs;
 //  }
   LLVMValueRef getStringBytesPtr(FunctionState* functionState, LLVMBuilderRef builder, Ref ref) override {
     auto strWrapperPtrLE =
-        referendStructs.makeWrapperPtr(
+        kindStructs.makeWrapperPtr(
             FL(), functionState, builder,
             globalState->metalCache->strRef,
             checkValidReference(
                 FL(), functionState, builder, globalState->metalCache->strRef, ref));
-    return referendStructs.getStringBytesPtr(functionState, builder, strWrapperPtrLE);
+    return kindStructs.getStringBytesPtr(functionState, builder, strWrapperPtrLE);
   }
   LLVMValueRef getStringLen(FunctionState* functionState, LLVMBuilderRef builder, Ref ref) override {
     auto strWrapperPtrLE =
-        referendStructs.makeWrapperPtr(
+        kindStructs.makeWrapperPtr(
             FL(), functionState, builder,
             globalState->metalCache->strRef,
             checkValidReference(
                 FL(), functionState, builder, globalState->metalCache->strRef, ref));
-    return referendStructs.getStringLen(functionState, builder, strWrapperPtrLE);
+    return kindStructs.getStringLen(functionState, builder, strWrapperPtrLE);
   }
-//  LLVMTypeRef getWeakRefHeaderStruct(Referend* referend) override {
-//    return mutWeakableStructs.getWeakRefHeaderStruct(referend);
+//  LLVMTypeRef getWeakRefHeaderStruct(Kind* kind) override {
+//    return mutWeakableStructs.getWeakRefHeaderStruct(kind);
 //  }
-//  LLVMTypeRef getWeakVoidRefStruct(Referend* referend) override {
-//    return mutWeakableStructs.getWeakVoidRefStruct(referend);
+//  LLVMTypeRef getWeakVoidRefStruct(Kind* kind) override {
+//    return mutWeakableStructs.getWeakVoidRefStruct(kind);
 //  }
   void fillControlBlock(
       AreaAndFileAndLine from,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       ControlBlockPtrLE controlBlockPtrLE,
       const std::string& typeName);
 
 
-  std::string getMemberArbitraryRefNameCSeeMMEDT(
-      Reference* refMT) override;
-  void generateStructDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StructDefinition* refMT) override;
-  void generateInterfaceDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, InterfaceDefinition* refMT) override;
-  void generateStaticSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StaticSizedArrayDefinitionT* ssaDefM) override;
-  void generateRuntimeSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, RuntimeSizedArrayDefinitionT* rsaDefM) override;
+  std::string getExportName(Package* currentPackage, Reference* refMT) override;
+  std::string generateStructDefsC(
+    Package* currentPackage,
+      StructDefinition* refMT) override;
+  std::string generateInterfaceDefsC(
+    Package* currentPackage,
+      InterfaceDefinition* refMT) override;
+  std::string generateStaticSizedArrayDefsC(
+    Package* currentPackage,
+      StaticSizedArrayDefinitionT* ssaDefM) override;
+  std::string generateRuntimeSizedArrayDefsC(
+    Package* currentPackage,
+      RuntimeSizedArrayDefinitionT* rsaDefM) override;
 
   Reference* getExternalType(Reference* refMT) override;
 
@@ -452,7 +455,7 @@ public:
   void declareExtraFunctions() override {}
   void defineExtraFunctions() override {}
 
-  Weakability getReferendWeakability(Referend* referend) override;
+  Weakability getKindWeakability(Kind* kind) override;
 
   void declareStructExtraFunctions(StructDefinition* structDefM) override {}
   void declareStaticSizedArrayExtraFunctions(StaticSizedArrayDefinitionT* ssaDef) override {}
@@ -484,16 +487,16 @@ protected:
 
   RegionId* regionId;
 
-  ReferendStructs mutNonWeakableStructs;
-  WeakableReferendStructs mutWeakableStructs;
+  KindStructs mutNonWeakableStructs;
+  WeakableKindStructs mutWeakableStructs;
 
-  ReferendStructsRouter referendStructs;
+  KindStructsRouter kindStructs;
   WeakRefStructsRouter weakRefStructs;
 
   FatWeaks fatWeaks;
   WrcWeaks wrcWeaks;
 
-  // TODO see if we can just use referendStructs/weakRefStructs instead of having these?
+  // TODO see if we can just use kindStructs/weakRefStructs instead of having these?
 //  WeakFatPtrLEMaker weakFatPtrMaker;
 //  InterfaceFatPtrLEMaker interfaceFatPtrMaker;
 //  ControlBlockPtrLEMaker controlBlockPtrMaker;

--- a/Midas/src/c-compiler/region/naiverc/naiverc.h
+++ b/Midas/src/c-compiler/region/naiverc/naiverc.h
@@ -410,7 +410,7 @@ public:
       const std::string& typeName);
 
 
-  std::string getExportName(Package* currentPackage, Reference* refMT) override;
+  std::string getExportName(Package* currentPackage, Reference* refMT, bool includeProjectName) override;
   std::string generateStructDefsC(
     Package* currentPackage,
       StructDefinition* refMT) override;

--- a/Midas/src/c-compiler/region/rcimm/rcimm.cpp
+++ b/Midas/src/c-compiler/region/rcimm/rcimm.cpp
@@ -895,7 +895,7 @@ std::string RCImm::generateRuntimeSizedArrayDefsC(
   if (rsaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(rsaDefM->kind);
+    auto name = currentPackage->getKindExportName(rsaDefM->kind, true);
     return std::string() + "typedef struct " + name + " { void* unused; } " + name + ";\n";
   }
 }
@@ -906,7 +906,7 @@ std::string RCImm::generateStaticSizedArrayDefsC(
   if (ssaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(ssaDefM->kind);
+    auto name = currentPackage->getKindExportName(ssaDefM->kind, true);
     return std::string() + "typedef struct " + name + " { void* unused; } " + name + ";\n";
   }
 }
@@ -1333,7 +1333,8 @@ Ref RCImm::localStore(FunctionState* functionState, LLVMBuilderRef builder, Loca
 
 std::string RCImm::getExportName(
     Package* package,
-    Reference* reference) {
+    Reference* reference,
+    bool includeProjectName) {
   assert(false);
 //  if (dynamic_cast<InterfaceKind*>(reference->kind)) {
 //    return package->getKindExportName(reference->kind);

--- a/Midas/src/c-compiler/region/rcimm/rcimm.h
+++ b/Midas/src/c-compiler/region/rcimm/rcimm.h
@@ -347,7 +347,7 @@ public:
   LLVMValueRef getStringLen(FunctionState* functionState, LLVMBuilderRef builder, Ref ref) override;
 
 
-  std::string getExportName(Package* currentPackage, Reference* refMT) override;
+  std::string getExportName(Package* currentPackage, Reference* refMT, bool includeProjectName) override;
   std::string generateStructDefsC(
     Package* currentPackage,
       StructDefinition* refMT) override;

--- a/Midas/src/c-compiler/region/rcimm/rcimm.h
+++ b/Midas/src/c-compiler/region/rcimm/rcimm.h
@@ -55,7 +55,7 @@ public:
       Reference* sourceInterfaceRefMT,
       Ref sourceInterfaceRef,
       bool sourceRefKnownLive,
-      Referend* targetReferend,
+      Kind* targetKind,
       std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
       std::function<Ref(LLVMBuilderRef)> buildElse) override;
 
@@ -72,9 +72,9 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       WeakFatPtrLE sourceRefLE,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Reference* sourceStructTypeM,
-      InterfaceReferend* targetInterfaceReferendM,
+      InterfaceKind* targetInterfaceKindM,
       Reference* targetInterfaceTypeM) override;
 
   void declareStruct(StructDefinition* structM) override;
@@ -186,11 +186,11 @@ public:
       LLVMBuilderRef builder,
 
       Reference* sourceStructMT,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Ref sourceRefLE,
 
       Reference* targetInterfaceTypeM,
-      InterfaceReferend* targetInterfaceReferendM) override;
+      InterfaceKind* targetInterfaceKindM) override;
 
   WrapperPtrLE lockWeakRef(
       AreaAndFileAndLine from,
@@ -207,7 +207,7 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       Reference* referenceM,
-      StaticSizedArrayT* referendM) override;
+      StaticSizedArrayT* kindM) override;
 
   // should expose a dereference thing instead
 //  LLVMValueRef getStaticSizedArrayElementsPtr(
@@ -346,16 +346,20 @@ public:
 
   LLVMValueRef getStringLen(FunctionState* functionState, LLVMBuilderRef builder, Ref ref) override;
 
-  std::string getMemberArbitraryRefNameCSeeMMEDT(
-      Reference* refMT) override;
-  void generateStructDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StructDefinition* refMT) override;
-  void generateInterfaceDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, InterfaceDefinition* refMT) override;
-  void generateStaticSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StaticSizedArrayDefinitionT* ssaDefM) override;
-  void generateRuntimeSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, RuntimeSizedArrayDefinitionT* rsaDefM) override;
+
+  std::string getExportName(Package* currentPackage, Reference* refMT) override;
+  std::string generateStructDefsC(
+    Package* currentPackage,
+      StructDefinition* refMT) override;
+  std::string generateInterfaceDefsC(
+    Package* currentPackage,
+      InterfaceDefinition* refMT) override;
+  std::string generateStaticSizedArrayDefsC(
+    Package* currentPackage,
+      StaticSizedArrayDefinitionT* ssaDefM) override;
+  std::string generateRuntimeSizedArrayDefsC(
+    Package* currentPackage,
+      RuntimeSizedArrayDefinitionT* rsaDefM) override;
 
 
   Reference* getExternalType(
@@ -392,7 +396,7 @@ public:
 
   LLVMTypeRef translateType(GlobalState* globalState, Reference* referenceM);
 
-  LLVMTypeRef getControlBlockStruct(Referend* referend);
+  LLVMTypeRef getControlBlockStruct(Kind* kind);
 
 
   LoadResult loadMember(
@@ -409,11 +413,11 @@ public:
       AreaAndFileAndLine checkerAFL,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      IReferendStructsSource* referendStructs,
+      IKindStructsSource* kindStructs,
       Reference* refM,
       LLVMValueRef refLE);
 
-  Weakability getReferendWeakability(Referend* referend) override;
+  Weakability getKindWeakability(Kind* kind) override;
 
   LLVMValueRef getInterfaceMethodFunctionPtr(
       FunctionState* functionState,
@@ -423,8 +427,8 @@ public:
       int indexInEdge) override;
 
   // This is public so that linear can get at it to stick it in a vtable.
-  Prototype* getUnserializePrototype(Referend* valeReferend);
-  Prototype* getUnserializeThunkPrototype(StructReferend* structReferend, InterfaceReferend* interfaceReferend);
+  Prototype* getUnserializePrototype(Kind* valeKind);
+  Prototype* getUnserializeThunkPrototype(StructKind* structKind, InterfaceKind* interfaceKind);
 
   LLVMValueRef stackify(
       FunctionState* functionState,
@@ -443,17 +447,17 @@ public:
   void mainCleanup(FunctionState* functionState, LLVMBuilderRef builder) override {}
 
 private:
-  void declareConcreteUnserializeFunction(Referend* valeReferendM);
-  void defineConcreteUnserializeFunction(Referend* valeReferendM);
-  void declareInterfaceUnserializeFunction(InterfaceReferend* valeReferend);
+  void declareConcreteUnserializeFunction(Kind* valeKindM);
+  void defineConcreteUnserializeFunction(Kind* valeKindM);
+  void declareInterfaceUnserializeFunction(InterfaceKind* valeKind);
   void defineEdgeUnserializeFunction(Edge* edge);
 
-  InterfaceMethod* getUnserializeInterfaceMethod(Referend* valeReferend);
+  InterfaceMethod* getUnserializeInterfaceMethod(Kind* valeKind);
 
   Ref callUnserialize(
       FunctionState *functionState,
       LLVMBuilderRef builder,
-      Referend* valeReferend,
+      Kind* valeKind,
       Ref objectRef);
 
   // Does the entire serialization process: measuring the length, allocating a buffer, and
@@ -461,12 +465,12 @@ private:
   Ref topLevelUnserialize(
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* valeReferend,
+      Kind* valeKind,
       Ref ref);
 
   GlobalState* globalState = nullptr;
 
-  ReferendStructs referendStructs;
+  KindStructs kindStructs;
 
   DefaultPrimitives primitives;
 };

--- a/Midas/src/c-compiler/region/resilientv3/resilientv3.cpp
+++ b/Midas/src/c-compiler/region/resilientv3/resilientv3.cpp
@@ -815,7 +815,7 @@ std::string ResilientV3::generateRuntimeSizedArrayDefsC(
   if (rsaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(rsaDefM->kind);
+    auto name = currentPackage->getKindExportName(rsaDefM->kind, true);
     return std::string() + "typedef struct " + name + "Ref { uint64_t unused0; void* unused; } " + name + "Ref;\n";
   }
 }
@@ -826,7 +826,7 @@ std::string ResilientV3::generateStaticSizedArrayDefsC(
   if (ssaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(ssaDefM->kind);
+    auto name = currentPackage->getKindExportName(ssaDefM->kind, true);
     return std::string() + "typedef struct " + name + "Ref { uint64_t unused0; void* unused; } " + name + "Ref;\n";
   }
 }
@@ -838,7 +838,7 @@ std::string ResilientV3::generateStructDefsC(
   if (structDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(structDefM->kind);
+    auto name = currentPackage->getKindExportName(structDefM->kind, true);
     return std::string() + "typedef struct " + name + "Ref { uint64_t unused0; void* unused; } " + name + "Ref;\n";
   }
 }
@@ -850,7 +850,7 @@ std::string ResilientV3::generateInterfaceDefsC(
   if (interfaceDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(interfaceDefM->kind);
+    auto name = currentPackage->getKindExportName(interfaceDefM->kind, true);
     return std::string() + "typedef struct " + name + "Ref { uint64_t unused0; void* unused1; void* unused2; } " + name + "Ref;\n";
   }
 }
@@ -1010,6 +1010,7 @@ Ref ResilientV3::localStore(FunctionState* functionState, LLVMBuilderRef builder
 
 std::string ResilientV3::getExportName(
     Package* package,
-    Reference* reference) {
-  return package->getKindExportName(reference->kind) + (reference->location == Location::YONDER ? "Ref" : "");
+    Reference* reference,
+    bool includeProjectName) {
+  return package->getKindExportName(reference->kind, includeProjectName) + (reference->location == Location::YONDER ? "Ref" : "");
 }

--- a/Midas/src/c-compiler/region/resilientv3/resilientv3.cpp
+++ b/Midas/src/c-compiler/region/resilientv3/resilientv3.cpp
@@ -33,14 +33,14 @@ ResilientV3::ResilientV3(GlobalState *globalState_, RegionId *regionId_) :
         globalState,
         makeResilientV3WeakableControlBlock(globalState),
         HybridGenerationalMemory::makeWeakRefHeaderStruct(globalState, regionId)),
-    referendStructs(
-        globalState, [this](Referend *referend) -> IReferendStructsSource * { return &mutWeakableStructs; }),
-    weakRefStructs([this](Referend *referend) -> IWeakRefStructsSource * { return &mutWeakableStructs; }),
+    kindStructs(
+        globalState, [this](Kind *kind) -> IKindStructsSource * { return &mutWeakableStructs; }),
+    weakRefStructs([this](Kind *kind) -> IWeakRefStructsSource * { return &mutWeakableStructs; }),
     fatWeaks(globalState_, &weakRefStructs),
     hgmWeaks(
         globalState_,
         mutWeakableStructs.getControlBlock(),
-        &referendStructs,
+        &kindStructs,
         &weakRefStructs,
         globalState->opt->elideChecksForKnownLive,
         false,
@@ -65,20 +65,20 @@ Ref ResilientV3::constructStaticSizedArray(
     FunctionState *functionState,
     LLVMBuilderRef builder,
     Reference *referenceM,
-    StaticSizedArrayT *referendM) {
-  auto ssaDef = globalState->program->getStaticSizedArray(referendM->name);
+    StaticSizedArrayT *kindM) {
+  auto ssaDef = globalState->program->getStaticSizedArray(kindM);
   auto resultRef =
       ::constructStaticSizedArray(
-          globalState, functionState, builder, referenceM, referendM, &referendStructs,
-          [this, functionState, referenceM, referendM](LLVMBuilderRef innerBuilder,
+          globalState, functionState, builder, referenceM, kindM, &kindStructs,
+          [this, functionState, referenceM, kindM](LLVMBuilderRef innerBuilder,
                                                        ControlBlockPtrLE controlBlockPtrLE) {
             fillControlBlock(
                 FL(),
                 functionState,
                 innerBuilder,
-                referenceM->referend,
+                referenceM->kind,
                 controlBlockPtrLE,
-                referendM->name->name);
+                kindM->name->name);
           });
   // We dont increment here, see SRCAO
   return resultRef;
@@ -101,16 +101,16 @@ Ref ResilientV3::allocate(
     LLVMBuilderRef builder,
     Reference *desiredReference,
     const std::vector<Ref> &memberRefs) {
-  auto structReferend = dynamic_cast<StructReferend *>(desiredReference->referend);
-  auto structM = globalState->program->getStruct(structReferend->fullName);
+  auto structKind = dynamic_cast<StructKind *>(desiredReference->kind);
+  auto structM = globalState->program->getStruct(structKind);
   auto resultRef =
       innerAllocate(
-          FL(), globalState, functionState, builder, desiredReference, &referendStructs, memberRefs,
+          FL(), globalState, functionState, builder, desiredReference, &kindStructs, memberRefs,
           Weakability::WEAKABLE,
           [this, functionState, desiredReference, structM](LLVMBuilderRef innerBuilder,
                                                            ControlBlockPtrLE controlBlockPtrLE) {
             fillControlBlock(
-                FL(), functionState, innerBuilder, desiredReference->referend,
+                FL(), functionState, innerBuilder, desiredReference->kind,
                 controlBlockPtrLE, structM->name->name);
           });
   return resultRef;
@@ -122,14 +122,14 @@ void ResilientV3::alias(
     LLVMBuilderRef builder,
     Reference *sourceRef,
     Ref expr) {
-  auto sourceRnd = sourceRef->referend;
+  auto sourceRnd = sourceRef->kind;
 
   if (dynamic_cast<Int *>(sourceRnd) ||
       dynamic_cast<Bool *>(sourceRnd) ||
       dynamic_cast<Float *>(sourceRnd)) {
     // Do nothing for these, they're always inlined and copied.
-  } else if (dynamic_cast<InterfaceReferend *>(sourceRnd) ||
-             dynamic_cast<StructReferend *>(sourceRnd) ||
+  } else if (dynamic_cast<InterfaceKind *>(sourceRnd) ||
+             dynamic_cast<StructKind *>(sourceRnd) ||
              dynamic_cast<StaticSizedArrayT *>(sourceRnd) ||
              dynamic_cast<RuntimeSizedArrayT *>(sourceRnd) ||
              dynamic_cast<Str *>(sourceRnd)) {
@@ -143,13 +143,13 @@ void ResilientV3::alias(
       if (sourceRef->location == Location::INLINE) {
         // Do nothing, we can just let inline structs disappear
       } else {
-        adjustStrongRc(from, globalState, functionState, &referendStructs, builder, expr, sourceRef, 1);
+        adjustStrongRc(from, globalState, functionState, &kindStructs, builder, expr, sourceRef, 1);
       }
     } else
       assert(false);
   } else {
     std::cerr << "Unimplemented type in acquireReference: "
-              << typeid(*sourceRef->referend).name() << std::endl;
+              << typeid(*sourceRef->kind).name() << std::endl;
     assert(false);
   }
 }
@@ -160,7 +160,7 @@ void ResilientV3::dealias(
     LLVMBuilderRef builder,
     Reference *sourceMT,
     Ref sourceRef) {
-  auto sourceRnd = sourceMT->referend;
+  auto sourceRnd = sourceMT->kind;
 
   if (sourceMT->ownership == Ownership::SHARE) {
     assert(false);
@@ -198,7 +198,7 @@ WrapperPtrLE ResilientV3::lockWeakRef(
       auto weakFatPtrLE =
           checkValidReference(
               FL(), functionState, builder, refM, weakRefLE);
-      return referendStructs.makeWrapperPtr(FL(), functionState, builder, refM, weakFatPtrLE);
+      return kindStructs.makeWrapperPtr(FL(), functionState, builder, refM, weakFatPtrLE);
     }
     case Ownership::BORROW:
     case Ownership::WEAK: {
@@ -207,7 +207,7 @@ WrapperPtrLE ResilientV3::lockWeakRef(
               refM,
               checkValidReference(
                   FL(), functionState, builder, refM, weakRefLE));
-      return referendStructs.makeWrapperPtr(
+      return kindStructs.makeWrapperPtr(
           FL(), functionState, builder, refM,
           hgmWeaks.lockGenFatPtr(
               from, functionState, builder, refM, weakFatPtrLE, weakRefKnownLive));
@@ -253,17 +253,17 @@ Ref ResilientV3::asSubtype(
     Reference* sourceInterfaceRefMT,
     Ref sourceInterfaceRef,
     bool sourceRefKnownLive,
-    Referend* targetReferend,
+    Kind* targetKind,
     std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
     std::function<Ref(LLVMBuilderRef)> buildElse) {
-  auto targetStructReferend = dynamic_cast<StructReferend*>(targetReferend);
-  assert(targetStructReferend);
-  auto sourceInterfaceReferend = dynamic_cast<InterfaceReferend*>(sourceInterfaceRefMT->referend);
-  assert(sourceInterfaceReferend);
+  auto targetStructKind = dynamic_cast<StructKind*>(targetKind);
+  assert(targetStructKind);
+  auto sourceInterfaceKind = dynamic_cast<InterfaceKind*>(sourceInterfaceRefMT->kind);
+  assert(sourceInterfaceKind);
 
   return resilientDowncast(
       globalState, functionState, builder, &weakRefStructs, resultOptTypeM, sourceInterfaceRefMT, sourceInterfaceRef,
-      targetReferend, buildThen, buildElse, targetStructReferend, sourceInterfaceReferend);
+      targetKind, buildThen, buildElse, targetStructKind, sourceInterfaceKind);
 }
 
 LLVMTypeRef ResilientV3::translateType(Reference *referenceM) {
@@ -272,11 +272,11 @@ LLVMTypeRef ResilientV3::translateType(Reference *referenceM) {
       assert(false);
     case Ownership::OWN:
       assert(referenceM->location != Location::INLINE);
-      return translateReferenceSimple(globalState, &referendStructs, referenceM->referend);
+      return translateReferenceSimple(globalState, &kindStructs, referenceM->kind);
     case Ownership::BORROW:
     case Ownership::WEAK:
       assert(referenceM->location != Location::INLINE);
-      return translateWeakReference(globalState, &weakRefStructs, referenceM->referend);
+      return translateWeakReference(globalState, &weakRefStructs, referenceM->kind);
     default:
       assert(false);
   }
@@ -286,29 +286,29 @@ Ref ResilientV3::upcastWeak(
     FunctionState *functionState,
     LLVMBuilderRef builder,
     WeakFatPtrLE sourceRefLE,
-    StructReferend *sourceStructReferendM,
+    StructKind *sourceStructKindM,
     Reference *sourceStructTypeM,
-    InterfaceReferend *targetInterfaceReferendM,
+    InterfaceKind *targetInterfaceKindM,
     Reference *targetInterfaceTypeM) {
   auto resultWeakInterfaceFatPtr =
       hgmWeaks.weakStructPtrToGenWeakInterfacePtr(
-          globalState, functionState, builder, sourceRefLE, sourceStructReferendM,
-          sourceStructTypeM, targetInterfaceReferendM, targetInterfaceTypeM);
+          globalState, functionState, builder, sourceRefLE, sourceStructKindM,
+          sourceStructTypeM, targetInterfaceKindM, targetInterfaceTypeM);
   return wrap(this, targetInterfaceTypeM, resultWeakInterfaceFatPtr);
 }
 
 void ResilientV3::declareStaticSizedArray(
     StaticSizedArrayDefinitionT *staticSizedArrayMT) {
-  globalState->regionIdByReferend.emplace(staticSizedArrayMT->referend, getRegionId());
+  globalState->regionIdByKind.emplace(staticSizedArrayMT->kind, getRegionId());
 
-  referendStructs.declareStaticSizedArray(staticSizedArrayMT);
+  kindStructs.declareStaticSizedArray(staticSizedArrayMT);
 }
 
 void ResilientV3::declareRuntimeSizedArray(
     RuntimeSizedArrayDefinitionT *runtimeSizedArrayMT) {
-  globalState->regionIdByReferend.emplace(runtimeSizedArrayMT->referend, getRegionId());
+  globalState->regionIdByKind.emplace(runtimeSizedArrayMT->kind, getRegionId());
 
-  referendStructs.declareRuntimeSizedArray(runtimeSizedArrayMT);
+  kindStructs.declareRuntimeSizedArray(runtimeSizedArrayMT);
 }
 
 void ResilientV3::defineRuntimeSizedArray(
@@ -316,7 +316,7 @@ void ResilientV3::defineRuntimeSizedArray(
   auto elementLT =
       globalState->getRegion(runtimeSizedArrayMT->rawArray->elementType)
           ->translateType(runtimeSizedArrayMT->rawArray->elementType);
-  referendStructs.defineRuntimeSizedArray(runtimeSizedArrayMT, elementLT);
+  kindStructs.defineRuntimeSizedArray(runtimeSizedArrayMT, elementLT);
 }
 
 void ResilientV3::defineStaticSizedArray(
@@ -324,14 +324,14 @@ void ResilientV3::defineStaticSizedArray(
   auto elementLT =
       globalState->getRegion(staticSizedArrayMT->rawArray->elementType)
           ->translateType(staticSizedArrayMT->rawArray->elementType);
-  referendStructs.defineStaticSizedArray(staticSizedArrayMT, elementLT);
+  kindStructs.defineStaticSizedArray(staticSizedArrayMT, elementLT);
 }
 
 void ResilientV3::declareStruct(
     StructDefinition *structM) {
-  globalState->regionIdByReferend.emplace(structM->referend, getRegionId());
+  globalState->regionIdByKind.emplace(structM->kind, getRegionId());
 
-  referendStructs.declareStruct(structM->referend);
+  kindStructs.declareStruct(structM->kind);
 }
 
 void ResilientV3::defineStruct(StructDefinition *structM) {
@@ -341,27 +341,27 @@ void ResilientV3::defineStruct(StructDefinition *structM) {
         globalState->getRegion(structM->members[i]->type)
             ->translateType(structM->members[i]->type));
   }
-  referendStructs.defineStruct(structM->referend, innerStructMemberTypesL);
+  kindStructs.defineStruct(structM->kind, innerStructMemberTypesL);
 }
 
 void ResilientV3::declareEdge(Edge *edge) {
-  referendStructs.declareEdge(edge);
+  kindStructs.declareEdge(edge);
 }
 
 void ResilientV3::defineEdge(Edge *edge) {
   auto interfaceFunctionsLT = globalState->getInterfaceFunctionTypes(edge->interfaceName);
   auto edgeFunctionsL = globalState->getEdgeFunctions(edge);
-  referendStructs.defineEdge(edge, interfaceFunctionsLT, edgeFunctionsL);
+  kindStructs.defineEdge(edge, interfaceFunctionsLT, edgeFunctionsL);
 }
 
 void ResilientV3::declareInterface(InterfaceDefinition *interfaceM) {
-  globalState->regionIdByReferend.emplace(interfaceM->referend, getRegionId());
-  referendStructs.declareInterface(interfaceM);
+  globalState->regionIdByKind.emplace(interfaceM->kind, getRegionId());
+  kindStructs.declareInterface(interfaceM);
 }
 
 void ResilientV3::defineInterface(InterfaceDefinition *interfaceM) {
-  auto interfaceMethodTypesL = globalState->getInterfaceFunctionTypes(interfaceM->referend);
-  referendStructs.defineInterface(interfaceM, interfaceMethodTypesL);
+  auto interfaceMethodTypesL = globalState->getInterfaceFunctionTypes(interfaceM->kind);
+  kindStructs.defineInterface(interfaceM, interfaceMethodTypesL);
 }
 
 void ResilientV3::discardOwningRef(
@@ -385,7 +385,7 @@ void ResilientV3::noteWeakableDestroyed(
     ControlBlockPtrLE controlBlockPtrLE) {
   if (refM->ownership == Ownership::SHARE) {
     assert(false);
-//    auto rcIsZeroLE = strongRcIsZero(globalState, &referendStructs, builder, refM, controlBlockPtrLE);
+//    auto rcIsZeroLE = strongRcIsZero(globalState, &kindStructs, builder, refM, controlBlockPtrLE);
 //    buildAssert(globalState, functionState, builder, rcIsZeroLE,
 //                "Tried to free concrete that had nonzero RC!");
   } else {
@@ -413,13 +413,13 @@ void ResilientV3::storeMember(
     case Ownership::OWN:
     case Ownership::SHARE: {
       return storeMemberStrong(
-          globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+          globalState, functionState, builder, &kindStructs, structRefMT, structRef,
           structKnownLive, memberIndex, memberName, newMemberLE);
     }
     case Ownership::BORROW:
     case Ownership::WEAK: {
       storeMemberWeak(
-          globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+          globalState, functionState, builder, &kindStructs, structRefMT, structRef,
           structKnownLive, memberIndex, memberName, newMemberLE);
       break;
     }
@@ -439,12 +439,12 @@ std::tuple<LLVMValueRef, LLVMValueRef> ResilientV3::explodeInterfaceRef(
     case Ownership::OWN:
     case Ownership::SHARE: {
       return explodeStrongInterfaceRef(
-          globalState, functionState, builder, &referendStructs, virtualParamMT, virtualArgRef);
+          globalState, functionState, builder, &kindStructs, virtualParamMT, virtualArgRef);
     }
     case Ownership::BORROW:
     case Ownership::WEAK: {
       return explodeWeakInterfaceRef(
-          globalState, functionState, builder, &referendStructs, &fatWeaks, &weakRefStructs,
+          globalState, functionState, builder, &kindStructs, &fatWeaks, &weakRefStructs,
           virtualParamMT, virtualArgRef,
           [this, functionState, builder, virtualParamMT](WeakFatPtrLE weakFatPtrLE) {
             return hgmWeaks.weakInterfaceRefToWeakStructRef(
@@ -465,7 +465,7 @@ Ref ResilientV3::getRuntimeSizedArrayLength(
   switch (rsaRefMT->ownership) {
     case Ownership::SHARE:
     case Ownership::OWN: {
-      return getRuntimeSizedArrayLengthStrong(globalState, functionState, builder, &referendStructs, rsaRefMT, arrayRef);
+      return getRuntimeSizedArrayLengthStrong(globalState, functionState, builder, &kindStructs, rsaRefMT, arrayRef);
     }
     case Ownership::BORROW: {
       auto wrapperPtrLE =
@@ -493,7 +493,7 @@ LLVMValueRef ResilientV3::checkValidReference(
 
   if (globalState->opt->census) {
     if (refM->ownership == Ownership::OWN) {
-      regularCheckValidReference(checkerAFL, globalState, functionState, builder, &referendStructs, refM, refLE);
+      regularCheckValidReference(checkerAFL, globalState, functionState, builder, &kindStructs, refM, refLE);
     } else if (refM->ownership == Ownership::SHARE) {
       assert(false);
     } else {
@@ -580,8 +580,8 @@ LLVMValueRef ResilientV3::getCensusObjectId(
     Reference *refM,
     Ref ref) {
   auto controlBlockPtrLE =
-      referendStructs.getControlBlockPtr(checkerAFL, functionState, builder, ref, refM);
-  return referendStructs.getObjIdFromControlBlockPtr(builder, refM->referend, controlBlockPtrLE);
+      kindStructs.getControlBlockPtr(checkerAFL, functionState, builder, ref, refM);
+  return kindStructs.getObjIdFromControlBlockPtr(builder, refM->kind, controlBlockPtrLE);
 }
 
 Ref ResilientV3::getIsAliveFromWeakRef(
@@ -598,12 +598,12 @@ void ResilientV3::fillControlBlock(
     AreaAndFileAndLine from,
     FunctionState *functionState,
     LLVMBuilderRef builder,
-    Referend *referendM,
+    Kind *kindM,
     ControlBlockPtrLE controlBlockPtrLE,
     const std::string &typeName) {
 
   gmFillControlBlock(
-      from, globalState, functionState, &referendStructs, builder, referendM, controlBlockPtrLE,
+      from, globalState, functionState, &kindStructs, builder, kindM, controlBlockPtrLE,
       typeName, &hgmWeaks);
 }
 
@@ -615,10 +615,10 @@ LoadResult ResilientV3::loadElementFromSSA(
     Ref arrayRef,
     bool arrayKnownLive,
     Ref indexRef) {
-  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT->name);
+  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT);
   return resilientloadElementFromSSA(
       globalState, functionState, builder, ssaRefMT, ssaMT, ssaDef->size, ssaDef->rawArray->mutability,
-      ssaDef->rawArray->elementType, arrayRef, arrayKnownLive, indexRef, &referendStructs);
+      ssaDef->rawArray->elementType, arrayRef, arrayKnownLive, indexRef, &kindStructs);
 }
 
 LoadResult ResilientV3::loadElementFromRSA(
@@ -629,9 +629,9 @@ LoadResult ResilientV3::loadElementFromRSA(
     Ref arrayRef,
     bool arrayKnownLive,
     Ref indexRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   return resilientLoadElementFromRSAWithoutUpgrade(
-      globalState, functionState, builder, &referendStructs, rsaRefMT, rsaDef->rawArray->mutability,
+      globalState, functionState, builder, &kindStructs, rsaRefMT, rsaDef->rawArray->mutability,
       rsaDef->rawArray->elementType, rsaMT, arrayRef, arrayKnownLive, indexRef);
 }
 
@@ -644,7 +644,7 @@ Ref ResilientV3::storeElementInRSA(
     bool arrayKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   auto arrayWrapperPtrLE = lockWeakRef(FL(), functionState, builder, rsaRefMT, arrayRef, arrayKnownLive);
   auto sizeRef = ::getRuntimeSizedArrayLength(globalState, functionState, builder, arrayWrapperPtrLE);
   auto arrayElementsPtrLE = getRuntimeSizedArrayContentsPtr(builder, arrayWrapperPtrLE);
@@ -660,22 +660,22 @@ Ref ResilientV3::upcast(
     LLVMBuilderRef builder,
 
     Reference *sourceStructMT,
-    StructReferend *sourceStructReferendM,
+    StructKind *sourceStructKindM,
     Ref sourceRefLE,
 
     Reference *targetInterfaceTypeM,
-    InterfaceReferend *targetInterfaceReferendM) {
+    InterfaceKind *targetInterfaceKindM) {
 
   switch (sourceStructMT->ownership) {
     case Ownership::SHARE:
     case Ownership::OWN: {
-      return upcastStrong(globalState, functionState, builder, &referendStructs, sourceStructMT, sourceStructReferendM,
-                          sourceRefLE, targetInterfaceTypeM, targetInterfaceReferendM);
+      return upcastStrong(globalState, functionState, builder, &kindStructs, sourceStructMT, sourceStructKindM,
+                          sourceRefLE, targetInterfaceTypeM, targetInterfaceKindM);
     }
     case Ownership::BORROW:
     case Ownership::WEAK: {
-      return ::upcastWeak(globalState, functionState, builder, &weakRefStructs, sourceStructMT, sourceStructReferendM,
-                          sourceRefLE, targetInterfaceTypeM, targetInterfaceReferendM);
+      return ::upcastWeak(globalState, functionState, builder, &weakRefStructs, sourceStructMT, sourceStructKindM,
+                          sourceRefLE, targetInterfaceTypeM, targetInterfaceKindM);
     }
     default:
       assert(false);
@@ -690,7 +690,7 @@ void ResilientV3::deallocate(
     LLVMBuilderRef builder,
     Reference *refMT,
     Ref ref) {
-  innerDeallocate(from, globalState, functionState, &referendStructs, builder, refMT, ref);
+  innerDeallocate(from, globalState, functionState, &kindStructs, builder, refMT, ref);
 }
 
 Ref ResilientV3::constructRuntimeSizedArray(
@@ -702,13 +702,13 @@ Ref ResilientV3::constructRuntimeSizedArray(
     Ref sizeRef,
     const std::string &typeName) {
   auto rsaWrapperPtrLT =
-      referendStructs.getRuntimeSizedArrayWrapperStruct(runtimeSizedArrayT);
-  auto rsaDef = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT->name);
-  auto elementType = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT->name)->rawArray->elementType;
+      kindStructs.getRuntimeSizedArrayWrapperStruct(runtimeSizedArrayT);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT);
+  auto elementType = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT)->rawArray->elementType;
   auto rsaElementLT = globalState->getRegion(elementType)->translateType(elementType);
   auto resultRef =
       ::constructRuntimeSizedArray(
-          globalState, functionState, builder, &referendStructs, rsaMT, rsaDef->rawArray->elementType,
+          globalState, functionState, builder, &kindStructs, rsaMT, rsaDef->rawArray->elementType,
           runtimeSizedArrayT,
           rsaWrapperPtrLT, rsaElementLT, sizeRef, typeName,
           [this, functionState, runtimeSizedArrayT, typeName](
@@ -746,7 +746,7 @@ Ref ResilientV3::loadMember(
         case Ownership::SHARE: {
           auto unupgradedMemberLE =
               regularLoadMember(
-                  globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+                  globalState, functionState, builder, &kindStructs, structRefMT, structRef,
                   memberIndex, expectedMemberType, targetType, memberName);
           return upgradeLoadResultToRefWithTargetOwnership(
               functionState, builder, expectedMemberType, targetType, unupgradedMemberLE);
@@ -755,7 +755,7 @@ Ref ResilientV3::loadMember(
         case Ownership::WEAK: {
           auto memberLE =
               resilientLoadWeakMember(
-                  globalState, functionState, builder, &referendStructs, structRefMT,
+                  globalState, functionState, builder, &kindStructs, structRefMT,
                   structRef,
                   structKnownLive, memberIndex, expectedMemberType, memberName);
           auto resultRef =
@@ -776,96 +776,82 @@ void ResilientV3::checkInlineStructType(
     Reference *refMT,
     Ref ref) {
   auto argLE = checkValidReference(FL(), functionState, builder, refMT, ref);
-  auto structReferend = dynamic_cast<StructReferend *>(refMT->referend);
-  assert(structReferend);
-  assert(LLVMTypeOf(argLE) == referendStructs.getInnerStruct(structReferend));
+  auto structKind = dynamic_cast<StructKind *>(refMT->kind);
+  assert(structKind);
+  assert(LLVMTypeOf(argLE) == kindStructs.getInnerStruct(structKind));
 }
 
 
-std::string ResilientV3::getMemberArbitraryRefNameCSeeMMEDT(Reference *refMT) {
-  if (refMT->ownership == Ownership::SHARE) {
-    assert(false);
-  } else if (auto structRefMT = dynamic_cast<StructReferend *>(refMT->referend)) {
-    auto structMT = globalState->program->getStruct(structRefMT->fullName);
-    auto baseName = globalState->program->getMemberArbitraryExportNameSeeMMEDT(structRefMT->fullName);
-    if (structMT->mutability == Mutability::MUTABLE) {
-      assert(refMT->location != Location::INLINE);
-      return baseName + "Ref";
-    } else {
-      if (refMT->location == Location::INLINE) {
-        return baseName + "Inl";
-      } else {
-        return baseName + "Ref";
-      }
-    }
-  } else if (auto interfaceMT = dynamic_cast<InterfaceReferend *>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(interfaceMT->fullName) + "Ref";
-  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(rsaMT->name) + "Ref";
-  } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(ssaMT->name) + "Ref";
-  } else {
-    assert(false);
-  }
-}
+//std::string ResilientV3::getMemberArbitraryRefNameCSeeMMEDT(Reference *refMT) {
+//  if (refMT->ownership == Ownership::SHARE) {
+//    assert(false);
+//  } else if (auto structRefMT = dynamic_cast<StructKind *>(refMT->kind)) {
+//    auto structMT = globalState->program->getStruct(structRefMT);
+//    auto baseName = globalState->program->getMemberArbitraryExportNameSeeMMEDT(structRefMT->fullName);
+//    if (structMT->mutability == Mutability::MUTABLE) {
+//      assert(refMT->location != Location::INLINE);
+//      return baseName + "Ref";
+//    } else {
+//      if (refMT->location == Location::INLINE) {
+//        return baseName + "Inl";
+//      } else {
+//        return baseName + "Ref";
+//      }
+//    }
+//  } else if (auto interfaceMT = dynamic_cast<InterfaceKind *>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(interfaceMT->fullName) + "Ref";
+//  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(rsaMT->name) + "Ref";
+//  } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(ssaMT->name) + "Ref";
+//  } else {
+//    assert(false);
+//  }
+//}
 
-void ResilientV3::generateRuntimeSizedArrayDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName,
+std::string ResilientV3::generateRuntimeSizedArrayDefsC(
+    Package* currentPackage,
     RuntimeSizedArrayDefinitionT* rsaDefM) {
   if (rsaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto baseName : globalState->program->getExportedNames(rsaDefM->name)) {
-      auto refTypeName = baseName + "Ref";
-      std::stringstream s;
-      s << "typedef struct " << refTypeName << " { uint64_t unused0; void* unused; } " << refTypeName << ";" << std::endl;
-      cByExportedName->insert(std::make_pair(baseName, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(rsaDefM->kind);
+    return std::string() + "typedef struct " + name + "Ref { uint64_t unused0; void* unused; } " + name + "Ref;\n";
   }
 }
 
-void ResilientV3::generateStaticSizedArrayDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName,
+std::string ResilientV3::generateStaticSizedArrayDefsC(
+    Package* currentPackage,
     StaticSizedArrayDefinitionT* ssaDefM) {
   if (ssaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto baseName : globalState->program->getExportedNames(ssaDefM->name)) {
-      auto refTypeName = baseName + "Ref";
-      std::stringstream s;
-      s << "typedef struct " << refTypeName << " { uint64_t unused0; void* unused; } " << refTypeName << ";" << std::endl;
-      cByExportedName->insert(std::make_pair(baseName, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(ssaDefM->kind);
+    return std::string() + "typedef struct " + name + "Ref { uint64_t unused0; void* unused; } " + name + "Ref;\n";
   }
 }
 
-void ResilientV3::generateStructDefsC(
-    std::unordered_map<std::string, std::string> *cByExportedName, StructDefinition *structDefM) {
+std::string ResilientV3::generateStructDefsC(
+    Package* currentPackage,
+    StructDefinition *structDefM) {
 
   if (structDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto baseName : globalState->program->getExportedNames(structDefM->referend->fullName)) {
-      auto refTypeName = baseName + "Ref";
-      std::stringstream s;
-      s << "typedef struct " << refTypeName << " { uint64_t unused0; void* unused1; } " << refTypeName << ";"
-        << std::endl;
-      cByExportedName->insert(std::make_pair(baseName, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(structDefM->kind);
+    return std::string() + "typedef struct " + name + "Ref { uint64_t unused0; void* unused; } " + name + "Ref;\n";
   }
 }
 
-void ResilientV3::generateInterfaceDefsC(
-    std::unordered_map<std::string, std::string> *cByExportedName, InterfaceDefinition *interfaceDefM) {
+std::string ResilientV3::generateInterfaceDefsC(
+    Package* currentPackage,
+    InterfaceDefinition *interfaceDefM) {
 
   if (interfaceDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto name : globalState->program->getExportedNames(interfaceDefM->referend->fullName)) {
-      std::stringstream s;
-      s << "typedef struct " << name << "Ref { uint64_t unused0; void* unused1; void* unused2; } " << name << "Ref;";
-      cByExportedName->insert(std::make_pair(name, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(interfaceDefM->kind);
+    return std::string() + "typedef struct " + name + "Ref { uint64_t unused0; void* unused1; void* unused2; } " + name + "Ref;\n";
   }
 }
 
@@ -897,7 +883,7 @@ LLVMTypeRef ResilientV3::getInterfaceMethodVirtualParamAnyType(Reference *refere
       return LLVMPointerType(LLVMInt8TypeInContext(globalState->context), 0);
     case Ownership::BORROW:
     case Ownership::WEAK:
-      return weakRefStructs.getWeakVoidRefStruct(reference->referend);
+      return weakRefStructs.getWeakVoidRefStruct(reference->kind);
   }
 }
 
@@ -929,7 +915,7 @@ void ResilientV3::initializeElementInRSA(
     bool arrayRefKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  ::initializeElementInRSA(globalState, functionState, builder, &referendStructs, rsaMT, rsaRefMT, rsaRef, indexRef,
+  ::initializeElementInRSA(globalState, functionState, builder, &kindStructs, rsaMT, rsaRefMT, rsaRef, indexRef,
                            elementRef);
 }
 
@@ -941,9 +927,9 @@ Ref ResilientV3::deinitializeElementFromRSA(
     Ref arrayRef,
     bool arrayRefKnownLive,
     Ref indexRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   return resilientLoadElementFromRSAWithoutUpgrade(
-      globalState, functionState, builder, &referendStructs, rsaRefMT, rsaDef->rawArray->mutability,
+      globalState, functionState, builder, &kindStructs, rsaRefMT, rsaDef->rawArray->mutability,
       rsaDef->rawArray->elementType, rsaMT, arrayRef, true, indexRef).move();
 }
 
@@ -956,9 +942,9 @@ void ResilientV3::initializeElementInSSA(
     bool arrayRefKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT->name);
+  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT);
   auto arrayWrapperPtrLE =
-      referendStructs.makeWrapperPtr(
+      kindStructs.makeWrapperPtr(
           FL(), functionState, builder, ssaRefMT,
           globalState->getRegion(ssaRefMT)->checkValidReference(FL(), functionState, builder, ssaRefMT, arrayRef));
   auto sizeRef = globalState->constI64(ssaDef->size);
@@ -979,11 +965,11 @@ Ref ResilientV3::deinitializeElementFromSSA(
   exit(1);
 }
 
-Weakability ResilientV3::getReferendWeakability(Referend *referend) {
-  if (auto structReferend = dynamic_cast<StructReferend *>(referend)) {
-    return globalState->lookupStruct(structReferend->fullName)->weakability;
-  } else if (auto interfaceReferend = dynamic_cast<InterfaceReferend *>(referend)) {
-    return globalState->lookupInterface(interfaceReferend->fullName)->weakability;
+Weakability ResilientV3::getKindWeakability(Kind *kind) {
+  if (auto structKind = dynamic_cast<StructKind *>(kind)) {
+    return globalState->lookupStruct(structKind)->weakability;
+  } else if (auto interfaceKind = dynamic_cast<InterfaceKind *>(kind)) {
+    return globalState->lookupInterface(interfaceKind)->weakability;
   } else {
     return Weakability::NON_WEAKABLE;
   }
@@ -1020,4 +1006,10 @@ Ref ResilientV3::loadLocal(FunctionState* functionState, LLVMBuilderRef builder,
 
 Ref ResilientV3::localStore(FunctionState* functionState, LLVMBuilderRef builder, Local* local, LLVMValueRef localAddr, Ref refToStore, bool knownLive) {
   return normalLocalStore(globalState, functionState, builder, local, localAddr, refToStore);
+}
+
+std::string ResilientV3::getExportName(
+    Package* package,
+    Reference* reference) {
+  return package->getKindExportName(reference->kind) + (reference->location == Location::YONDER ? "Ref" : "");
 }

--- a/Midas/src/c-compiler/region/resilientv3/resilientv3.h
+++ b/Midas/src/c-compiler/region/resilientv3/resilientv3.h
@@ -423,7 +423,7 @@ public:
 
 
 
-  std::string getExportName(Package* currentPackage, Reference* refMT) override;
+  std::string getExportName(Package* currentPackage, Reference* refMT, bool includeProjectName) override;
   std::string generateStructDefsC(
     Package* currentPackage,
       StructDefinition* refMT) override;

--- a/Midas/src/c-compiler/region/resilientv3/resilientv3.h
+++ b/Midas/src/c-compiler/region/resilientv3/resilientv3.h
@@ -43,9 +43,9 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       WeakFatPtrLE sourceRefLE,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Reference* sourceStructTypeM,
-      InterfaceReferend* targetInterfaceReferendM,
+      InterfaceKind* targetInterfaceKindM,
       Reference* targetInterfaceTypeM) override;
 
   Ref upcast(
@@ -53,11 +53,11 @@ public:
       LLVMBuilderRef builder,
 
       Reference* sourceStructMT,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Ref sourceRefLE,
 
       Reference* targetInterfaceTypeM,
-      InterfaceReferend* targetInterfaceReferendM) override;
+      InterfaceKind* targetInterfaceKindM) override;
 
 
   void defineStaticSizedArray(
@@ -104,7 +104,7 @@ public:
       Reference* sourceInterfaceRefMT,
       Ref sourceInterfaceRefLE,
       bool sourceRefKnownLive,
-      Referend* targetReferend,
+      Kind* targetKind,
       std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
       std::function<Ref(LLVMBuilderRef)> buildElse) override;
 
@@ -115,7 +115,7 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       Reference* referenceM,
-      StaticSizedArrayT* referendM) override;
+      StaticSizedArrayT* kindM) override;
 
   // should expose a dereference thing instead
 //  LLVMValueRef getStaticSizedArrayElementsPtr(
@@ -367,7 +367,7 @@ public:
 //      FunctionState* functionState,
 //      LLVMBuilderRef builder,
 //      Location location,
-//      LLVMTypeRef referendLT) override;
+//      LLVMTypeRef kindLT) override;
 
 //  LLVMValueRef mallocRuntimeSizedArray(
 //      LLVMBuilderRef builder,
@@ -380,58 +380,62 @@ public:
 //    return mutWeakableStructs.makeWeakFatPtr(referenceM_, ptrLE);
 //  }
   // TODO get rid of these once refactor is done
-//  ControlBlock* getControlBlock(Referend* referend) override {
-//    return referendStructs.getControlBlock(referend);
+//  ControlBlock* getControlBlock(Kind* kind) override {
+//    return kindStructs.getControlBlock(kind);
 //  }
-//  IReferendStructsSource* getReferendStructsSource() override {
-//    return &referendStructs;
+//  IKindStructsSource* getKindStructsSource() override {
+//    return &kindStructs;
 //  }
 //  IWeakRefStructsSource* getWeakRefStructsSource() override {
 //    return &weakRefStructs;
 //  }
   LLVMValueRef getStringBytesPtr(FunctionState* functionState, LLVMBuilderRef builder, Ref ref) override {
     auto strWrapperPtrLE =
-        referendStructs.makeWrapperPtr(
+        kindStructs.makeWrapperPtr(
             FL(), functionState, builder,
             globalState->metalCache->strRef,
             checkValidReference(
                 FL(), functionState, builder, globalState->metalCache->strRef, ref));
-    return referendStructs.getStringBytesPtr(functionState, builder, strWrapperPtrLE);
+    return kindStructs.getStringBytesPtr(functionState, builder, strWrapperPtrLE);
   }
   LLVMValueRef getStringLen(FunctionState* functionState, LLVMBuilderRef builder, Ref ref) override {
     auto strWrapperPtrLE =
-        referendStructs.makeWrapperPtr(
+        kindStructs.makeWrapperPtr(
             FL(), functionState, builder,
             globalState->metalCache->strRef,
             checkValidReference(
                 FL(), functionState, builder, globalState->metalCache->strRef, ref));
-    return referendStructs.getStringLen(functionState, builder, strWrapperPtrLE);
+    return kindStructs.getStringLen(functionState, builder, strWrapperPtrLE);
   }
-//  LLVMTypeRef getWeakRefHeaderStruct(Referend* referend) override {
-//    return mutWeakableStructs.getWeakRefHeaderStruct(referend);
+//  LLVMTypeRef getWeakRefHeaderStruct(Kind* kind) override {
+//    return mutWeakableStructs.getWeakRefHeaderStruct(kind);
 //  }
-//  LLVMTypeRef getWeakVoidRefStruct(Referend* referend) override {
-//    return mutWeakableStructs.getWeakVoidRefStruct(referend);
+//  LLVMTypeRef getWeakVoidRefStruct(Kind* kind) override {
+//    return mutWeakableStructs.getWeakVoidRefStruct(kind);
 //  }
   void fillControlBlock(
       AreaAndFileAndLine from,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       ControlBlockPtrLE controlBlockPtrLE,
       const std::string& typeName);
 
 
-  std::string getMemberArbitraryRefNameCSeeMMEDT(
-      Reference* refMT) override;
-  void generateStructDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StructDefinition* refMT) override;
-  void generateInterfaceDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, InterfaceDefinition* refMT) override;
-  void generateStaticSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StaticSizedArrayDefinitionT* ssaDefM) override;
-  void generateRuntimeSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, RuntimeSizedArrayDefinitionT* rsaDefM) override;
+
+  std::string getExportName(Package* currentPackage, Reference* refMT) override;
+  std::string generateStructDefsC(
+    Package* currentPackage,
+      StructDefinition* refMT) override;
+  std::string generateInterfaceDefsC(
+    Package* currentPackage,
+      InterfaceDefinition* refMT) override;
+  std::string generateStaticSizedArrayDefsC(
+    Package* currentPackage,
+      StaticSizedArrayDefinitionT* ssaDefM) override;
+  std::string generateRuntimeSizedArrayDefsC(
+    Package* currentPackage,
+      RuntimeSizedArrayDefinitionT* rsaDefM) override;
 
   Reference* getExternalType(Reference* refMT) override;
 
@@ -464,7 +468,7 @@ public:
   void declareExtraFunctions() override {}
   void defineExtraFunctions() override {}
 
-  Weakability getReferendWeakability(Referend* referend) override;
+  Weakability getKindWeakability(Kind* kind) override;
 
   void declareStructExtraFunctions(StructDefinition* structDefM) override {}
   void declareStaticSizedArrayExtraFunctions(StaticSizedArrayDefinitionT* ssaDef) override {}
@@ -486,15 +490,15 @@ protected:
 
   RegionId* regionId;
 
-  WeakableReferendStructs mutWeakableStructs;
+  WeakableKindStructs mutWeakableStructs;
 
-  ReferendStructsRouter referendStructs;
+  KindStructsRouter kindStructs;
   WeakRefStructsRouter weakRefStructs;
 
   FatWeaks fatWeaks;
   HybridGenerationalMemory hgmWeaks;
 
-  // TODO see if we can just use referendStructs/weakRefStructs instead of having these?
+  // TODO see if we can just use kindStructs/weakRefStructs instead of having these?
 //  WeakFatPtrLEMaker weakFatPtrMaker;
 //  InterfaceFatPtrLEMaker interfaceFatPtrMaker;
 //  ControlBlockPtrLEMaker controlBlockPtrMaker;

--- a/Midas/src/c-compiler/region/resilientv4/resilientv4.cpp
+++ b/Midas/src/c-compiler/region/resilientv4/resilientv4.cpp
@@ -27,11 +27,13 @@ ControlBlock makeResilientV4WeakableControlBlock(GlobalState* globalState) {
   return controlBlock;
 }
 
-StructReferend* makeAny(GlobalState* globalState, RegionId* regionId) {
-  auto structReferend = globalState->metalCache->getStructReferend(globalState->metalCache->getName("__ValeHGMV4_Any"));
-  auto iter = globalState->regionIdByReferend.emplace(structReferend, regionId).first;
-  assert(globalState->regionIdByReferend[structReferend] == regionId);
-  return structReferend;
+StructKind* makeAny(GlobalState* globalState, RegionId* regionId) {
+  auto structKind =
+      globalState->metalCache->getStructKind(
+          globalState->metalCache->getName(globalState->metalCache->builtinPackageCoord, "__ValeHGMV4_Any"));
+  auto iter = globalState->regionIdByKind.emplace(structKind, regionId).first;
+  assert(globalState->regionIdByKind[structKind] == regionId);
+  return structKind;
 }
 
 ResilientV4::ResilientV4(GlobalState *globalState_, RegionId *regionId_) :
@@ -41,21 +43,21 @@ ResilientV4::ResilientV4(GlobalState *globalState_, RegionId *regionId_) :
         globalState,
         makeResilientV4WeakableControlBlock(globalState),
         HybridGenerationalMemory::makeWeakRefHeaderStruct(globalState, regionId)),
-    referendStructs(
-        globalState, [this](Referend *referend) -> IReferendStructsSource * { return &mutWeakableStructs; }),
-    weakRefStructs([this](Referend *referend) -> IWeakRefStructsSource * { return &mutWeakableStructs; }),
+    kindStructs(
+        globalState, [this](Kind *kind) -> IKindStructsSource * { return &mutWeakableStructs; }),
+    weakRefStructs([this](Kind *kind) -> IWeakRefStructsSource * { return &mutWeakableStructs; }),
     fatWeaks(globalState_, &weakRefStructs),
     anyMT(makeAny(globalState, regionId)),
     hgmWeaks(
         globalState_,
         mutWeakableStructs.getControlBlock(),
-        &referendStructs,
+        &kindStructs,
         &weakRefStructs,
         globalState->opt->elideChecksForKnownLive,
         false,
         anyMT) {
-  referendStructs.declareStruct(anyMT);
-  referendStructs.defineStruct(anyMT, {});
+  kindStructs.declareStruct(anyMT);
+  kindStructs.defineStruct(anyMT, {});
 }
 
 void ResilientV4::mainSetup(FunctionState* functionState, LLVMBuilderRef builder) {
@@ -75,20 +77,20 @@ Ref ResilientV4::constructStaticSizedArray(
     FunctionState *functionState,
     LLVMBuilderRef builder,
     Reference *referenceM,
-    StaticSizedArrayT *referendM) {
-  auto ssaDef = globalState->program->getStaticSizedArray(referendM->name);
+    StaticSizedArrayT *kindM) {
+  auto ssaDef = globalState->program->getStaticSizedArray(kindM);
   auto resultRef =
       ::constructStaticSizedArray(
-          globalState, functionState, builder, referenceM, referendM, &referendStructs,
-          [this, functionState, referenceM, referendM](LLVMBuilderRef innerBuilder,
+          globalState, functionState, builder, referenceM, kindM, &kindStructs,
+          [this, functionState, referenceM, kindM](LLVMBuilderRef innerBuilder,
                                                        ControlBlockPtrLE controlBlockPtrLE) {
             fillControlBlock(
                 FL(),
                 functionState,
                 innerBuilder,
-                referenceM->referend,
+                referenceM->kind,
                 controlBlockPtrLE,
-                referendM->name->name);
+                kindM->name->name);
           });
   // We dont increment here, see SRCAO
   return resultRef;
@@ -111,16 +113,16 @@ Ref ResilientV4::allocate(
     LLVMBuilderRef builder,
     Reference *desiredReference,
     const std::vector<Ref> &memberRefs) {
-  auto structReferend = dynamic_cast<StructReferend *>(desiredReference->referend);
-  auto structM = globalState->program->getStruct(structReferend->fullName);
+  auto structKind = dynamic_cast<StructKind *>(desiredReference->kind);
+  auto structM = globalState->program->getStruct(structKind);
   auto resultRef =
       innerAllocate(
-          FL(), globalState, functionState, builder, desiredReference, &referendStructs, memberRefs,
+          FL(), globalState, functionState, builder, desiredReference, &kindStructs, memberRefs,
           Weakability::WEAKABLE,
           [this, functionState, desiredReference, structM](LLVMBuilderRef innerBuilder,
                                                            ControlBlockPtrLE controlBlockPtrLE) {
             fillControlBlock(
-                FL(), functionState, innerBuilder, desiredReference->referend,
+                FL(), functionState, innerBuilder, desiredReference->kind,
                 controlBlockPtrLE, structM->name->name);
           });
   return resultRef;
@@ -132,14 +134,14 @@ void ResilientV4::alias(
     LLVMBuilderRef builder,
     Reference *sourceRef,
     Ref expr) {
-  auto sourceRnd = sourceRef->referend;
+  auto sourceRnd = sourceRef->kind;
 
   if (dynamic_cast<Int *>(sourceRnd) ||
       dynamic_cast<Bool *>(sourceRnd) ||
       dynamic_cast<Float *>(sourceRnd)) {
     // Do nothing for these, they're always inlined and copied.
-  } else if (dynamic_cast<InterfaceReferend *>(sourceRnd) ||
-             dynamic_cast<StructReferend *>(sourceRnd) ||
+  } else if (dynamic_cast<InterfaceKind *>(sourceRnd) ||
+             dynamic_cast<StructKind *>(sourceRnd) ||
              dynamic_cast<StaticSizedArrayT *>(sourceRnd) ||
              dynamic_cast<RuntimeSizedArrayT *>(sourceRnd) ||
              dynamic_cast<Str *>(sourceRnd)) {
@@ -153,13 +155,13 @@ void ResilientV4::alias(
       if (sourceRef->location == Location::INLINE) {
         // Do nothing, we can just let inline structs disappear
       } else {
-        adjustStrongRc(from, globalState, functionState, &referendStructs, builder, expr, sourceRef, 1);
+        adjustStrongRc(from, globalState, functionState, &kindStructs, builder, expr, sourceRef, 1);
       }
     } else
       assert(false);
   } else {
     std::cerr << "Unimplemented type in acquireReference: "
-              << typeid(*sourceRef->referend).name() << std::endl;
+              << typeid(*sourceRef->kind).name() << std::endl;
     assert(false);
   }
 }
@@ -170,7 +172,7 @@ void ResilientV4::dealias(
     LLVMBuilderRef builder,
     Reference *sourceMT,
     Ref sourceRef) {
-  auto sourceRnd = sourceMT->referend;
+  auto sourceRnd = sourceMT->kind;
 
   if (sourceMT->ownership == Ownership::SHARE) {
     assert(false);
@@ -208,7 +210,7 @@ WrapperPtrLE ResilientV4::lockWeakRef(
       auto weakFatPtrLE =
           checkValidReference(
               FL(), functionState, builder, refM, weakRefLE);
-      return referendStructs.makeWrapperPtr(FL(), functionState, builder, refM, weakFatPtrLE);
+      return kindStructs.makeWrapperPtr(FL(), functionState, builder, refM, weakFatPtrLE);
     }
     case Ownership::BORROW:
     case Ownership::WEAK: {
@@ -217,7 +219,7 @@ WrapperPtrLE ResilientV4::lockWeakRef(
               refM,
               checkValidReference(
                   FL(), functionState, builder, refM, weakRefLE));
-      return referendStructs.makeWrapperPtr(
+      return kindStructs.makeWrapperPtr(
           FL(), functionState, builder, refM,
           hgmWeaks.lockGenFatPtr(
               from, functionState, builder, refM, weakFatPtrLE, weakRefKnownLive));
@@ -263,17 +265,17 @@ Ref ResilientV4::asSubtype(
     Reference* sourceInterfaceRefMT,
     Ref sourceInterfaceRef,
     bool sourceRefKnownLive,
-    Referend* targetReferend,
+    Kind* targetKind,
     std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
     std::function<Ref(LLVMBuilderRef)> buildElse) {
-  auto targetStructReferend = dynamic_cast<StructReferend*>(targetReferend);
-  assert(targetStructReferend);
-  auto sourceInterfaceReferend = dynamic_cast<InterfaceReferend*>(sourceInterfaceRefMT->referend);
-  assert(sourceInterfaceReferend);
+  auto targetStructKind = dynamic_cast<StructKind*>(targetKind);
+  assert(targetStructKind);
+  auto sourceInterfaceKind = dynamic_cast<InterfaceKind*>(sourceInterfaceRefMT->kind);
+  assert(sourceInterfaceKind);
 
   return resilientDowncast(
       globalState, functionState, builder, &weakRefStructs, resultOptTypeM, sourceInterfaceRefMT, sourceInterfaceRef,
-      targetReferend, buildThen, buildElse, targetStructReferend, sourceInterfaceReferend);
+      targetKind, buildThen, buildElse, targetStructKind, sourceInterfaceKind);
 }
 
 LLVMTypeRef ResilientV4::translateType(Reference *referenceM) {
@@ -282,18 +284,18 @@ LLVMTypeRef ResilientV4::translateType(Reference *referenceM) {
       assert(false);
     case Ownership::OWN:
       if (referenceM->location == Location::INLINE) {
-        if (auto structReferend = dynamic_cast<StructReferend *>(referenceM->referend)) {
-          return referendStructs.getWrapperStruct(structReferend);
+        if (auto structKind = dynamic_cast<StructKind *>(referenceM->kind)) {
+          return kindStructs.getWrapperStruct(structKind);
         } else {
           assert(false);
         }
       } else {
-        return translateReferenceSimple(globalState, &referendStructs, referenceM->referend);
+        return translateReferenceSimple(globalState, &kindStructs, referenceM->kind);
       }
     case Ownership::BORROW:
     case Ownership::WEAK:
       assert(referenceM->location != Location::INLINE);
-      return translateWeakReference(globalState, &weakRefStructs, referenceM->referend);
+      return translateWeakReference(globalState, &weakRefStructs, referenceM->kind);
     default:
       assert(false);
   }
@@ -303,29 +305,29 @@ Ref ResilientV4::upcastWeak(
     FunctionState *functionState,
     LLVMBuilderRef builder,
     WeakFatPtrLE sourceRefLE,
-    StructReferend *sourceStructReferendM,
+    StructKind *sourceStructKindM,
     Reference *sourceStructTypeM,
-    InterfaceReferend *targetInterfaceReferendM,
+    InterfaceKind *targetInterfaceKindM,
     Reference *targetInterfaceTypeM) {
   auto resultWeakInterfaceFatPtr =
       hgmWeaks.weakStructPtrToGenWeakInterfacePtr(
-          globalState, functionState, builder, sourceRefLE, sourceStructReferendM,
-          sourceStructTypeM, targetInterfaceReferendM, targetInterfaceTypeM);
+          globalState, functionState, builder, sourceRefLE, sourceStructKindM,
+          sourceStructTypeM, targetInterfaceKindM, targetInterfaceTypeM);
   return wrap(this, targetInterfaceTypeM, resultWeakInterfaceFatPtr);
 }
 
 void ResilientV4::declareStaticSizedArray(
     StaticSizedArrayDefinitionT *staticSizedArrayMT) {
-  globalState->regionIdByReferend.emplace(staticSizedArrayMT->referend, getRegionId());
+  globalState->regionIdByKind.emplace(staticSizedArrayMT->kind, getRegionId());
 
-  referendStructs.declareStaticSizedArray(staticSizedArrayMT);
+  kindStructs.declareStaticSizedArray(staticSizedArrayMT);
 }
 
 void ResilientV4::declareRuntimeSizedArray(
     RuntimeSizedArrayDefinitionT *runtimeSizedArrayMT) {
-  globalState->regionIdByReferend.emplace(runtimeSizedArrayMT->referend, getRegionId());
+  globalState->regionIdByKind.emplace(runtimeSizedArrayMT->kind, getRegionId());
 
-  referendStructs.declareRuntimeSizedArray(runtimeSizedArrayMT);
+  kindStructs.declareRuntimeSizedArray(runtimeSizedArrayMT);
 }
 
 void ResilientV4::defineRuntimeSizedArray(
@@ -333,7 +335,7 @@ void ResilientV4::defineRuntimeSizedArray(
   auto elementLT =
       globalState->getRegion(runtimeSizedArrayMT->rawArray->elementType)
           ->translateType(runtimeSizedArrayMT->rawArray->elementType);
-  referendStructs.defineRuntimeSizedArray(runtimeSizedArrayMT, elementLT);
+  kindStructs.defineRuntimeSizedArray(runtimeSizedArrayMT, elementLT);
 }
 
 void ResilientV4::defineStaticSizedArray(
@@ -341,14 +343,14 @@ void ResilientV4::defineStaticSizedArray(
   auto elementLT =
       globalState->getRegion(staticSizedArrayMT->rawArray->elementType)
           ->translateType(staticSizedArrayMT->rawArray->elementType);
-  referendStructs.defineStaticSizedArray(staticSizedArrayMT, elementLT);
+  kindStructs.defineStaticSizedArray(staticSizedArrayMT, elementLT);
 }
 
 void ResilientV4::declareStruct(
     StructDefinition *structM) {
-  globalState->regionIdByReferend.emplace(structM->referend, getRegionId());
+  globalState->regionIdByKind.emplace(structM->kind, getRegionId());
 
-  referendStructs.declareStruct(structM->referend);
+  kindStructs.declareStruct(structM->kind);
 }
 
 void ResilientV4::defineStruct(StructDefinition *structM) {
@@ -358,27 +360,27 @@ void ResilientV4::defineStruct(StructDefinition *structM) {
         globalState->getRegion(structM->members[i]->type)
             ->translateType(structM->members[i]->type));
   }
-  referendStructs.defineStruct(structM->referend, innerStructMemberTypesL);
+  kindStructs.defineStruct(structM->kind, innerStructMemberTypesL);
 }
 
 void ResilientV4::declareEdge(Edge *edge) {
-  referendStructs.declareEdge(edge);
+  kindStructs.declareEdge(edge);
 }
 
 void ResilientV4::defineEdge(Edge *edge) {
   auto interfaceFunctionsLT = globalState->getInterfaceFunctionTypes(edge->interfaceName);
   auto edgeFunctionsL = globalState->getEdgeFunctions(edge);
-  referendStructs.defineEdge(edge, interfaceFunctionsLT, edgeFunctionsL);
+  kindStructs.defineEdge(edge, interfaceFunctionsLT, edgeFunctionsL);
 }
 
 void ResilientV4::declareInterface(InterfaceDefinition *interfaceM) {
-  globalState->regionIdByReferend.emplace(interfaceM->referend, getRegionId());
-  referendStructs.declareInterface(interfaceM);
+  globalState->regionIdByKind.emplace(interfaceM->kind, getRegionId());
+  kindStructs.declareInterface(interfaceM);
 }
 
 void ResilientV4::defineInterface(InterfaceDefinition *interfaceM) {
-  auto interfaceMethodTypesL = globalState->getInterfaceFunctionTypes(interfaceM->referend);
-  referendStructs.defineInterface(interfaceM, interfaceMethodTypesL);
+  auto interfaceMethodTypesL = globalState->getInterfaceFunctionTypes(interfaceM->kind);
+  kindStructs.defineInterface(interfaceM, interfaceMethodTypesL);
 }
 
 void ResilientV4::discardOwningRef(
@@ -402,7 +404,7 @@ void ResilientV4::noteWeakableDestroyed(
     ControlBlockPtrLE controlBlockPtrLE) {
   if (refM->ownership == Ownership::SHARE) {
     assert(false);
-//    auto rcIsZeroLE = strongRcIsZero(globalState, &referendStructs, builder, refM, controlBlockPtrLE);
+//    auto rcIsZeroLE = strongRcIsZero(globalState, &kindStructs, builder, refM, controlBlockPtrLE);
 //    buildAssert(globalState, functionState, builder, rcIsZeroLE,
 //                "Tried to free concrete that had nonzero RC!");
   } else {
@@ -430,13 +432,13 @@ void ResilientV4::storeMember(
     case Ownership::OWN:
     case Ownership::SHARE: {
       return storeMemberStrong(
-          globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+          globalState, functionState, builder, &kindStructs, structRefMT, structRef,
           structKnownLive, memberIndex, memberName, newMemberLE);
     }
     case Ownership::BORROW:
     case Ownership::WEAK: {
       storeMemberWeak(
-          globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+          globalState, functionState, builder, &kindStructs, structRefMT, structRef,
           structKnownLive, memberIndex, memberName, newMemberLE);
       break;
     }
@@ -456,12 +458,12 @@ std::tuple<LLVMValueRef, LLVMValueRef> ResilientV4::explodeInterfaceRef(
     case Ownership::OWN:
     case Ownership::SHARE: {
       return explodeStrongInterfaceRef(
-          globalState, functionState, builder, &referendStructs, virtualParamMT, virtualArgRef);
+          globalState, functionState, builder, &kindStructs, virtualParamMT, virtualArgRef);
     }
     case Ownership::BORROW:
     case Ownership::WEAK: {
       return explodeWeakInterfaceRef(
-          globalState, functionState, builder, &referendStructs, &fatWeaks, &weakRefStructs,
+          globalState, functionState, builder, &kindStructs, &fatWeaks, &weakRefStructs,
           virtualParamMT, virtualArgRef,
           [this, functionState, builder, virtualParamMT](WeakFatPtrLE weakFatPtrLE) {
             return hgmWeaks.weakInterfaceRefToWeakStructRef(
@@ -482,7 +484,7 @@ Ref ResilientV4::getRuntimeSizedArrayLength(
   switch (rsaRefMT->ownership) {
     case Ownership::SHARE:
     case Ownership::OWN: {
-      return getRuntimeSizedArrayLengthStrong(globalState, functionState, builder, &referendStructs, rsaRefMT, arrayRef);
+      return getRuntimeSizedArrayLengthStrong(globalState, functionState, builder, &kindStructs, rsaRefMT, arrayRef);
     }
     case Ownership::BORROW: {
       auto wrapperPtrLE =
@@ -510,7 +512,7 @@ LLVMValueRef ResilientV4::checkValidReference(
 
   if (globalState->opt->census) {
     if (refM->ownership == Ownership::OWN) {
-      regularCheckValidReference(checkerAFL, globalState, functionState, builder, &referendStructs, refM, refLE);
+      regularCheckValidReference(checkerAFL, globalState, functionState, builder, &kindStructs, refM, refLE);
     } else if (refM->ownership == Ownership::SHARE) {
       assert(false);
     } else {
@@ -597,8 +599,8 @@ LLVMValueRef ResilientV4::getCensusObjectId(
     Reference *refM,
     Ref ref) {
   auto controlBlockPtrLE =
-      referendStructs.getControlBlockPtr(checkerAFL, functionState, builder, ref, refM);
-  return referendStructs.getObjIdFromControlBlockPtr(builder, refM->referend, controlBlockPtrLE);
+      kindStructs.getControlBlockPtr(checkerAFL, functionState, builder, ref, refM);
+  return kindStructs.getObjIdFromControlBlockPtr(builder, refM->kind, controlBlockPtrLE);
 }
 
 Ref ResilientV4::getIsAliveFromWeakRef(
@@ -615,12 +617,12 @@ void ResilientV4::fillControlBlock(
     AreaAndFileAndLine from,
     FunctionState *functionState,
     LLVMBuilderRef builder,
-    Referend *referendM,
+    Kind *kindM,
     ControlBlockPtrLE controlBlockPtrLE,
     const std::string &typeName) {
 
   gmFillControlBlock(
-      from, globalState, functionState, &referendStructs, builder, referendM, controlBlockPtrLE,
+      from, globalState, functionState, &kindStructs, builder, kindM, controlBlockPtrLE,
       typeName, &hgmWeaks);
 }
 
@@ -632,10 +634,10 @@ LoadResult ResilientV4::loadElementFromSSA(
     Ref arrayRef,
     bool arrayKnownLive,
     Ref indexRef) {
-  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT->name);
+  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT);
   return resilientloadElementFromSSA(
       globalState, functionState, builder, ssaRefMT, ssaMT, ssaDef->size, ssaDef->rawArray->mutability,
-      ssaDef->rawArray->elementType, arrayRef, arrayKnownLive, indexRef, &referendStructs);
+      ssaDef->rawArray->elementType, arrayRef, arrayKnownLive, indexRef, &kindStructs);
 }
 
 LoadResult ResilientV4::loadElementFromRSA(
@@ -646,9 +648,9 @@ LoadResult ResilientV4::loadElementFromRSA(
     Ref arrayRef,
     bool arrayKnownLive,
     Ref indexRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   return resilientLoadElementFromRSAWithoutUpgrade(
-      globalState, functionState, builder, &referendStructs, rsaRefMT, rsaDef->rawArray->mutability,
+      globalState, functionState, builder, &kindStructs, rsaRefMT, rsaDef->rawArray->mutability,
       rsaDef->rawArray->elementType, rsaMT, arrayRef, arrayKnownLive, indexRef);
 }
 
@@ -661,7 +663,7 @@ Ref ResilientV4::storeElementInRSA(
     bool arrayKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   auto arrayWrapperPtrLE = lockWeakRef(FL(), functionState, builder, rsaRefMT, arrayRef, arrayKnownLive);
   auto sizeRef = ::getRuntimeSizedArrayLength(globalState, functionState, builder, arrayWrapperPtrLE);
   auto arrayElementsPtrLE = getRuntimeSizedArrayContentsPtr(builder, arrayWrapperPtrLE);
@@ -677,24 +679,24 @@ Ref ResilientV4::upcast(
     LLVMBuilderRef builder,
 
     Reference *sourceStructMT,
-    StructReferend *sourceStructReferendM,
+    StructKind *sourceStructKindM,
     Ref sourceRefLE,
 
     Reference *targetInterfaceTypeM,
-    InterfaceReferend *targetInterfaceReferendM) {
+    InterfaceKind *targetInterfaceKindM) {
 
   switch (sourceStructMT->ownership) {
     case Ownership::SHARE:
     case Ownership::OWN: {
       return upcastStrong(
-          globalState, functionState, builder, &referendStructs, sourceStructMT, sourceStructReferendM,
-          sourceRefLE, targetInterfaceTypeM, targetInterfaceReferendM);
+          globalState, functionState, builder, &kindStructs, sourceStructMT, sourceStructKindM,
+          sourceRefLE, targetInterfaceTypeM, targetInterfaceKindM);
     }
     case Ownership::BORROW:
     case Ownership::WEAK: {
       return ::upcastWeak(
-          globalState, functionState, builder, &weakRefStructs, sourceStructMT, sourceStructReferendM,
-          sourceRefLE, targetInterfaceTypeM, targetInterfaceReferendM);
+          globalState, functionState, builder, &weakRefStructs, sourceStructMT, sourceStructKindM,
+          sourceRefLE, targetInterfaceTypeM, targetInterfaceKindM);
     }
     default:
       assert(false);
@@ -702,19 +704,19 @@ Ref ResilientV4::upcast(
 }
 
 
-LLVMValueRef ResilientV4::predictShallowSize(LLVMBuilderRef builder, Referend* referend, LLVMValueRef lenIntLE) {
-  assert(globalState->getRegion(referend) == this);
-  if (auto structReferend = dynamic_cast<StructReferend*>(referend)) {
-    return constI64LE(globalState, LLVMABISizeOfType(globalState->dataLayout, referendStructs.getWrapperStruct(structReferend)));
-  } else if (dynamic_cast<Str*>(referend)) {
+LLVMValueRef ResilientV4::predictShallowSize(LLVMBuilderRef builder, Kind* kind, LLVMValueRef lenIntLE) {
+  assert(globalState->getRegion(kind) == this);
+  if (auto structKind = dynamic_cast<StructKind*>(kind)) {
+    return constI64LE(globalState, LLVMABISizeOfType(globalState->dataLayout, kindStructs.getWrapperStruct(structKind)));
+  } else if (dynamic_cast<Str*>(kind)) {
     auto headerBytesLE =
-        constI64LE(globalState, LLVMABISizeOfType(globalState->dataLayout, referendStructs.getStringWrapperStruct()));
+        constI64LE(globalState, LLVMABISizeOfType(globalState->dataLayout, kindStructs.getStringWrapperStruct()));
     return LLVMBuildAdd(builder, headerBytesLE, lenIntLE, "sum");
-  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(referend)) {
+  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(kind)) {
     auto headerBytesLE =
-        constI64LE(globalState, LLVMABISizeOfType(globalState->dataLayout, referendStructs.getRuntimeSizedArrayWrapperStruct(rsaMT)));
+        constI64LE(globalState, LLVMABISizeOfType(globalState->dataLayout, kindStructs.getRuntimeSizedArrayWrapperStruct(rsaMT)));
 
-    auto elementRefMT = globalState->program->getRuntimeSizedArray(rsaMT->name)->rawArray->elementType;
+    auto elementRefMT = globalState->program->getRuntimeSizedArray(rsaMT)->rawArray->elementType;
     auto elementRefLT = globalState->getRegion(elementRefMT)->translateType(elementRefMT);
 
     auto sizePerElement = LLVMABISizeOfType(globalState->dataLayout, LLVMArrayType(elementRefLT, 1));
@@ -724,11 +726,11 @@ LLVMValueRef ResilientV4::predictShallowSize(LLVMBuilderRef builder, Referend* r
     auto elementsSizeLE = LLVMBuildMul(builder, constI64LE(globalState, sizePerElement), lenIntLE, "elementsSize");
 
     return LLVMBuildAdd(builder, headerBytesLE, elementsSizeLE, "sum");
-  } else if (auto hostKsaMT = dynamic_cast<StaticSizedArrayT*>(referend)) {
+  } else if (auto hostKsaMT = dynamic_cast<StaticSizedArrayT*>(kind)) {
     auto headerBytesLE =
-        constI64LE(globalState, LLVMABISizeOfType(globalState->dataLayout, referendStructs.getStaticSizedArrayWrapperStruct(hostKsaMT)));
+        constI64LE(globalState, LLVMABISizeOfType(globalState->dataLayout, kindStructs.getStaticSizedArrayWrapperStruct(hostKsaMT)));
 
-    auto elementRefMT = globalState->program->getRuntimeSizedArray(rsaMT->name)->rawArray->elementType;
+    auto elementRefMT = globalState->program->getRuntimeSizedArray(rsaMT)->rawArray->elementType;
     auto elementRefLT = translateType(elementRefMT);
 
     auto sizePerElement = LLVMABISizeOfType(globalState->dataLayout, LLVMArrayType(elementRefLT, 1));
@@ -748,11 +750,11 @@ void ResilientV4::deallocate(
     Reference *refMT,
     Ref ref) {
   auto sourceRefLE = checkValidReference(FL(), functionState, builder, refMT, ref);
-  auto controlBlockPtrLE = referendStructs.getControlBlockPtr(FL(), functionState, builder, sourceRefLE, refMT);
-  auto sourceWrapperPtrLE = referendStructs.makeWrapperPtr(from, functionState, builder, refMT, sourceRefLE);
-  auto sourceContentsPtrLE = referendStructs.getStructContentsPtr(builder, refMT->referend, sourceWrapperPtrLE);
+  auto controlBlockPtrLE = kindStructs.getControlBlockPtr(FL(), functionState, builder, sourceRefLE, refMT);
+  auto sourceWrapperPtrLE = kindStructs.makeWrapperPtr(from, functionState, builder, refMT, sourceRefLE);
+  auto sourceContentsPtrLE = kindStructs.getStructContentsPtr(builder, refMT->kind, sourceWrapperPtrLE);
 
-  auto controlBlock = referendStructs.getControlBlock(refMT->referend);
+  auto controlBlock = kindStructs.getControlBlock(refMT->kind);
   auto tetherMemberIndex = controlBlock->getMemberIndex(ControlBlockMember::TETHER_32B);
   auto tetherPtrLE = LLVMBuildStructGEP(builder, controlBlockPtrLE.refLE, tetherMemberIndex, "tetherPtr");
   auto tetherI32LE = LLVMBuildLoad(builder, tetherPtrLE, "tetherI32");
@@ -762,31 +764,31 @@ void ResilientV4::deallocate(
       [this, functionState, sourceContentsPtrLE, refMT, ref, sourceWrapperPtrLE](LLVMBuilderRef thenBuilder) {
         buildFlare(FL(), globalState, functionState, thenBuilder, "still tethered, undeadifying!");
         auto sourceContentsI8PtrLE = LLVMBuildPointerCast(thenBuilder, sourceContentsPtrLE, LLVMPointerType(LLVMInt8TypeInContext(globalState->context), 0), "sourceContentsI8Ptr");
-//        auto structReferend = dynamic_cast<StructReferend*>(refMT->referend);
-//        assert(structReferend);
-//        auto structLT = referendStructs.getInnerStruct(structReferend);
+//        auto structKind = dynamic_cast<StructKind*>(refMT->kind);
+//        assert(structKind);
+//        auto structLT = kindStructs.getInnerStruct(structKind);
 
         LLVMValueRef lenLE = nullptr;
-        if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(refMT->referend)) {
+        if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(refMT->kind)) {
           buildFlare(FL(), globalState, functionState, thenBuilder);
           lenLE =
               globalState->getRegion(globalState->metalCache->intRef)->checkValidReference(
                   FL(), functionState, thenBuilder, globalState->metalCache->intRef,
                   getRuntimeSizedArrayLength(functionState, thenBuilder, refMT, ref, true));
-        } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(refMT->referend)) {
+        } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(refMT->kind)) {
           buildFlare(FL(), globalState, functionState, thenBuilder);
           lenLE =
               globalState->getRegion(globalState->metalCache->intRef)->checkValidReference(
                   FL(), functionState, thenBuilder, globalState->metalCache->intRef,
                   getRuntimeSizedArrayLength(functionState, thenBuilder, refMT, ref, true));
-        } else if (dynamic_cast<StructReferend*>(refMT->referend)) {
+        } else if (dynamic_cast<StructKind*>(refMT->kind)) {
           buildFlare(FL(), globalState, functionState, thenBuilder);
           lenLE = constI64LE(globalState, 0);
-        } else if (dynamic_cast<InterfaceReferend*>(refMT->referend)) {
+        } else if (dynamic_cast<InterfaceKind*>(refMT->kind)) {
           buildFlare(FL(), globalState, functionState, thenBuilder);
           lenLE = constI64LE(globalState, 0);
         }
-        auto sizeLE = predictShallowSize(thenBuilder, refMT->referend, lenLE);
+        auto sizeLE = predictShallowSize(thenBuilder, refMT->kind, lenLE);
         buildFlare(FL(), globalState, functionState, thenBuilder, "size: ", sizeLE);
 
         std::vector<LLVMValueRef> argsLE = { sourceContentsI8PtrLE, constI8LE(globalState, 0), sizeLE };
@@ -797,7 +799,7 @@ void ResilientV4::deallocate(
       },
       [this, from, functionState, refMT, ref](LLVMBuilderRef elseBuilder) {
         buildFlare(FL(), globalState, functionState, elseBuilder);
-        innerDeallocate(from, globalState, functionState, &referendStructs, elseBuilder, refMT, ref);
+        innerDeallocate(from, globalState, functionState, &kindStructs, elseBuilder, refMT, ref);
       });
 }
 
@@ -810,13 +812,13 @@ Ref ResilientV4::constructRuntimeSizedArray(
     Ref sizeRef,
     const std::string &typeName) {
   auto rsaWrapperPtrLT =
-      referendStructs.getRuntimeSizedArrayWrapperStruct(runtimeSizedArrayT);
-  auto rsaDef = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT->name);
-  auto elementType = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT->name)->rawArray->elementType;
+      kindStructs.getRuntimeSizedArrayWrapperStruct(runtimeSizedArrayT);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT);
+  auto elementType = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT)->rawArray->elementType;
   auto rsaElementLT = globalState->getRegion(elementType)->translateType(elementType);
   auto resultRef =
       ::constructRuntimeSizedArray(
-          globalState, functionState, builder, &referendStructs, rsaMT, rsaDef->rawArray->elementType,
+          globalState, functionState, builder, &kindStructs, rsaMT, rsaDef->rawArray->elementType,
           runtimeSizedArrayT,
           rsaWrapperPtrLT, rsaElementLT, sizeRef, typeName,
           [this, functionState, runtimeSizedArrayT, typeName](
@@ -854,7 +856,7 @@ Ref ResilientV4::loadMember(
         case Ownership::SHARE: {
           auto unupgradedMemberLE =
               regularLoadMember(
-                  globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+                  globalState, functionState, builder, &kindStructs, structRefMT, structRef,
                   memberIndex, expectedMemberType, targetType, memberName);
           return upgradeLoadResultToRefWithTargetOwnership(
               functionState, builder, expectedMemberType, targetType, unupgradedMemberLE);
@@ -863,7 +865,7 @@ Ref ResilientV4::loadMember(
         case Ownership::WEAK: {
           auto memberLE =
               resilientLoadWeakMember(
-                  globalState, functionState, builder, &referendStructs, structRefMT,
+                  globalState, functionState, builder, &kindStructs, structRefMT,
                   structRef,
                   structKnownLive, memberIndex, expectedMemberType, memberName);
           auto resultRef =
@@ -884,78 +886,78 @@ void ResilientV4::checkInlineStructType(
     Reference *refMT,
     Ref ref) {
   auto argLE = checkValidReference(FL(), functionState, builder, refMT, ref);
-  auto structReferend = dynamic_cast<StructReferend *>(refMT->referend);
-  assert(structReferend);
-  assert(LLVMTypeOf(argLE) == referendStructs.getInnerStruct(structReferend));
+  auto structKind = dynamic_cast<StructKind *>(refMT->kind);
+  assert(structKind);
+  assert(LLVMTypeOf(argLE) == kindStructs.getInnerStruct(structKind));
 }
 
+//
+//std::string ResilientV4::getMemberArbitraryRefNameCSeeMMEDT(Reference *refMT) {
+//  if (refMT->ownership == Ownership::SHARE) {
+//    assert(false);
+//  } else if (auto structRefMT = dynamic_cast<StructKind *>(refMT->kind)) {
+//    auto structMT = globalState->program->getStruct(structRefMT);
+//    auto baseName = globalState->program->getMemberArbitraryExportNameSeeMMEDT(structRefMT->fullName);
+//    if (structMT->mutability == Mutability::MUTABLE) {
+//      assert(refMT->location != Location::INLINE);
+//      return baseName + "Ref";
+//    } else {
+//      if (refMT->location == Location::INLINE) {
+//        return baseName + "Inl";
+//      } else {
+//        return baseName + "Ref";
+//      }
+//    }
+//  } else if (auto interfaceMT = dynamic_cast<InterfaceKind *>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(interfaceMT->fullName) + "Ref";
+//  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(rsaMT->name) + "Ref";
+//  } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(ssaMT->name) + "Ref";
+//  } else {
+//    assert(false);
+//  }
+//}
 
-std::string ResilientV4::getMemberArbitraryRefNameCSeeMMEDT(Reference *refMT) {
-  if (refMT->ownership == Ownership::SHARE) {
+std::string ResilientV4::generateRuntimeSizedArrayDefsC(
+    Package* currentPackage,
+    RuntimeSizedArrayDefinitionT *rsaDefM) {
+  assert(false);
+  return "";
+}
+
+std::string ResilientV4::generateStaticSizedArrayDefsC(
+    Package* currentPackage,
+    StaticSizedArrayDefinitionT *ssaDefM) {
+  if (ssaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
-  } else if (auto structRefMT = dynamic_cast<StructReferend *>(refMT->referend)) {
-    auto structMT = globalState->program->getStruct(structRefMT->fullName);
-    auto baseName = globalState->program->getMemberArbitraryExportNameSeeMMEDT(structRefMT->fullName);
-    if (structMT->mutability == Mutability::MUTABLE) {
-      assert(refMT->location != Location::INLINE);
-      return baseName + "Ref";
-    } else {
-      if (refMT->location == Location::INLINE) {
-        return baseName + "Inl";
-      } else {
-        return baseName + "Ref";
-      }
-    }
-  } else if (auto interfaceMT = dynamic_cast<InterfaceReferend *>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(interfaceMT->fullName) + "Ref";
-  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(rsaMT->name) + "Ref";
-  } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(ssaMT->name) + "Ref";
   } else {
-    assert(false);
+    auto name = currentPackage->getKindExportName(ssaDefM->kind);
+    return std::string() + "typedef struct " + name + " { uint64_t unused0; void* unused; } " + name + ";\n";
   }
 }
 
-void ResilientV4::generateRuntimeSizedArrayDefsC(
-    std::unordered_map<std::string, std::string> *cByExportedName,
-    RuntimeSizedArrayDefinitionT *rsaDefM) {
-  assert(false);
-}
-
-void ResilientV4::generateStaticSizedArrayDefsC(
-    std::unordered_map<std::string, std::string> *cByExportedName,
-    StaticSizedArrayDefinitionT *rsaDefM) {
-  assert(false);
-}
-
-void ResilientV4::generateStructDefsC(
-    std::unordered_map<std::string, std::string> *cByExportedName, StructDefinition *structDefM) {
+std::string ResilientV4::generateStructDefsC(
+    Package* currentPackage,
+     StructDefinition *structDefM) {
 
   if (structDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto baseName : globalState->program->getExportedNames(structDefM->referend->fullName)) {
-      auto refTypeName = baseName + "Ref";
-      std::stringstream s;
-      s << "typedef struct " << refTypeName << " { uint64_t unused0; void* unused1; } " << refTypeName << ";"
-        << std::endl;
-      cByExportedName->insert(std::make_pair(baseName, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(structDefM->kind);
+    return std::string() + "typedef struct " + name + " { uint64_t unused0; void* unused; } " + name + ";\n";
   }
 }
 
-void ResilientV4::generateInterfaceDefsC(
-    std::unordered_map<std::string, std::string> *cByExportedName, InterfaceDefinition *interfaceDefM) {
+std::string ResilientV4::generateInterfaceDefsC(
+    Package* currentPackage,
+     InterfaceDefinition *interfaceDefM) {
 
   if (interfaceDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto name : globalState->program->getExportedNames(interfaceDefM->referend->fullName)) {
-      std::stringstream s;
-      s << "typedef struct " << name << "Ref { uint64_t unused0; void* unused1; void* unused2; } " << name << "Ref;";
-      cByExportedName->insert(std::make_pair(name, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(interfaceDefM->kind);
+    return std::string() + "typedef struct " + name + " { uint64_t unused0; void* unused1; void* unused2; } " + name + ";\n";
   }
 }
 
@@ -987,7 +989,7 @@ LLVMTypeRef ResilientV4::getInterfaceMethodVirtualParamAnyType(Reference *refere
       return LLVMPointerType(LLVMInt8TypeInContext(globalState->context), 0);
     case Ownership::BORROW:
     case Ownership::WEAK:
-      return weakRefStructs.getWeakVoidRefStruct(reference->referend);
+      return weakRefStructs.getWeakVoidRefStruct(reference->kind);
   }
 }
 
@@ -1019,7 +1021,7 @@ void ResilientV4::initializeElementInRSA(
     bool arrayRefKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  ::initializeElementInRSA(globalState, functionState, builder, &referendStructs, rsaMT, rsaRefMT, rsaRef, indexRef,
+  ::initializeElementInRSA(globalState, functionState, builder, &kindStructs, rsaMT, rsaRefMT, rsaRef, indexRef,
                            elementRef);
 }
 
@@ -1031,9 +1033,9 @@ Ref ResilientV4::deinitializeElementFromRSA(
     Ref arrayRef,
     bool arrayRefKnownLive,
     Ref indexRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   return resilientLoadElementFromRSAWithoutUpgrade(
-      globalState, functionState, builder, &referendStructs, rsaRefMT, rsaDef->rawArray->mutability,
+      globalState, functionState, builder, &kindStructs, rsaRefMT, rsaDef->rawArray->mutability,
       rsaDef->rawArray->elementType, rsaMT, arrayRef, true, indexRef).move();
 }
 
@@ -1046,9 +1048,9 @@ void ResilientV4::initializeElementInSSA(
     bool arrayRefKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT->name);
+  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT);
   auto arrayWrapperPtrLE =
-      referendStructs.makeWrapperPtr(
+      kindStructs.makeWrapperPtr(
           FL(), functionState, builder, ssaRefMT,
           globalState->getRegion(ssaRefMT)->checkValidReference(FL(), functionState, builder, ssaRefMT, arrayRef));
   auto sizeRef = globalState->constI64(ssaDef->size);
@@ -1069,11 +1071,11 @@ Ref ResilientV4::deinitializeElementFromSSA(
   exit(1);
 }
 
-Weakability ResilientV4::getReferendWeakability(Referend *referend) {
-  if (auto structReferend = dynamic_cast<StructReferend *>(referend)) {
-    return globalState->lookupStruct(structReferend->fullName)->weakability;
-  } else if (auto interfaceReferend = dynamic_cast<InterfaceReferend *>(referend)) {
-    return globalState->lookupInterface(interfaceReferend->fullName)->weakability;
+Weakability ResilientV4::getKindWeakability(Kind *kind) {
+  if (auto structKind = dynamic_cast<StructKind *>(kind)) {
+    return globalState->lookupStruct(structKind)->weakability;
+  } else if (auto interfaceKind = dynamic_cast<InterfaceKind *>(kind)) {
+    return globalState->lookupInterface(interfaceKind)->weakability;
   } else {
     return Weakability::NON_WEAKABLE;
   }
@@ -1100,21 +1102,21 @@ void ResilientV4::untether(
   auto sourceWeakFatPtrLE = weakRefStructs.makeWeakFatPtr(local->type, sourceRefLE);
   assert(local->type->ownership == Ownership::BORROW);
   ControlBlockPtrLE controlBlockPtrLE =
-    (dynamic_cast<InterfaceReferend*>(local->type->referend)) ? [&](){
+    (dynamic_cast<InterfaceKind*>(local->type->kind)) ? [&](){
       auto interfaceFatPtrLE =
-          referendStructs.makeInterfaceFatPtr(
+          kindStructs.makeInterfaceFatPtr(
               FL(), functionState, builder, local->type,
               fatWeaks.getInnerRefFromWeakRef(functionState, builder, local->type, sourceWeakFatPtrLE));
-      return referendStructs.getControlBlockPtr(FL(), functionState, builder, local->type->referend, interfaceFatPtrLE);
+      return kindStructs.getControlBlockPtr(FL(), functionState, builder, local->type->kind, interfaceFatPtrLE);
     }() : [&](){
       auto wrapperPtrLE =
-          referendStructs.makeWrapperPtr(
+          kindStructs.makeWrapperPtr(
               FL(), functionState, builder, local->type,
               fatWeaks.getInnerRefFromWeakRef(functionState, builder, local->type, sourceWeakFatPtrLE));
-      return referendStructs.getControlBlockPtr(FL(), functionState, builder, wrapperPtrLE.refLE, local->type);
+      return kindStructs.getControlBlockPtr(FL(), functionState, builder, wrapperPtrLE.refLE, local->type);
     }();
 
-  auto controlBlock = referendStructs.getControlBlock(local->type->referend);
+  auto controlBlock = kindStructs.getControlBlock(local->type->kind);
   auto tetherMemberIndex = controlBlock->getMemberIndex(ControlBlockMember::TETHER_32B);
   auto tetherPtrLE = LLVMBuildStructGEP(builder, controlBlockPtrLE.refLE, tetherMemberIndex, "tetherPtr");
   auto wasAliveI32LE = LLVMBuildZExt(builder, wasAliveLE, LLVMInt32TypeInContext(globalState->context), "wasAliveI32");
@@ -1136,10 +1138,10 @@ void ResilientV4::storeAndTether(
     bool knownLive,
     LLVMValueRef localAddr) {
   LLVMTypeRef wrapperStructLT = nullptr;
-  if (auto structRReferend = dynamic_cast<StructReferend*>(local->type->referend)) {
-    wrapperStructLT = referendStructs.getWrapperStruct(structRReferend);
-  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(local->type->referend)) {
-    wrapperStructLT = referendStructs.getRuntimeSizedArrayWrapperStruct(rsaMT);
+  if (auto structRKind = dynamic_cast<StructKind*>(local->type->kind)) {
+    wrapperStructLT = kindStructs.getWrapperStruct(structRKind);
+  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(local->type->kind)) {
+    wrapperStructLT = kindStructs.getRuntimeSizedArrayWrapperStruct(rsaMT);
   } else {
     assert(false);
   }
@@ -1147,7 +1149,7 @@ void ResilientV4::storeAndTether(
   auto maybeAliveRefLE = checkValidReference(FL(), functionState, builder, local->type, refToStore);
   auto weakFatPtrLE = weakRefStructs.makeWeakFatPtr(local->type, maybeAliveRefLE);
   auto innerRefLE = fatWeaks.getInnerRefFromWeakRef(functionState, builder, local->type, weakFatPtrLE);
-  auto wrapperPtrLE = referendStructs.makeWrapperPtr(FL(), functionState, builder, local->type, innerRefLE);
+  auto wrapperPtrLE = kindStructs.makeWrapperPtr(FL(), functionState, builder, local->type, innerRefLE);
 
   auto halfProtectedWrapperPtrLE =
       hgmWeaks.getHalfProtectedPtr(functionState, builder, local->type, wrapperStructPtrLT);
@@ -1159,19 +1161,19 @@ void ResilientV4::storeAndTether(
   assert(wrapperPtrLE.refM == halfProtectedWrapperPtrLE.refM);
   assert(LLVMTypeOf(wrapperPtrLE.refLE) == LLVMTypeOf(halfProtectedWrapperPtrLE.refLE));
   auto newWrapperPtrLE =
-      referendStructs.makeWrapperPtr(
+      kindStructs.makeWrapperPtr(
           FL(), functionState, builder, local->type,
           LLVMBuildSelect(
               builder, isAliveLE, wrapperPtrLE.refLE, halfProtectedWrapperPtrLE.refLE, "clearableRef"));
 
   std::unique_ptr<WeakFatPtrLE> newWeakFatPtrU;
-  if (auto structRReferend = dynamic_cast<StructReferend*>(local->type->referend)) {
+  if (auto structRKind = dynamic_cast<StructKind*>(local->type->kind)) {
     newWeakFatPtrU =
         std::unique_ptr<WeakFatPtrLE>{
           new WeakFatPtrLE(
             hgmWeaks.assembleStructWeakRef(
-                functionState, builder, local->type, local->type, structRReferend, newWrapperPtrLE))};
-  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(local->type->referend)) {
+                functionState, builder, local->type, local->type, structRKind, newWrapperPtrLE))};
+  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(local->type->kind)) {
     newWeakFatPtrU =
         std::unique_ptr<WeakFatPtrLE>{
             new WeakFatPtrLE(
@@ -1184,13 +1186,13 @@ void ResilientV4::storeAndTether(
 
 
 
-//  auto controlBlockPtrLE = referendStructs.getControlBlockPtr(FL(), functionState, builder, refToStore, local->type);
-//  auto sourceWrapperPtrLE = referendStructs.makeWrapperPtr(FL(), functionState, builder, local->type, maybeAliveRefLE);
-//  auto sourceContentsPtrLE = referendStructs.getStructContentsPtr(builder, local->type->referend, sourceWrapperPtrLE);
+//  auto controlBlockPtrLE = kindStructs.getControlBlockPtr(FL(), functionState, builder, refToStore, local->type);
+//  auto sourceWrapperPtrLE = kindStructs.makeWrapperPtr(FL(), functionState, builder, local->type, maybeAliveRefLE);
+//  auto sourceContentsPtrLE = kindStructs.getStructContentsPtr(builder, local->type->kind, sourceWrapperPtrLE);
 
-  auto controlBlock = referendStructs.getControlBlock(local->type->referend);
+  auto controlBlock = kindStructs.getControlBlock(local->type->kind);
   auto tetherMemberIndex = controlBlock->getMemberIndex(ControlBlockMember::TETHER_32B);
-  auto controlBlockPtrLE = referendStructs.getConcreteControlBlockPtr(FL(), functionState, builder, local->type, newWrapperPtrLE);
+  auto controlBlockPtrLE = kindStructs.getConcreteControlBlockPtr(FL(), functionState, builder, local->type, newWrapperPtrLE);
   auto tetherPtrLE = LLVMBuildStructGEP(builder, controlBlockPtrLE.refLE, tetherMemberIndex, "tetherPtr");
   auto tetherI32LE = LLVMBuildLoad(builder, tetherPtrLE, "tetherI32");
   auto wasTetheredLE = LLVMBuildTrunc(builder, tetherI32LE, LLVMInt1TypeInContext(globalState->context), "wasAlive");
@@ -1317,4 +1319,10 @@ Ref ResilientV4::localStore(
       assert(false);
   }
   return oldRef;
+}
+
+std::string ResilientV4::getExportName(
+    Package* package,
+    Reference* reference) {
+  return package->getKindExportName(reference->kind) + (reference->location == Location::YONDER ? "Ref" : "");
 }

--- a/Midas/src/c-compiler/region/resilientv4/resilientv4.cpp
+++ b/Midas/src/c-compiler/region/resilientv4/resilientv4.cpp
@@ -932,7 +932,7 @@ std::string ResilientV4::generateStaticSizedArrayDefsC(
   if (ssaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(ssaDefM->kind);
+    auto name = currentPackage->getKindExportName(ssaDefM->kind, true);
     return std::string() + "typedef struct " + name + " { uint64_t unused0; void* unused; } " + name + ";\n";
   }
 }
@@ -944,7 +944,7 @@ std::string ResilientV4::generateStructDefsC(
   if (structDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(structDefM->kind);
+    auto name = currentPackage->getKindExportName(structDefM->kind, true);
     return std::string() + "typedef struct " + name + " { uint64_t unused0; void* unused; } " + name + ";\n";
   }
 }
@@ -956,7 +956,7 @@ std::string ResilientV4::generateInterfaceDefsC(
   if (interfaceDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(interfaceDefM->kind);
+    auto name = currentPackage->getKindExportName(interfaceDefM->kind, true);
     return std::string() + "typedef struct " + name + " { uint64_t unused0; void* unused1; void* unused2; } " + name + ";\n";
   }
 }
@@ -1323,6 +1323,7 @@ Ref ResilientV4::localStore(
 
 std::string ResilientV4::getExportName(
     Package* package,
-    Reference* reference) {
-  return package->getKindExportName(reference->kind) + (reference->location == Location::YONDER ? "Ref" : "");
+    Reference* reference,
+    bool includeProjectName) {
+  return package->getKindExportName(reference->kind, includeProjectName) + (reference->location == Location::YONDER ? "Ref" : "");
 }

--- a/Midas/src/c-compiler/region/resilientv4/resilientv4.h
+++ b/Midas/src/c-compiler/region/resilientv4/resilientv4.h
@@ -43,9 +43,9 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       WeakFatPtrLE sourceRefLE,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Reference* sourceStructTypeM,
-      InterfaceReferend* targetInterfaceReferendM,
+      InterfaceKind* targetInterfaceKindM,
       Reference* targetInterfaceTypeM) override;
 
   Ref upcast(
@@ -53,11 +53,11 @@ public:
       LLVMBuilderRef builder,
 
       Reference* sourceStructMT,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Ref sourceRefLE,
 
       Reference* targetInterfaceTypeM,
-      InterfaceReferend* targetInterfaceReferendM) override;
+      InterfaceKind* targetInterfaceKindM) override;
 
 
   void defineStaticSizedArray(
@@ -104,7 +104,7 @@ public:
       Reference* sourceInterfaceRefMT,
       Ref sourceInterfaceRef,
       bool sourceRefKnownLive,
-      Referend* targetReferend,
+      Kind* targetKind,
       std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
       std::function<Ref(LLVMBuilderRef)> buildElse) override;
 
@@ -115,7 +115,7 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       Reference* referenceM,
-      StaticSizedArrayT* referendM) override;
+      StaticSizedArrayT* kindM) override;
 
   // should expose a dereference thing instead
 //  LLVMValueRef getStaticSizedArrayElementsPtr(
@@ -354,7 +354,7 @@ public:
 //      FunctionState* functionState,
 //      LLVMBuilderRef builder,
 //      Location location,
-//      LLVMTypeRef referendLT) override;
+//      LLVMTypeRef kindLT) override;
 
 //  LLVMValueRef mallocRuntimeSizedArray(
 //      LLVMBuilderRef builder,
@@ -367,58 +367,62 @@ public:
 //    return mutWeakableStructs.makeWeakFatPtr(referenceM_, ptrLE);
 //  }
   // TODO get rid of these once refactor is done
-//  ControlBlock* getControlBlock(Referend* referend) override {
-//    return referendStructs.getControlBlock(referend);
+//  ControlBlock* getControlBlock(Kind* kind) override {
+//    return kindStructs.getControlBlock(kind);
 //  }
-//  IReferendStructsSource* getReferendStructsSource() override {
-//    return &referendStructs;
+//  IKindStructsSource* getKindStructsSource() override {
+//    return &kindStructs;
 //  }
 //  IWeakRefStructsSource* getWeakRefStructsSource() override {
 //    return &weakRefStructs;
 //  }
   LLVMValueRef getStringBytesPtr(FunctionState* functionState, LLVMBuilderRef builder, Ref ref) override {
     auto strWrapperPtrLE =
-        referendStructs.makeWrapperPtr(
+        kindStructs.makeWrapperPtr(
             FL(), functionState, builder,
             globalState->metalCache->strRef,
             checkValidReference(
                 FL(), functionState, builder, globalState->metalCache->strRef, ref));
-    return referendStructs.getStringBytesPtr(functionState, builder, strWrapperPtrLE);
+    return kindStructs.getStringBytesPtr(functionState, builder, strWrapperPtrLE);
   }
   LLVMValueRef getStringLen(FunctionState* functionState, LLVMBuilderRef builder, Ref ref) override {
     auto strWrapperPtrLE =
-        referendStructs.makeWrapperPtr(
+        kindStructs.makeWrapperPtr(
             FL(), functionState, builder,
             globalState->metalCache->strRef,
             checkValidReference(
                 FL(), functionState, builder, globalState->metalCache->strRef, ref));
-    return referendStructs.getStringLen(functionState, builder, strWrapperPtrLE);
+    return kindStructs.getStringLen(functionState, builder, strWrapperPtrLE);
   }
-//  LLVMTypeRef getWeakRefHeaderStruct(Referend* referend) override {
-//    return mutWeakableStructs.getWeakRefHeaderStruct(referend);
+//  LLVMTypeRef getWeakRefHeaderStruct(Kind* kind) override {
+//    return mutWeakableStructs.getWeakRefHeaderStruct(kind);
 //  }
-//  LLVMTypeRef getWeakVoidRefStruct(Referend* referend) override {
-//    return mutWeakableStructs.getWeakVoidRefStruct(referend);
+//  LLVMTypeRef getWeakVoidRefStruct(Kind* kind) override {
+//    return mutWeakableStructs.getWeakVoidRefStruct(kind);
 //  }
   void fillControlBlock(
       AreaAndFileAndLine from,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       ControlBlockPtrLE controlBlockPtrLE,
       const std::string& typeName);
 
 
-  std::string getMemberArbitraryRefNameCSeeMMEDT(
-      Reference* refMT) override;
-  void generateStructDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StructDefinition* refMT) override;
-  void generateInterfaceDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, InterfaceDefinition* refMT) override;
-  void generateStaticSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StaticSizedArrayDefinitionT* ssaDefM) override;
-  void generateRuntimeSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, RuntimeSizedArrayDefinitionT* rsaDefM) override;
+
+  std::string getExportName(Package* currentPackage, Reference* refMT) override;
+  std::string generateStructDefsC(
+    Package* currentPackage,
+      StructDefinition* refMT) override;
+  std::string generateInterfaceDefsC(
+    Package* currentPackage,
+      InterfaceDefinition* refMT) override;
+  std::string generateStaticSizedArrayDefsC(
+    Package* currentPackage,
+      StaticSizedArrayDefinitionT* ssaDefM) override;
+  std::string generateRuntimeSizedArrayDefsC(
+    Package* currentPackage,
+      RuntimeSizedArrayDefinitionT* rsaDefM) override;
 
   Reference* getExternalType(Reference* refMT) override;
 
@@ -451,7 +455,7 @@ public:
   void declareExtraFunctions() override {}
   void defineExtraFunctions() override {}
 
-  Weakability getReferendWeakability(Referend* referend) override;
+  Weakability getKindWeakability(Kind* kind) override;
 
   void declareStructExtraFunctions(StructDefinition* structDefM) override {}
   void declareStaticSizedArrayExtraFunctions(StaticSizedArrayDefinitionT* ssaDef) override {}
@@ -504,21 +508,21 @@ protected:
       bool knownLive,
       LLVMValueRef localAddr);
 
-  LLVMValueRef predictShallowSize(LLVMBuilderRef builder, Referend* referend, LLVMValueRef lenIntLE);
+  LLVMValueRef predictShallowSize(LLVMBuilderRef builder, Kind* kind, LLVMValueRef lenIntLE);
 
   GlobalState* globalState = nullptr;
 
   RegionId* regionId = nullptr;
 
-  WeakableReferendStructs mutWeakableStructs;
+  WeakableKindStructs mutWeakableStructs;
 
-  ReferendStructsRouter referendStructs;
+  KindStructsRouter kindStructs;
   WeakRefStructsRouter weakRefStructs;
 
   FatWeaks fatWeaks;
 
   // Used by the undead cycle cleanup function
-  StructReferend* anyMT = nullptr;
+  StructKind* anyMT = nullptr;
 
   HybridGenerationalMemory hgmWeaks;
 };

--- a/Midas/src/c-compiler/region/resilientv4/resilientv4.h
+++ b/Midas/src/c-compiler/region/resilientv4/resilientv4.h
@@ -410,7 +410,7 @@ public:
 
 
 
-  std::string getExportName(Package* currentPackage, Reference* refMT) override;
+  std::string getExportName(Package* currentPackage, Reference* refMT, bool includeProjectName) override;
   std::string generateStructDefsC(
     Package* currentPackage,
       StructDefinition* refMT) override;

--- a/Midas/src/c-compiler/region/unsafe/unsafe.cpp
+++ b/Midas/src/c-compiler/region/unsafe/unsafe.cpp
@@ -803,7 +803,7 @@ std::string Unsafe::generateStructDefsC(
   if (structDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(structDefM->kind);
+    auto name = currentPackage->getKindExportName(structDefM->kind, true);
     return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
@@ -822,7 +822,7 @@ std::string Unsafe::generateRuntimeSizedArrayDefsC(
   if (rsaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(rsaDefM->kind);
+    auto name = currentPackage->getKindExportName(rsaDefM->kind, true);
     return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
@@ -833,7 +833,7 @@ std::string Unsafe::generateStaticSizedArrayDefsC(
   if (ssaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    auto name = currentPackage->getKindExportName(ssaDefM->kind);
+    auto name = currentPackage->getKindExportName(ssaDefM->kind, true);
     return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
@@ -1006,6 +1006,7 @@ Ref Unsafe::localStore(FunctionState* functionState, LLVMBuilderRef builder, Loc
 
 std::string Unsafe::getExportName(
     Package* package,
-    Reference* reference) {
-  return package->getKindExportName(reference->kind) + (reference->location == Location::YONDER ? "Ref" : "");
+    Reference* reference,
+    bool includeProjectName) {
+  return package->getKindExportName(reference->kind, includeProjectName) + (reference->location == Location::YONDER ? "Ref" : "");
 }

--- a/Midas/src/c-compiler/region/unsafe/unsafe.cpp
+++ b/Midas/src/c-compiler/region/unsafe/unsafe.cpp
@@ -21,25 +21,25 @@ Unsafe::Unsafe(GlobalState* globalState_) :
         globalState,
         makeFastWeakableControlBlock(globalState),
         WrcWeaks::makeWeakRefHeaderStruct(globalState)),
-    referendStructs(
+    kindStructs(
         globalState,
-        [this](Referend* referend) -> IReferendStructsSource* {
-          if (globalState->getReferendWeakability(referend) == Weakability::NON_WEAKABLE) {
+        [this](Kind* kind) -> IKindStructsSource* {
+          if (globalState->getKindWeakability(kind) == Weakability::NON_WEAKABLE) {
             return &mutNonWeakableStructs;
           } else {
             return &mutWeakableStructs;
           }
         }),
     weakRefStructs(
-        [this](Referend* referend) -> IWeakRefStructsSource* {
-            if (globalState->getReferendWeakability(referend) == Weakability::NON_WEAKABLE) {
+        [this](Kind* kind) -> IWeakRefStructsSource* {
+            if (globalState->getKindWeakability(kind) == Weakability::NON_WEAKABLE) {
               assert(false);
             } else {
               return &mutWeakableStructs;
             }
         }),
     fatWeaks(globalState_, &weakRefStructs),
-    wrcWeaks(globalState_, &referendStructs, &weakRefStructs) {
+    wrcWeaks(globalState_, &kindStructs, &weakRefStructs) {
   regionLT = LLVMStructCreateNamed(globalState->context, "__Unsafe_Region");
   LLVMStructSetBody(regionLT, nullptr, 0, false);
 }
@@ -61,19 +61,19 @@ Ref Unsafe::constructStaticSizedArray(
     FunctionState *functionState,
     LLVMBuilderRef builder,
     Reference *referenceM,
-    StaticSizedArrayT *referendM) {
-  auto ssaDef = globalState->program->getStaticSizedArray(referendM->name);
+    StaticSizedArrayT *kindM) {
+  auto ssaDef = globalState->program->getStaticSizedArray(kindM);
   auto resultRef =
       ::constructStaticSizedArray(
-          globalState, functionState, builder, referenceM, referendM, &referendStructs,
-          [this, functionState, referenceM, referendM](LLVMBuilderRef innerBuilder, ControlBlockPtrLE controlBlockPtrLE) {
+          globalState, functionState, builder, referenceM, kindM, &kindStructs,
+          [this, functionState, referenceM, kindM](LLVMBuilderRef innerBuilder, ControlBlockPtrLE controlBlockPtrLE) {
             fillControlBlock(
                 FL(),
                 functionState,
                 innerBuilder,
-                referenceM->referend,
+                referenceM->kind,
                 controlBlockPtrLE,
-                referendM->name->name);
+                kindM->name->name);
           });
   return resultRef;
 }
@@ -95,14 +95,14 @@ Ref Unsafe::allocate(
     LLVMBuilderRef builder,
     Reference* desiredReference,
     const std::vector<Ref>& memberRefs) {
-  auto structReferend = dynamic_cast<StructReferend*>(desiredReference->referend);
-  auto structM = globalState->program->getStruct(structReferend->fullName);
+  auto structKind = dynamic_cast<StructKind*>(desiredReference->kind);
+  auto structM = globalState->program->getStruct(structKind);
   auto resultRef =
       innerAllocate(
-          FL(), globalState, functionState, builder, desiredReference, &referendStructs, memberRefs, Weakability::WEAKABLE,
+          FL(), globalState, functionState, builder, desiredReference, &kindStructs, memberRefs, Weakability::WEAKABLE,
           [this, functionState, desiredReference, structM](LLVMBuilderRef innerBuilder, ControlBlockPtrLE controlBlockPtrLE) {
             fillControlBlock(
-                FL(), functionState, innerBuilder, desiredReference->referend,
+                FL(), functionState, innerBuilder, desiredReference->kind,
                 controlBlockPtrLE, structM->name->name);
           });
   return resultRef;
@@ -114,14 +114,14 @@ void Unsafe::alias(
     LLVMBuilderRef builder,
     Reference* sourceRef,
     Ref expr) {
-  auto sourceRnd = sourceRef->referend;
+  auto sourceRnd = sourceRef->kind;
 
   if (dynamic_cast<Int *>(sourceRnd) ||
       dynamic_cast<Bool *>(sourceRnd) ||
       dynamic_cast<Float *>(sourceRnd)) {
     // Do nothing for these, they're always inlined and copied.
-  } else if (dynamic_cast<InterfaceReferend *>(sourceRnd) ||
-      dynamic_cast<StructReferend *>(sourceRnd) ||
+  } else if (dynamic_cast<InterfaceKind *>(sourceRnd) ||
+      dynamic_cast<StructKind *>(sourceRnd) ||
       dynamic_cast<StaticSizedArrayT *>(sourceRnd) ||
       dynamic_cast<RuntimeSizedArrayT *>(sourceRnd) ||
       dynamic_cast<Str *>(sourceRnd)) {
@@ -136,13 +136,13 @@ void Unsafe::alias(
       if (sourceRef->location == Location::INLINE) {
         // Do nothing, we can just let inline structs disappear
       } else {
-        adjustStrongRc(from, globalState, functionState, &referendStructs, builder, expr, sourceRef, 1);
+        adjustStrongRc(from, globalState, functionState, &kindStructs, builder, expr, sourceRef, 1);
       }
     } else
       assert(false);
   } else {
     std::cerr << "Unimplemented type in acquireReference: "
-        << typeid(*sourceRef->referend).name() << std::endl;
+        << typeid(*sourceRef->kind).name() << std::endl;
     assert(false);
   }
 }
@@ -153,7 +153,7 @@ void Unsafe::dealias(
     LLVMBuilderRef builder,
     Reference* sourceMT,
     Ref sourceRef) {
-  auto sourceRnd = sourceMT->referend;
+  auto sourceRnd = sourceMT->kind;
 
   if (sourceMT->ownership == Ownership::SHARE) {
     assert(false);
@@ -169,7 +169,7 @@ void Unsafe::dealias(
 }
 
 Ref Unsafe::weakAlias(FunctionState* functionState, LLVMBuilderRef builder, Reference* sourceRefMT, Reference* targetRefMT, Ref sourceRef) {
-  return regularWeakAlias(globalState, functionState, &referendStructs, &wrcWeaks, builder, sourceRefMT, targetRefMT, sourceRef);
+  return regularWeakAlias(globalState, functionState, &kindStructs, &wrcWeaks, builder, sourceRefMT, targetRefMT, sourceRef);
 }
 
 // Doesn't return a constraint ref, returns a raw ref to the wrapper struct.
@@ -191,7 +191,7 @@ WrapperPtrLE Unsafe::lockWeakRef(
           weakRefStructs.makeWeakFatPtr(
               refM,
               checkValidReference(FL(), functionState, builder, refM, weakRefLE));
-      return referendStructs.makeWrapperPtr(
+      return kindStructs.makeWrapperPtr(
           FL(), functionState, builder, refM,
           wrcWeaks.lockWrciFatPtr(from, functionState, builder, refM, weakFatPtrLE));
     }
@@ -236,13 +236,13 @@ Ref Unsafe::asSubtype(
     Reference* sourceInterfaceRefMT,
     Ref sourceInterfaceRef,
     bool sourceRefKnownLive,
-    Referend* targetReferend,
+    Kind* targetKind,
     std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
     std::function<Ref(LLVMBuilderRef)> buildElse) {
 
   return regularDowncast(
       globalState, functionState, builder, thenResultIsNever, elseResultIsNever, resultOptTypeM, constraintRefM,
-      sourceInterfaceRefMT, sourceInterfaceRef, sourceRefKnownLive, targetReferend, buildThen, buildElse);
+      sourceInterfaceRefMT, sourceInterfaceRef, sourceRefKnownLive, targetKind, buildThen, buildElse);
 }
 
 LLVMTypeRef Unsafe::translateType(Reference* referenceM) {
@@ -252,10 +252,10 @@ LLVMTypeRef Unsafe::translateType(Reference* referenceM) {
     case Ownership::OWN:
     case Ownership::BORROW:
       assert(referenceM->location != Location::INLINE);
-      return translateReferenceSimple(globalState, &referendStructs, referenceM->referend);
+      return translateReferenceSimple(globalState, &kindStructs, referenceM->kind);
     case Ownership::WEAK:
       assert(referenceM->location != Location::INLINE);
-      return translateWeakReference(globalState, &weakRefStructs, referenceM->referend);
+      return translateWeakReference(globalState, &weakRefStructs, referenceM->kind);
     default:
       assert(false);
   }
@@ -265,29 +265,29 @@ Ref Unsafe::upcastWeak(
     FunctionState* functionState,
     LLVMBuilderRef builder,
     WeakFatPtrLE sourceRefLE,
-    StructReferend* sourceStructReferendM,
+    StructKind* sourceStructKindM,
     Reference* sourceStructTypeM,
-    InterfaceReferend* targetInterfaceReferendM,
+    InterfaceKind* targetInterfaceKindM,
     Reference* targetInterfaceTypeM) {
   auto resultWeakInterfaceFatPtr =
       wrcWeaks.weakStructPtrToWrciWeakInterfacePtr(
-          globalState, functionState, builder, sourceRefLE, sourceStructReferendM,
-          sourceStructTypeM, targetInterfaceReferendM, targetInterfaceTypeM);
+          globalState, functionState, builder, sourceRefLE, sourceStructKindM,
+          sourceStructTypeM, targetInterfaceKindM, targetInterfaceTypeM);
   return wrap(this, targetInterfaceTypeM, resultWeakInterfaceFatPtr);
 }
 
 void Unsafe::declareStaticSizedArray(
     StaticSizedArrayDefinitionT* staticSizedArrayMT) {
-  globalState->regionIdByReferend.emplace(staticSizedArrayMT->referend, getRegionId());
+  globalState->regionIdByKind.emplace(staticSizedArrayMT->kind, getRegionId());
 
-  referendStructs.declareStaticSizedArray(staticSizedArrayMT);
+  kindStructs.declareStaticSizedArray(staticSizedArrayMT);
 }
 
 void Unsafe::declareRuntimeSizedArray(
     RuntimeSizedArrayDefinitionT* runtimeSizedArrayMT) {
-  globalState->regionIdByReferend.emplace(runtimeSizedArrayMT->referend, getRegionId());
+  globalState->regionIdByKind.emplace(runtimeSizedArrayMT->kind, getRegionId());
 
-  referendStructs.declareRuntimeSizedArray(runtimeSizedArrayMT);
+  kindStructs.declareRuntimeSizedArray(runtimeSizedArrayMT);
 }
 
 void Unsafe::defineRuntimeSizedArray(
@@ -295,7 +295,7 @@ void Unsafe::defineRuntimeSizedArray(
   auto elementLT =
       globalState->getRegion(runtimeSizedArrayMT->rawArray->elementType)
           ->translateType(runtimeSizedArrayMT->rawArray->elementType);
-  referendStructs.defineRuntimeSizedArray(runtimeSizedArrayMT, elementLT);
+  kindStructs.defineRuntimeSizedArray(runtimeSizedArrayMT, elementLT);
 }
 
 void Unsafe::defineStaticSizedArray(
@@ -303,14 +303,14 @@ void Unsafe::defineStaticSizedArray(
   auto elementLT =
       globalState->getRegion(staticSizedArrayMT->rawArray->elementType)
           ->translateType(staticSizedArrayMT->rawArray->elementType);
-  referendStructs.defineStaticSizedArray(staticSizedArrayMT, elementLT);
+  kindStructs.defineStaticSizedArray(staticSizedArrayMT, elementLT);
 }
 
 void Unsafe::declareStruct(
     StructDefinition* structM) {
-  globalState->regionIdByReferend.emplace(structM->referend, getRegionId());
+  globalState->regionIdByKind.emplace(structM->kind, getRegionId());
 
-  referendStructs.declareStruct(structM->referend);
+  kindStructs.declareStruct(structM->kind);
 }
 
 void Unsafe::defineStruct(
@@ -321,32 +321,32 @@ void Unsafe::defineStruct(
         globalState->getRegion(structM->members[i]->type)
             ->translateType(structM->members[i]->type));
   }
-  referendStructs.defineStruct(structM->referend, innerStructMemberTypesL);
+  kindStructs.defineStruct(structM->kind, innerStructMemberTypesL);
 }
 
 void Unsafe::declareEdge(
     Edge* edge) {
-  referendStructs.declareEdge(edge);
+  kindStructs.declareEdge(edge);
 }
 
 void Unsafe::defineEdge(
     Edge* edge) {
   auto interfaceFunctionsLT = globalState->getInterfaceFunctionTypes(edge->interfaceName);
   auto edgeFunctionsL = globalState->getEdgeFunctions(edge);
-  referendStructs.defineEdge(edge, interfaceFunctionsLT, edgeFunctionsL);
+  kindStructs.defineEdge(edge, interfaceFunctionsLT, edgeFunctionsL);
 }
 
 void Unsafe::declareInterface(
     InterfaceDefinition* interfaceM) {
-  globalState->regionIdByReferend.emplace(interfaceM->referend, getRegionId());
+  globalState->regionIdByKind.emplace(interfaceM->kind, getRegionId());
 
-  referendStructs.declareInterface(interfaceM);
+  kindStructs.declareInterface(interfaceM);
 }
 
 void Unsafe::defineInterface(
     InterfaceDefinition* interfaceM) {
-  auto interfaceMethodTypesL = globalState->getInterfaceFunctionTypes(interfaceM->referend);
-  referendStructs.defineInterface(interfaceM, interfaceMethodTypesL);
+  auto interfaceMethodTypesL = globalState->getInterfaceFunctionTypes(interfaceM->kind);
+  kindStructs.defineInterface(interfaceM, interfaceMethodTypesL);
 }
 
 void Unsafe::discardOwningRef(
@@ -369,19 +369,19 @@ void Unsafe::noteWeakableDestroyed(
   if (refM->ownership == Ownership::SHARE) {
     assert(false);
 //    // Only shared stuff is RC'd in fast mode
-//    auto rcIsZeroLE = strongRcIsZero(globalState, &referendStructs, builder, refM, controlBlockPtrLE);
+//    auto rcIsZeroLE = strongRcIsZero(globalState, &kindStructs, builder, refM, controlBlockPtrLE);
 //    buildAssert(globalState, functionState, builder, rcIsZeroLE,
 //        "Tried to free concrete that had nonzero RC!");
   } else {
     // It's a mutable, so mark WRCs dead
 
-    if (auto structReferendM = dynamic_cast<StructReferend *>(refM->referend)) {
-      auto structM = globalState->program->getStruct(structReferendM->fullName);
+    if (auto structKindM = dynamic_cast<StructKind *>(refM->kind)) {
+      auto structM = globalState->program->getStruct(structKindM);
       if (structM->weakability == Weakability::WEAKABLE) {
         wrcWeaks.innerNoteWeakableDestroyed(functionState, builder, refM, controlBlockPtrLE);
       }
-    } else if (auto interfaceReferendM = dynamic_cast<InterfaceReferend *>(refM->referend)) {
-      auto interfaceM = globalState->program->getStruct(interfaceReferendM->fullName);
+    } else if (auto interfaceKindM = dynamic_cast<InterfaceKind *>(refM->kind)) {
+      auto interfaceM = globalState->program->getInterface(interfaceKindM);
       if (interfaceM->weakability == Weakability::WEAKABLE) {
         wrcWeaks.innerNoteWeakableDestroyed(functionState, builder, refM, controlBlockPtrLE);
       }
@@ -409,13 +409,13 @@ void Unsafe::storeMember(
     case Ownership::SHARE:
     case Ownership::BORROW: {
       storeMemberStrong(
-          globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+          globalState, functionState, builder, &kindStructs, structRefMT, structRef,
           structKnownLive, memberIndex, memberName, newMemberLE);
       break;
     }
     case Ownership::WEAK: {
       storeMemberWeak(
-          globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+          globalState, functionState, builder, &kindStructs, structRefMT, structRef,
           structKnownLive, memberIndex, memberName, newMemberLE);
       break;
     }
@@ -436,11 +436,11 @@ std::tuple<LLVMValueRef, LLVMValueRef> Unsafe::explodeInterfaceRef(
     case Ownership::BORROW:
     case Ownership::SHARE: {
       return explodeStrongInterfaceRef(
-          globalState, functionState, builder, &referendStructs, virtualParamMT, virtualArgRef);
+          globalState, functionState, builder, &kindStructs, virtualParamMT, virtualArgRef);
     }
     case Ownership::WEAK: {
       return explodeWeakInterfaceRef(
-          globalState, functionState, builder, &referendStructs, &fatWeaks, &weakRefStructs,
+          globalState, functionState, builder, &kindStructs, &fatWeaks, &weakRefStructs,
           virtualParamMT, virtualArgRef,
           [this, functionState, builder, virtualParamMT](WeakFatPtrLE weakFatPtrLE) {
             return wrcWeaks.weakInterfaceRefToWeakStructRef(
@@ -458,7 +458,7 @@ Ref Unsafe::getRuntimeSizedArrayLength(
     Reference* rsaRefMT,
     Ref arrayRef,
     bool arrayKnownLive) {
-  return getRuntimeSizedArrayLengthStrong(globalState, functionState, builder, &referendStructs, rsaRefMT, arrayRef);
+  return getRuntimeSizedArrayLengthStrong(globalState, functionState, builder, &kindStructs, rsaRefMT, arrayRef);
 }
 
 LLVMValueRef Unsafe::checkValidReference(
@@ -475,13 +475,13 @@ LLVMValueRef Unsafe::checkValidReference(
   assert(LLVMTypeOf(refLE) == translateType(refM));
 
   if (refM->ownership == Ownership::OWN) {
-    regularCheckValidReference(checkerAFL, globalState, functionState, builder, &referendStructs, refM, refLE);
+    regularCheckValidReference(checkerAFL, globalState, functionState, builder, &kindStructs, refM, refLE);
   } else if (refM->ownership == Ownership::SHARE) {
     assert(false);
   } else {
     if (refM->ownership == Ownership::BORROW) {
       regularCheckValidReference(checkerAFL, globalState, functionState, builder,
-          &referendStructs, refM, refLE);
+          &kindStructs, refM, refLE);
     } else if (refM->ownership == Ownership::WEAK) {
       wrcWeaks.buildCheckWeakRef(checkerAFL, functionState, builder, refM, ref);
     } else
@@ -545,7 +545,7 @@ Ref Unsafe::upgradeLoadResultToRefWithTargetOwnership(
       return sourceRef;
     } else if (targetOwnership == Ownership::WEAK) {
       // Making a weak ref from a constraint ref local.
-      assert(dynamic_cast<StructReferend*>(sourceType->referend) || dynamic_cast<InterfaceReferend*>(sourceType->referend));
+      assert(dynamic_cast<StructKind*>(sourceType->kind) || dynamic_cast<InterfaceKind*>(sourceType->kind));
       return wrcWeaks.assembleWeakRef(functionState, builder, sourceType, targetType, sourceRef);
     } else {
       assert(false);
@@ -584,8 +584,8 @@ LLVMValueRef Unsafe::getCensusObjectId(
     Reference* refM,
     Ref ref) {
   auto controlBlockPtrLE =
-      referendStructs.getControlBlockPtr(checkerAFL, functionState, builder, ref, refM);
-  return referendStructs.getObjIdFromControlBlockPtr(builder, refM->referend, controlBlockPtrLE);
+      kindStructs.getControlBlockPtr(checkerAFL, functionState, builder, ref, refM);
+  return kindStructs.getObjIdFromControlBlockPtr(builder, refM->kind, controlBlockPtrLE);
 }
 
 Ref Unsafe::getIsAliveFromWeakRef(
@@ -602,18 +602,18 @@ void Unsafe::fillControlBlock(
     AreaAndFileAndLine from,
     FunctionState* functionState,
     LLVMBuilderRef builder,
-    Referend* referendM,
+    Kind* kindM,
     ControlBlockPtrLE controlBlockPtrLE,
     const std::string& typeName) {
 
-  LLVMValueRef newControlBlockLE = LLVMGetUndef(referendStructs.getControlBlock(referendM)->getStruct());
+  LLVMValueRef newControlBlockLE = LLVMGetUndef(kindStructs.getControlBlock(kindM)->getStruct());
 
   newControlBlockLE =
       fillControlBlockCensusFields(
-          from, globalState, functionState, &referendStructs, builder, referendM, newControlBlockLE, typeName);
+          from, globalState, functionState, &kindStructs, builder, kindM, newControlBlockLE, typeName);
 
-  if (globalState->getReferendWeakability(referendM) == Weakability::WEAKABLE) {
-    newControlBlockLE = wrcWeaks.fillWeakableControlBlock(functionState, builder, &referendStructs, referendM,
+  if (globalState->getKindWeakability(kindM) == Weakability::WEAKABLE) {
+    newControlBlockLE = wrcWeaks.fillWeakableControlBlock(functionState, builder, &kindStructs, kindM,
         newControlBlockLE);
   }
 
@@ -631,9 +631,9 @@ LoadResult Unsafe::loadElementFromSSA(
     Ref arrayRef,
     bool arrayKnownLive,
     Ref indexRef) {
-  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT->name);
+  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT);
   return regularloadElementFromSSA(
-      globalState, functionState, builder, ssaRefMT, ssaMT, ssaDef->rawArray->elementType, ssaDef->size, ssaDef->rawArray->mutability, arrayRef, arrayKnownLive, indexRef, &referendStructs);
+      globalState, functionState, builder, ssaRefMT, ssaMT, ssaDef->rawArray->elementType, ssaDef->size, ssaDef->rawArray->mutability, arrayRef, arrayKnownLive, indexRef, &kindStructs);
 }
 
 LoadResult Unsafe::loadElementFromRSA(
@@ -644,9 +644,9 @@ LoadResult Unsafe::loadElementFromRSA(
     Ref arrayRef,
     bool arrayKnownLive,
     Ref indexRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   return regularLoadElementFromRSAWithoutUpgrade(
-      globalState, functionState, builder, &referendStructs, rsaRefMT, rsaMT, rsaDef->rawArray->mutability, rsaDef->rawArray->elementType, arrayRef, arrayKnownLive, indexRef);
+      globalState, functionState, builder, &kindStructs, rsaRefMT, rsaMT, rsaDef->rawArray->mutability, rsaDef->rawArray->elementType, arrayRef, arrayKnownLive, indexRef);
 }
 
 Ref Unsafe::storeElementInRSA(
@@ -658,9 +658,9 @@ Ref Unsafe::storeElementInRSA(
     bool arrayKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   auto arrayWrapperPtrLE =
-      referendStructs.makeWrapperPtr(
+      kindStructs.makeWrapperPtr(
           FL(), functionState, builder, rsaRefMT,
           globalState->getRegion(rsaRefMT)->checkValidReference(FL(), functionState, builder, rsaRefMT, arrayRef));
   auto sizeRef = ::getRuntimeSizedArrayLength(globalState, functionState, builder, arrayWrapperPtrLE);
@@ -675,20 +675,20 @@ Ref Unsafe::upcast(
     LLVMBuilderRef builder,
 
     Reference* sourceStructMT,
-    StructReferend* sourceStructReferendM,
+    StructKind* sourceStructKindM,
     Ref sourceRefLE,
 
     Reference* targetInterfaceTypeM,
-    InterfaceReferend* targetInterfaceReferendM) {
+    InterfaceKind* targetInterfaceKindM) {
 
   switch (sourceStructMT->ownership) {
     case Ownership::SHARE:
     case Ownership::OWN:
     case Ownership::BORROW: {
-      return upcastStrong(globalState, functionState, builder, &referendStructs, sourceStructMT, sourceStructReferendM, sourceRefLE, targetInterfaceTypeM, targetInterfaceReferendM);
+      return upcastStrong(globalState, functionState, builder, &kindStructs, sourceStructMT, sourceStructKindM, sourceRefLE, targetInterfaceTypeM, targetInterfaceKindM);
     }
     case Ownership::WEAK: {
-      return ::upcastWeak(globalState, functionState, builder, &weakRefStructs, sourceStructMT, sourceStructReferendM, sourceRefLE, targetInterfaceTypeM, targetInterfaceReferendM);
+      return ::upcastWeak(globalState, functionState, builder, &weakRefStructs, sourceStructMT, sourceStructKindM, sourceRefLE, targetInterfaceTypeM, targetInterfaceKindM);
     }
     default:
       assert(false);
@@ -702,7 +702,7 @@ void Unsafe::deallocate(
     LLVMBuilderRef builder,
     Reference* refMT,
     Ref ref) {
-  innerDeallocate(from, globalState, functionState, &referendStructs, builder, refMT, ref);
+  innerDeallocate(from, globalState, functionState, &kindStructs, builder, refMT, ref);
 }
 
 Ref Unsafe::constructRuntimeSizedArray(
@@ -714,13 +714,13 @@ Ref Unsafe::constructRuntimeSizedArray(
     Ref sizeRef,
     const std::string& typeName) {
   auto rsaWrapperPtrLT =
-      referendStructs.getRuntimeSizedArrayWrapperStruct(runtimeSizedArrayT);
-  auto rsaDef = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT->name);
-  auto elementType = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT->name)->rawArray->elementType;
+      kindStructs.getRuntimeSizedArrayWrapperStruct(runtimeSizedArrayT);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT);
+  auto elementType = globalState->program->getRuntimeSizedArray(runtimeSizedArrayT)->rawArray->elementType;
   auto rsaElementLT = globalState->getRegion(elementType)->translateType(elementType);
   auto resultRef =
       ::constructRuntimeSizedArray(
-           globalState, functionState, builder, &referendStructs, rsaMT, rsaDef->rawArray->elementType, runtimeSizedArrayT,
+           globalState, functionState, builder, &kindStructs, rsaMT, rsaDef->rawArray->elementType, runtimeSizedArrayT,
            rsaWrapperPtrLT, rsaElementLT, sizeRef, typeName,
           [this, functionState, runtimeSizedArrayT, rsaMT, typeName](
               LLVMBuilderRef innerBuilder, ControlBlockPtrLE controlBlockPtrLE) {
@@ -751,7 +751,7 @@ Ref Unsafe::loadMember(
   } else {
     auto unupgradedMemberLE =
         regularLoadMember(
-            globalState, functionState, builder, &referendStructs, structRefMT, structRef,
+            globalState, functionState, builder, &kindStructs, structRefMT, structRef,
             memberIndex, expectedMemberType, targetType, memberName);
     return upgradeLoadResultToRefWithTargetOwnership(
         functionState, builder, expectedMemberType, targetType, unupgradedMemberLE);
@@ -764,86 +764,77 @@ void Unsafe::checkInlineStructType(
     Reference* refMT,
     Ref ref) {
   auto argLE = checkValidReference(FL(), functionState, builder, refMT, ref);
-  auto structReferend = dynamic_cast<StructReferend*>(refMT->referend);
-  assert(structReferend);
-  assert(LLVMTypeOf(argLE) == referendStructs.getInnerStruct(structReferend));
+  auto structKind = dynamic_cast<StructKind*>(refMT->kind);
+  assert(structKind);
+  assert(LLVMTypeOf(argLE) == kindStructs.getInnerStruct(structKind));
 }
 
 
-std::string Unsafe::getMemberArbitraryRefNameCSeeMMEDT(Reference* refMT) {
-  if (refMT->ownership == Ownership::SHARE) {
-    assert(false);
-  } else if (auto structRefMT = dynamic_cast<StructReferend*>(refMT->referend)) {
-    auto structMT = globalState->program->getStruct(structRefMT->fullName);
-    auto baseName = globalState->program->getMemberArbitraryExportNameSeeMMEDT(structRefMT->fullName);
-    if (structMT->mutability == Mutability::MUTABLE) {
-      assert(refMT->location != Location::INLINE);
-      return baseName + "Ref";
-    } else {
-      if (refMT->location == Location::INLINE) {
-        return baseName + "Inl";
-      } else {
-        return baseName + "Ref";
-      }
-    }
-  } else if (auto interfaceMT = dynamic_cast<InterfaceReferend*>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(interfaceMT->fullName) + "Ref";
-  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(rsaMT->name) + "Ref";
-  } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(refMT->referend)) {
-    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(ssaMT->name) + "Ref";
-  } else {
-    assert(false);
-  }
-}
+//std::string Unsafe::getMemberArbitraryRefNameCSeeMMEDT(Reference* refMT) {
+//  if (refMT->ownership == Ownership::SHARE) {
+//    assert(false);
+//  } else if (auto structRefMT = dynamic_cast<StructKind*>(refMT->kind)) {
+//    auto structMT = globalState->program->getStruct(structRefMT);
+//    auto baseName = globalState->program->getMemberArbitraryExportNameSeeMMEDT(structRefMT->fullName);
+//    if (structMT->mutability == Mutability::MUTABLE) {
+//      assert(refMT->location != Location::INLINE);
+//      return baseName + "Ref";
+//    } else {
+//      if (refMT->location == Location::INLINE) {
+//        return baseName + "Inl";
+//      } else {
+//        return baseName + "Ref";
+//      }
+//    }
+//  } else if (auto interfaceMT = dynamic_cast<InterfaceKind*>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(interfaceMT->fullName) + "Ref";
+//  } else if (auto rsaMT = dynamic_cast<RuntimeSizedArrayT*>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(rsaMT->name) + "Ref";
+//  } else if (auto ssaMT = dynamic_cast<StaticSizedArrayT*>(refMT->kind)) {
+//    return globalState->program->getMemberArbitraryExportNameSeeMMEDT(ssaMT->name) + "Ref";
+//  } else {
+//    assert(false);
+//  }
+//}
 
-void Unsafe::generateStructDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName, StructDefinition* structDefM) {
+std::string Unsafe::generateStructDefsC(
+    Package* currentPackage,
+    StructDefinition* structDefM) {
   if (structDefM->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto baseName : globalState->program->getExportedNames(structDefM->referend->fullName)) {
-      auto refTypeName = baseName + "Ref";
-      std::stringstream s;
-      s << "typedef struct " << refTypeName << " { void* unused; } " << refTypeName << ";" << std::endl;
-      cByExportedName->insert(std::make_pair(baseName, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(structDefM->kind);
+    return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
 
-void Unsafe::generateInterfaceDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName, InterfaceDefinition* interfaceDefM) {
+std::string Unsafe::generateInterfaceDefsC(
+    Package* currentPackage,
+    InterfaceDefinition* interfaceDefM) {
 //      return "void* unused; void* unused;";
   assert(false); // impl
+  return "";
 }
 
-void Unsafe::generateRuntimeSizedArrayDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName,
+std::string Unsafe::generateRuntimeSizedArrayDefsC(
+    Package* currentPackage,
     RuntimeSizedArrayDefinitionT* rsaDefM) {
   if (rsaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto baseName : globalState->program->getExportedNames(rsaDefM->name)) {
-      auto refTypeName = baseName + "Ref";
-      std::stringstream s;
-      s << "typedef struct " << refTypeName << " { void* unused; } " << refTypeName << ";" << std::endl;
-      cByExportedName->insert(std::make_pair(baseName, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(rsaDefM->kind);
+    return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
 
-void Unsafe::generateStaticSizedArrayDefsC(
-    std::unordered_map<std::string, std::string>* cByExportedName,
+std::string Unsafe::generateStaticSizedArrayDefsC(
+    Package* currentPackage,
     StaticSizedArrayDefinitionT* ssaDefM) {
   if (ssaDefM->rawArray->mutability == Mutability::IMMUTABLE) {
     assert(false);
   } else {
-    for (auto baseName : globalState->program->getExportedNames(ssaDefM->name)) {
-      auto refTypeName = baseName + "Ref";
-      std::stringstream s;
-      s << "typedef struct " << refTypeName << " { void* unused; } " << refTypeName << ";" << std::endl;
-      cByExportedName->insert(std::make_pair(baseName, s.str()));
-    }
+    auto name = currentPackage->getKindExportName(ssaDefM->kind);
+    return std::string() + "typedef struct " + name + "Ref { void* unused; } " + name + "Ref;\n";
   }
 }
 
@@ -852,9 +843,9 @@ Reference* Unsafe::getExternalType(Reference* refMT) {
 //  if (refMT->ownership == Ownership::SHARE) {
 //    assert(false);
 //  } else {
-//    if (auto structReferend = dynamic_cast<StructReferend*>(refMT->referend)) {
-//      return LLVMPointerType(referendStructs.getWrapperStruct(structReferend), 0);
-//    } else if (auto interfaceReferend = dynamic_cast<InterfaceReferend*>(refMT->referend)) {
+//    if (auto structKind = dynamic_cast<StructKind*>(refMT->kind)) {
+//      return LLVMPointerType(kindStructs.getWrapperStruct(structKind), 0);
+//    } else if (auto interfaceKind = dynamic_cast<InterfaceKind*>(refMT->kind)) {
 //      assert(false); // impl
 //    } else {
 //      std::cerr << "Invalid type for extern!" << std::endl;
@@ -880,7 +871,7 @@ LLVMTypeRef Unsafe::getInterfaceMethodVirtualParamAnyType(Reference* reference) 
     case Ownership::SHARE:
       return LLVMPointerType(LLVMInt8TypeInContext(globalState->context), 0);
     case Ownership::WEAK:
-      return mutWeakableStructs.getWeakVoidRefStruct(reference->referend);
+      return mutWeakableStructs.getWeakVoidRefStruct(reference->kind);
     default:
       assert(false);
   }
@@ -914,9 +905,9 @@ void Unsafe::initializeElementInRSA(
     bool arrayRefKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   auto arrayWrapperPtrLE =
-      referendStructs.makeWrapperPtr(
+      kindStructs.makeWrapperPtr(
           FL(), functionState, builder, rsaRefMT,
           globalState->getRegion(rsaRefMT)->checkValidReference(FL(), functionState, builder, rsaRefMT, rsaRef));
   auto sizeRef = ::getRuntimeSizedArrayLength(globalState, functionState, builder, arrayWrapperPtrLE);
@@ -933,9 +924,9 @@ Ref Unsafe::deinitializeElementFromRSA(
     Ref arrayRef,
     bool arrayRefKnownLive,
     Ref indexRef) {
-  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT->name);
+  auto rsaDef = globalState->program->getRuntimeSizedArray(rsaMT);
   return regularLoadElementFromRSAWithoutUpgrade(
-      globalState, functionState, builder, &referendStructs, rsaRefMT, rsaMT, rsaDef->rawArray->mutability, rsaDef->rawArray->elementType, arrayRef, true, indexRef).move();
+      globalState, functionState, builder, &kindStructs, rsaRefMT, rsaMT, rsaDef->rawArray->mutability, rsaDef->rawArray->elementType, arrayRef, true, indexRef).move();
 }
 
 void Unsafe::initializeElementInSSA(
@@ -947,9 +938,9 @@ void Unsafe::initializeElementInSSA(
     bool arrayRefKnownLive,
     Ref indexRef,
     Ref elementRef) {
-  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT->name);
+  auto ssaDef = globalState->program->getStaticSizedArray(ssaMT);
   auto arrayWrapperPtrLE =
-      referendStructs.makeWrapperPtr(
+      kindStructs.makeWrapperPtr(
           FL(), functionState, builder, ssaRefMT,
           globalState->getRegion(ssaRefMT)->checkValidReference(FL(), functionState, builder, ssaRefMT, arrayRef));
   auto sizeRef = globalState->constI64(ssaDef->size);
@@ -970,11 +961,11 @@ Ref Unsafe::deinitializeElementFromSSA(
   exit(1);
 }
 
-Weakability Unsafe::getReferendWeakability(Referend* referend) {
-  if (auto structReferend = dynamic_cast<StructReferend*>(referend)) {
-    return globalState->lookupStruct(structReferend->fullName)->weakability;
-  } else if (auto interfaceReferend = dynamic_cast<InterfaceReferend*>(referend)) {
-    return globalState->lookupInterface(interfaceReferend->fullName)->weakability;
+Weakability Unsafe::getKindWeakability(Kind* kind) {
+  if (auto structKind = dynamic_cast<StructKind*>(kind)) {
+    return globalState->lookupStruct(structKind)->weakability;
+  } else if (auto interfaceKind = dynamic_cast<InterfaceKind*>(kind)) {
+    return globalState->lookupInterface(interfaceKind)->weakability;
   } else {
     return Weakability::NON_WEAKABLE;
   }
@@ -1011,4 +1002,10 @@ Ref Unsafe::loadLocal(FunctionState* functionState, LLVMBuilderRef builder, Loca
 
 Ref Unsafe::localStore(FunctionState* functionState, LLVMBuilderRef builder, Local* local, LLVMValueRef localAddr, Ref refToStore, bool knownLive) {
   return normalLocalStore(globalState, functionState, builder, local, localAddr, refToStore);
+}
+
+std::string Unsafe::getExportName(
+    Package* package,
+    Reference* reference) {
+  return package->getKindExportName(reference->kind) + (reference->location == Location::YONDER ? "Ref" : "");
 }

--- a/Midas/src/c-compiler/region/unsafe/unsafe.h
+++ b/Midas/src/c-compiler/region/unsafe/unsafe.h
@@ -409,7 +409,7 @@ public:
 
 
 
-  std::string getExportName(Package* currentPackage, Reference* refMT) override;
+  std::string getExportName(Package* currentPackage, Reference* refMT, bool includeProjectName) override;
   std::string generateStructDefsC(
     Package* currentPackage,
       StructDefinition* refMT) override;

--- a/Midas/src/c-compiler/region/unsafe/unsafe.h
+++ b/Midas/src/c-compiler/region/unsafe/unsafe.h
@@ -43,9 +43,9 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       WeakFatPtrLE sourceRefLE,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Reference* sourceStructTypeM,
-      InterfaceReferend* targetInterfaceReferendM,
+      InterfaceKind* targetInterfaceKindM,
       Reference* targetInterfaceTypeM) override;
 
   Ref upcast(
@@ -53,11 +53,11 @@ public:
       LLVMBuilderRef builder,
 
       Reference* sourceStructMT,
-      StructReferend* sourceStructReferendM,
+      StructKind* sourceStructKindM,
       Ref sourceRefLE,
 
       Reference* targetInterfaceTypeM,
-      InterfaceReferend* targetInterfaceReferendM) override;
+      InterfaceKind* targetInterfaceKindM) override;
 
 
   void defineStaticSizedArray(
@@ -104,7 +104,7 @@ public:
       Reference* sourceInterfaceRefMT,
       Ref sourceInterfaceRefLE,
       bool sourceRefKnownLive,
-      Referend* targetReferend,
+      Kind* targetKind,
       std::function<Ref(LLVMBuilderRef, Ref)> buildThen,
       std::function<Ref(LLVMBuilderRef)> buildElse) override;
 
@@ -115,7 +115,7 @@ public:
       FunctionState* functionState,
       LLVMBuilderRef builder,
       Reference* referenceM,
-      StaticSizedArrayT* referendM) override;
+      StaticSizedArrayT* kindM) override;
 
   // should expose a dereference thing instead
 //  LLVMValueRef getStaticSizedArrayElementsPtr(
@@ -353,7 +353,7 @@ public:
 //      FunctionState* functionState,
 //      LLVMBuilderRef builder,
 //      Location location,
-//      LLVMTypeRef referendLT) override;
+//      LLVMTypeRef kindLT) override;
 
 //  LLVMValueRef mallocRuntimeSizedArray(
 //      LLVMBuilderRef builder,
@@ -366,58 +366,62 @@ public:
 //    return mutWeakableStructs.makeWeakFatPtr(referenceM_, ptrLE);
 //  }
   // TODO get rid of these once refactor is done
-//  ControlBlock* getControlBlock(Referend* referend) override {
-//    return referendStructs.getControlBlock(referend);
+//  ControlBlock* getControlBlock(Kind* kind) override {
+//    return kindStructs.getControlBlock(kind);
 //  }
-//  IReferendStructsSource* getReferendStructsSource() override {
-//    return &referendStructs;
+//  IKindStructsSource* getKindStructsSource() override {
+//    return &kindStructs;
 //  }
 //  IWeakRefStructsSource* getWeakRefStructsSource() override {
 //    return &weakRefStructs;
 //  }
   LLVMValueRef getStringBytesPtr(FunctionState* functionState, LLVMBuilderRef builder, Ref ref) override {
     auto strWrapperPtrLE =
-        referendStructs.makeWrapperPtr(
+        kindStructs.makeWrapperPtr(
             FL(), functionState, builder,
             globalState->metalCache->strRef,
             checkValidReference(
                 FL(), functionState, builder, globalState->metalCache->strRef, ref));
-    return referendStructs.getStringBytesPtr(functionState, builder, strWrapperPtrLE);
+    return kindStructs.getStringBytesPtr(functionState, builder, strWrapperPtrLE);
   }
   LLVMValueRef getStringLen(FunctionState* functionState, LLVMBuilderRef builder, Ref ref) override {
     auto strWrapperPtrLE =
-        referendStructs.makeWrapperPtr(
+        kindStructs.makeWrapperPtr(
             FL(), functionState, builder,
             globalState->metalCache->strRef,
             checkValidReference(
                 FL(), functionState, builder, globalState->metalCache->strRef, ref));
-    return referendStructs.getStringLen(functionState, builder, strWrapperPtrLE);
+    return kindStructs.getStringLen(functionState, builder, strWrapperPtrLE);
   }
-//  LLVMTypeRef getWeakRefHeaderStruct(Referend* referend) override {
-//    return mutWeakableStructs.getWeakRefHeaderStruct(referend);
+//  LLVMTypeRef getWeakRefHeaderStruct(Kind* kind) override {
+//    return mutWeakableStructs.getWeakRefHeaderStruct(kind);
 //  }
-//  LLVMTypeRef getWeakVoidRefStruct(Referend* referend) override {
-//    return mutWeakableStructs.getWeakVoidRefStruct(referend);
+//  LLVMTypeRef getWeakVoidRefStruct(Kind* kind) override {
+//    return mutWeakableStructs.getWeakVoidRefStruct(kind);
 //  }
   void fillControlBlock(
       AreaAndFileAndLine from,
       FunctionState* functionState,
       LLVMBuilderRef builder,
-      Referend* referendM,
+      Kind* kindM,
       ControlBlockPtrLE controlBlockPtrLE,
       const std::string& typeName);
 
 
-  std::string getMemberArbitraryRefNameCSeeMMEDT(
-      Reference* refMT) override;
-  void generateStructDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StructDefinition* refMT) override;
-  void generateInterfaceDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, InterfaceDefinition* refMT) override;
-  void generateStaticSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, StaticSizedArrayDefinitionT* ssaDefM) override;
-  void generateRuntimeSizedArrayDefsC(
-      std::unordered_map<std::string, std::string>* cByExportedName, RuntimeSizedArrayDefinitionT* rsaDefM) override;
+
+  std::string getExportName(Package* currentPackage, Reference* refMT) override;
+  std::string generateStructDefsC(
+    Package* currentPackage,
+      StructDefinition* refMT) override;
+  std::string generateInterfaceDefsC(
+    Package* currentPackage,
+      InterfaceDefinition* refMT) override;
+  std::string generateStaticSizedArrayDefsC(
+    Package* currentPackage,
+      StaticSizedArrayDefinitionT* ssaDefM) override;
+  std::string generateRuntimeSizedArrayDefsC(
+    Package* currentPackage,
+      RuntimeSizedArrayDefinitionT* rsaDefM) override;
 
   Reference* getExternalType(Reference* refMT) override;
 
@@ -450,7 +454,7 @@ public:
   void declareExtraFunctions() override {}
   void defineExtraFunctions() override {}
 
-  Weakability getReferendWeakability(Referend* referend) override;
+  Weakability getKindWeakability(Kind* kind) override;
 
   void declareStructExtraFunctions(StructDefinition* structDefM) override {}
   void declareStaticSizedArrayExtraFunctions(StaticSizedArrayDefinitionT* ssaDef) override {}
@@ -483,10 +487,10 @@ public:
 protected:
   GlobalState* globalState = nullptr;
 
-  ReferendStructs mutNonWeakableStructs;
-  WeakableReferendStructs mutWeakableStructs;
+  KindStructs mutNonWeakableStructs;
+  WeakableKindStructs mutWeakableStructs;
 
-  ReferendStructsRouter referendStructs;
+  KindStructsRouter kindStructs;
   WeakRefStructsRouter weakRefStructs;
 
   FatWeaks fatWeaks;
@@ -494,7 +498,7 @@ protected:
 
   LLVMTypeRef regionLT;
 
-  // TODO see if we can just use referendStructs/weakRefStructs instead of having these?
+  // TODO see if we can just use kindStructs/weakRefStructs instead of having these?
 //  WeakFatPtrLEMaker weakFatPtrMaker;
 //  InterfaceFatPtrLEMaker interfaceFatPtrMaker;
 //  ControlBlockPtrLEMaker controlBlockPtrMaker;

--- a/Midas/src/c-compiler/vale.cpp
+++ b/Midas/src/c-compiler/vale.cpp
@@ -233,7 +233,7 @@ void generateExports(GlobalState* globalState, Prototype* mainM) {
       if (!skipExporting) {
         std::stringstream s;
         auto externReturnType = globalState->getRegion(functionM->prototype->returnType)->getExternalType(functionM->prototype->returnType);
-        auto returnExportName = globalState->getRegion(externReturnType)->getExportName(package, externReturnType);
+        auto returnExportName = globalState->getRegion(externReturnType)->getExportName(package, externReturnType, true);
         s << "extern " << returnExportName << " ";
         s << exportName << "(";
         for (int i = 0; i < functionM->prototype->params.size(); i++) {
@@ -241,7 +241,7 @@ void generateExports(GlobalState* globalState, Prototype* mainM) {
             s << ", ";
           }
           auto hostParamRefMT = globalState->getRegion(functionM->prototype->params[i])->getExternalType(functionM->prototype->params[i]);
-          auto paramExportName = globalState->getRegion(hostParamRefMT)->getExportName(package, hostParamRefMT);
+          auto paramExportName = globalState->getRegion(hostParamRefMT)->getExportName(package, hostParamRefMT, true);
           s << paramExportName << " param" << i;
         }
         s << ");" << std::endl;
@@ -717,7 +717,7 @@ void compileValeCode(GlobalState* globalState, const std::string& filename) {
 
   for (auto[packageCoord, package] : program->packages) {
     for (auto[externName, prototype] : package->externNameToFunction) {
-      declareExternFunction(globalState, prototype);
+      declareExternFunction(globalState, package, prototype);
     }
   }
 
@@ -732,7 +732,7 @@ void compileValeCode(GlobalState* globalState, const std::string& filename) {
       bool skipExporting = exportName == "main";
       if (!skipExporting) {
         auto function = program->getFunction(prototype->name);
-        exportFunction(globalState, package, function, exportName);
+        exportFunction(globalState, package, function);
       }
     }
   }

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/Astronomer.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/Astronomer.scala
@@ -21,12 +21,12 @@ case class Environment(
     typeByRune: Map[IRuneA, ITemplataType],
     locals: List[LocalVariableA]) {
 
-  val structsS: List[StructS] = codeMap.moduleToPackagesToFilenameToContents.values.flatMap(_.values.flatMap(_.structs)).toList
-  val interfacesS: List[InterfaceS] = codeMap.moduleToPackagesToFilenameToContents.values.flatMap(_.values.flatMap(_.interfaces)).toList
-  val implsS: List[ImplS] = codeMap.moduleToPackagesToFilenameToContents.values.flatMap(_.values.flatMap(_.impls)).toList
-  val functionsS: List[FunctionS] = codeMap.moduleToPackagesToFilenameToContents.values.flatMap(_.values.flatMap(_.implementedFunctions)).toList
-  val exportsS: List[ExportAsS] = codeMap.moduleToPackagesToFilenameToContents.values.flatMap(_.values.flatMap(_.exports)).toList
-  val imports: List[ImportS] = codeMap.moduleToPackagesToFilenameToContents.values.flatMap(_.values.flatMap(_.imports)).toList
+  val structsS: List[StructS] = codeMap.moduleToPackagesToContents.values.flatMap(_.values.flatMap(_.structs)).toList
+  val interfacesS: List[InterfaceS] = codeMap.moduleToPackagesToContents.values.flatMap(_.values.flatMap(_.interfaces)).toList
+  val implsS: List[ImplS] = codeMap.moduleToPackagesToContents.values.flatMap(_.values.flatMap(_.impls)).toList
+  val functionsS: List[FunctionS] = codeMap.moduleToPackagesToContents.values.flatMap(_.values.flatMap(_.implementedFunctions)).toList
+  val exportsS: List[ExportAsS] = codeMap.moduleToPackagesToContents.values.flatMap(_.values.flatMap(_.exports)).toList
+  val imports: List[ImportS] = codeMap.moduleToPackagesToContents.values.flatMap(_.values.flatMap(_.imports)).toList
 
   def addLocals(newLocals: List[LocalVariableA]): Environment = {
     Environment(maybeName, maybeParentEnv, primitives, codeMap, typeByRune, locals ++ newLocals)

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/OrderModules.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/OrderModules.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable.List
 object OrderModules {
   def orderModules(mergedProgramS: PackageCoordinateMap[ProgramS]): List[String] = {
     val dependentAndDependeeModule: List[(String, String)] =
-      mergedProgramS.moduleToPackagesToFilenameToContents.map({ case (dependentModuleName, packagesToFilenameToContents) =>
+      mergedProgramS.moduleToPackagesToContents.map({ case (dependentModuleName, packagesToFilenameToContents) =>
         val dependeeModules = packagesToFilenameToContents.values.flatMap(_.imports.map(_.moduleName))
         dependeeModules.map(dependeeName => (dependentModuleName -> dependeeName))
       }).flatten.toList

--- a/Valestrom/Astronomer/test/net/verdagon/vale/astronomer/ErrorTests.scala
+++ b/Valestrom/Astronomer/test/net/verdagon/vale/astronomer/ErrorTests.scala
@@ -61,7 +61,7 @@ class ErrorTests extends FunSuite with Matchers  {
   test("Report type not found") {
     val compilation =
       new Compilation(
-      """fn main() {
+      """fn main() export {
         |  a Bork = 5;
         |}
         |""".stripMargin)
@@ -82,7 +82,7 @@ class ErrorTests extends FunSuite with Matchers  {
           |fn moo<A>(x int) {
           |  42
           |}
-          |fn main() {
+          |fn main() export {
           |  moo();
           |}
           |""".stripMargin)

--- a/Valestrom/Driver/src/net/verdagon/vale/driver/FullCompilation.scala
+++ b/Valestrom/Driver/src/net/verdagon/vale/driver/FullCompilation.scala
@@ -9,7 +9,7 @@ import net.verdagon.vale.parser.{CombinatorParsers, FailedParse, FileP, ImportP,
 import net.verdagon.vale.scout.{ICompileErrorS, ProgramS, Scout}
 import net.verdagon.vale.templar.{ICompileErrorT, Templar, TemplarErrorHumanizer, Temputs}
 import net.verdagon.vale.{Builtins, Err, FileCoordinate, FileCoordinateMap, IPackageResolver, IProfiler, NullProfiler, Ok, PackageCoordinate, PackageCoordinateMap, Result, vassert, vassertSome, vfail, vimpl, vwat}
-import net.verdagon.vale.vivem.{Heap, PrimitiveReferendV, ReferenceV, Vivem}
+import net.verdagon.vale.vivem.{Heap, PrimitiveKindV, ReferenceV, Vivem}
 import net.verdagon.von.{IVonData, JsonSyntax, VonPrinter}
 
 import scala.collection.immutable.List

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/CallHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/CallHammer.scala
@@ -17,7 +17,7 @@ object CallHammer {
     locals: LocalsBox,
     prototype2: Prototype2,
     argsExprs2: List[ReferenceExpression2]):
-  (ExpressionH[ReferendH]) = {
+  (ExpressionH[KindH]) = {
     val (argsResultLines, argsDeferreds) =
       ExpressionHammer.translateExpressions(
         hinputs, hamuts, currentFunctionHeader, locals, argsExprs2);
@@ -44,7 +44,7 @@ object CallHammer {
       function: Prototype2,
       args: List[Expression2],
       resultType2: Coord):
-  ExpressionH[ReferendH] = {
+  ExpressionH[KindH] = {
     val returnType2 = function.returnType
     val paramTypes = function.paramTypes
     val (argLines, argsDeferreds) =
@@ -75,7 +75,7 @@ object CallHammer {
       currentFunctionHeader: FunctionHeader2,
       locals: LocalsBox,
       constructArray2: ConstructArray2):
-  (ExpressionH[ReferendH]) = {
+  (ExpressionH[KindH]) = {
     val ConstructArray2(arrayType2, sizeExpr2, generatorExpr2, generatorMethod) = constructArray2;
 
     val (sizeRegisterId, sizeDeferreds) =
@@ -117,7 +117,7 @@ object CallHammer {
     currentFunctionHeader: FunctionHeader2,
     locals: LocalsBox,
     exprTE: StaticArrayFromCallable2):
-  (ExpressionH[ReferendH]) = {
+  (ExpressionH[KindH]) = {
     val StaticArrayFromCallable2(arrayType2, generatorExpr2, generatorMethod) = exprTE;
 
     val (generatorRegisterId, generatorDeferreds) =
@@ -154,7 +154,7 @@ object CallHammer {
       currentFunctionHeader: FunctionHeader2,
       locals: LocalsBox,
       das2: DestroyStaticSizedArrayIntoFunction2):
-  ExpressionH[ReferendH] = {
+  ExpressionH[KindH] = {
     val DestroyStaticSizedArrayIntoFunction2(arrayExpr2, staticSizedArrayType, consumerExpr2, consumerMethod2) = das2;
 
     val (arrayTypeH) =
@@ -200,7 +200,7 @@ object CallHammer {
       currentFunctionHeader: FunctionHeader2,
     locals: LocalsBox,
     das2: DestroyRuntimeSizedArray2):
-  ExpressionH[ReferendH] = {
+  ExpressionH[KindH] = {
     val DestroyRuntimeSizedArray2(arrayExpr2, runtimeSizedArrayType2, consumerExpr2, consumerMethod2) = das2;
 
 //    val RuntimeSizedArrayT2(RawArrayT2(memberType2, mutability)) = runtimeSizedArrayType2
@@ -244,7 +244,7 @@ object CallHammer {
     currentFunctionHeader: FunctionHeader2,
     parentLocals: LocalsBox,
     if2: If2):
-  ExpressionH[ReferendH] = {
+  ExpressionH[KindH] = {
     val If2(condition2, thenBlock2, elseBlock2) = if2
 
     val (conditionBlockH, List()) =
@@ -330,7 +330,7 @@ object CallHammer {
       superFunctionHeader: FunctionHeader2,
       resultType2: Coord,
       argsExprs2: List[Expression2]):
-  ExpressionH[ReferendH] = {
+  ExpressionH[KindH] = {
     val (argLines, argsDeferreds) =
       ExpressionHammer.translateExpressions(
         hinputs, hamuts, currentFunctionHeader, locals, argsExprs2);
@@ -438,8 +438,8 @@ object CallHammer {
 //      firstVirtualParamIndex: Int,
 //      firstVirtualParamInterface: InterfaceRefH,
 //      functionTypeH: FunctionTH,
-//      argLines: List[NodeH[ReferendH]]):
-//  (Vector[NodeH], Option[NodeH[ReferendH]]) = {
+//      argLines: List[NodeH[KindH]]):
+//  (Vector[NodeH], Option[NodeH[KindH]]) = {
 //    val interfaceId = firstVirtualParamInterface.interfaceId
 //
 //    val edgeBlueprint =

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/ExpressionHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/ExpressionHammer.scala
@@ -23,7 +23,7 @@ object ExpressionHammer {
       currentFunctionHeader: FunctionHeader2,
       locals: LocalsBox,
       expr2: Expression2
-  ): (ExpressionH[ReferendH], List[Expression2]) = {
+  ): (ExpressionH[KindH], List[Expression2]) = {
     expr2 match {
       case IntLiteral2(value) => {
         (ConstantI64H(value), List())
@@ -415,7 +415,7 @@ object ExpressionHammer {
             translateDeferreds(hinputs, hamuts, currentFunctionHeader, locals, innerExprResultLine, innerDeferreds)
 
         vassert(
-          innerExpr.resultRegister.referend == Never2() ||
+          innerExpr.resultRegister.kind == Never2() ||
           innerExpr.resultRegister.reference == currentFunctionHeader.returnType)
         (ReturnH(innerWithDeferreds), List())
       }
@@ -511,9 +511,9 @@ object ExpressionHammer {
     hamuts: HamutsBox,
     currentFunctionHeader: FunctionHeader2,
     locals: LocalsBox,
-    originalExpr: ExpressionH[ReferendH],
+    originalExpr: ExpressionH[KindH],
     deferreds: List[Expression2]):
-  ExpressionH[ReferendH] = {
+  ExpressionH[KindH] = {
     if (deferreds.isEmpty) {
       return originalExpr
     }
@@ -555,7 +555,7 @@ object ExpressionHammer {
     currentFunctionHeader: FunctionHeader2,
       locals: LocalsBox,
       exprs2: List[Expression2]):
-  (List[ExpressionH[ReferendH]], List[Expression2]) = {
+  (List[ExpressionH[KindH]], List[Expression2]) = {
     exprs2 match {
       case Nil => (List(), List())
       case firstExpr :: restExprs => {
@@ -576,7 +576,7 @@ object ExpressionHammer {
     currentFunctionHeader: FunctionHeader2,
     locals: LocalsBox,
     exprs2: List[Expression2]):
-  List[ExpressionH[ReferendH]] = {
+  List[ExpressionH[KindH]] = {
     exprs2 match {
       case Nil => List()
       case firstExpr :: restExprs => {

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/FunctionHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/FunctionHammer.scala
@@ -64,8 +64,16 @@ object FunctionHammer {
         val functionH = FunctionH(prototypeH, maybeExportNsCoord.nonEmpty, isAbstract, isExtern, attrsH, bodyH);
         hamuts.addFunction(header.toPrototype, functionH)
 
-        if (maybeExportNsCoord.nonEmpty) {
-          Hammer.exportName(hamuts, maybeExportNsCoord.get, function2.header.fullName, prototypeH.fullName)
+        maybeExportNsCoord match {
+          case None =>
+          case Some(exportPackageCoord) => {
+            val exportedName =
+              humanName.last match {
+                case FunctionName2(humanName, _, _) => humanName
+                case _ => vfail("Can't export something that doesn't have a human readable name!")
+              }
+            hamuts.addFunctionExport(prototypeH, exportPackageCoord, exportedName)
+          }
         }
 
         (temporaryFunctionRefH)

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/Hamuts.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/Hamuts.scala
@@ -10,9 +10,10 @@ import net.verdagon.von.IVonData
 
 case class HamutsBox(var inner: Hamuts) {
 
-  def packageCoordToExportNameToFullName: Map[PackageCoordinate, Map[String, FullNameH]] = {
-    inner.packageCoordToExportNameToFullName
-  }
+  def packageCoordToExportNameToFunction: Map[PackageCoordinate, Map[String, PrototypeH]] = inner.packageCoordToExportNameToFunction
+  def packageCoordToExportNameToKind: Map[PackageCoordinate, Map[String, KindH]] = inner.packageCoordToExportNameToKind
+  def packageCoordToExternNameToFunction: Map[PackageCoordinate, Map[String, PrototypeH]] = inner.packageCoordToExternNameToFunction
+  def packageCoordToExternNameToKind: Map[PackageCoordinate, Map[String, KindH]] = inner.packageCoordToExternNameToKind
   def structRefsByRef2: Map[StructRef2, StructRefH] = inner.structRefsByRef2
   def structDefsByRef2: Map[StructRef2, StructDefinitionH] = inner.structDefsByRef2
   def structDefs: List[StructDefinitionH] = inner.structDefs
@@ -59,8 +60,20 @@ case class HamutsBox(var inner: Hamuts) {
     inner = inner.addFunction(functionRef2, functionDefH)
   }
 
-  def addExport(fullNameH: FullNameH, packageCoordinate: PackageCoordinate, exportedName: String): Unit = {
-    inner = inner.addExport(fullNameH, packageCoordinate, exportedName)
+  def addKindExport(kind: KindH, packageCoordinate: PackageCoordinate, exportedName: String): Unit = {
+    inner = inner.addKindExport(kind, packageCoordinate, exportedName)
+  }
+
+  def addKindExtern(kind: KindH, packageCoordinate: PackageCoordinate, exportedName: String): Unit = {
+    inner = inner.addKindExtern(kind, packageCoordinate, exportedName)
+  }
+
+  def addFunctionExport(prototype: PrototypeH, packageCoordinate: PackageCoordinate, exportedName: String): Unit = {
+    inner = inner.addFunctionExport(prototype, packageCoordinate, exportedName)
+  }
+
+  def addFunctionExtern(prototype: PrototypeH, packageCoordinate: PackageCoordinate, exportedName: String): Unit = {
+    inner = inner.addFunctionExtern(prototype, packageCoordinate, exportedName)
   }
 
   def getNameId(readableName: String, packageCoordinate: PackageCoordinate, parts: List[IVonData]): Int = {
@@ -79,7 +92,6 @@ case class HamutsBox(var inner: Hamuts) {
 
 case class Hamuts(
     idByFullNameByHumanName: Map[String, Map[String, Int]],
-    packageCoordToExportNameToFullName: Map[PackageCoordinate, Map[String, FullNameH]],
     structRefsByRef2: Map[StructRef2, StructRefH],
     structDefsByRef2: Map[StructRef2, StructDefinitionH],
     structDefs: List[StructDefinitionH],
@@ -88,11 +100,14 @@ case class Hamuts(
     interfaceRefs: Map[InterfaceRef2, InterfaceRefH],
     interfaceDefs: Map[InterfaceRef2, InterfaceDefinitionH],
     functionRefs: Map[Prototype2, FunctionRefH],
-    functionDefs: Map[Prototype2, FunctionH]) {
+    functionDefs: Map[Prototype2, FunctionH],
+    packageCoordToExportNameToFunction: Map[PackageCoordinate, Map[String, PrototypeH]],
+    packageCoordToExportNameToKind: Map[PackageCoordinate, Map[String, KindH]],
+    packageCoordToExternNameToFunction: Map[PackageCoordinate, Map[String, PrototypeH]],
+    packageCoordToExternNameToKind: Map[PackageCoordinate, Map[String, KindH]]) {
   def forwardDeclareStruct(structRef2: StructRef2, structRefH: StructRefH): Hamuts = {
     Hamuts(
       idByFullNameByHumanName,
-      packageCoordToExportNameToFullName,
       structRefsByRef2 + (structRef2 -> structRefH),
       structDefsByRef2,
       structDefs,
@@ -101,14 +116,17 @@ case class Hamuts(
       interfaceRefs,
       interfaceDefs,
       functionRefs,
-      functionDefs)
+      functionDefs,
+      packageCoordToExportNameToFunction,
+      packageCoordToExportNameToKind,
+      packageCoordToExternNameToFunction,
+      packageCoordToExternNameToKind)
   }
 
   def addStructOriginatingFromTemplar(structRef2: StructRef2, structDefH: StructDefinitionH): Hamuts = {
     vassert(structRefsByRef2.contains(structRef2))
     Hamuts(
       idByFullNameByHumanName,
-      packageCoordToExportNameToFullName,
       structRefsByRef2,
       structDefsByRef2 + (structRef2 -> structDefH),
       structDefs :+ structDefH,
@@ -117,13 +135,16 @@ case class Hamuts(
       interfaceRefs,
       interfaceDefs,
       functionRefs,
-      functionDefs)
+      functionDefs,
+      packageCoordToExportNameToFunction,
+      packageCoordToExportNameToKind,
+      packageCoordToExternNameToFunction,
+      packageCoordToExternNameToKind)
   }
 
   def addStructOriginatingFromHammer(structDefH: StructDefinitionH): Hamuts = {
     Hamuts(
       idByFullNameByHumanName,
-      packageCoordToExportNameToFullName,
       structRefsByRef2,
       structDefsByRef2,
       structDefs :+ structDefH,
@@ -132,13 +153,16 @@ case class Hamuts(
       interfaceRefs,
       interfaceDefs,
       functionRefs,
-      functionDefs)
+      functionDefs,
+      packageCoordToExportNameToFunction,
+      packageCoordToExportNameToKind,
+      packageCoordToExternNameToFunction,
+      packageCoordToExternNameToKind)
   }
 
   def forwardDeclareInterface(interfaceRef2: InterfaceRef2, interfaceRefH: InterfaceRefH): Hamuts = {
     Hamuts(
       idByFullNameByHumanName,
-      packageCoordToExportNameToFullName,
       structRefsByRef2,
       structDefsByRef2,
       structDefs,
@@ -147,14 +171,17 @@ case class Hamuts(
       interfaceRefs + (interfaceRef2 -> interfaceRefH),
       interfaceDefs,
       functionRefs,
-      functionDefs)
+      functionDefs,
+      packageCoordToExportNameToFunction,
+      packageCoordToExportNameToKind,
+      packageCoordToExternNameToFunction,
+      packageCoordToExternNameToKind)
   }
 
   def addInterface(interfaceRef2: InterfaceRef2, interfaceDefH: InterfaceDefinitionH): Hamuts = {
     vassert(interfaceRefs.contains(interfaceRef2))
     Hamuts(
       idByFullNameByHumanName,
-      packageCoordToExportNameToFullName,
       structRefsByRef2,
       structDefsByRef2,
       structDefs,
@@ -163,13 +190,16 @@ case class Hamuts(
       interfaceRefs,
       interfaceDefs + (interfaceRef2 -> interfaceDefH),
       functionRefs,
-      functionDefs)
+      functionDefs,
+      packageCoordToExportNameToFunction,
+      packageCoordToExportNameToKind,
+      packageCoordToExternNameToFunction,
+      packageCoordToExternNameToKind)
   }
 
   def forwardDeclareFunction(functionRef2: Prototype2, functionRefH: FunctionRefH): Hamuts = {
     Hamuts(
       idByFullNameByHumanName,
-      packageCoordToExportNameToFullName,
       structRefsByRef2,
       structDefsByRef2,
       structDefs,
@@ -178,7 +208,11 @@ case class Hamuts(
       interfaceRefs,
       interfaceDefs,
       functionRefs + (functionRef2 -> functionRefH),
-      functionDefs)
+      functionDefs,
+      packageCoordToExportNameToFunction,
+      packageCoordToExportNameToKind,
+      packageCoordToExternNameToFunction,
+      packageCoordToExternNameToKind)
   }
 
   def addFunction(functionRef2: Prototype2, functionDefH: FunctionH): Hamuts = {
@@ -186,7 +220,6 @@ case class Hamuts(
 
     Hamuts(
       idByFullNameByHumanName,
-      packageCoordToExportNameToFullName,
       structRefsByRef2,
       structDefsByRef2,
       structDefs,
@@ -195,19 +228,23 @@ case class Hamuts(
       interfaceRefs,
       interfaceDefs,
       functionRefs,
-      functionDefs + (functionRef2 -> functionDefH))
+      functionDefs + (functionRef2 -> functionDefH),
+      packageCoordToExportNameToFunction,
+      packageCoordToExportNameToKind,
+      packageCoordToExternNameToFunction,
+      packageCoordToExternNameToKind)
   }
 
-  def addExport(fullNameH: FullNameH, packageCoordinate: PackageCoordinate, exportedName: String): Hamuts = {
-    val newExportNameToFullName =
-      packageCoordToExportNameToFullName.get(packageCoordinate) match {
+  def addKindExport(kind: KindH, packageCoordinate: PackageCoordinate, exportedName: String): Hamuts = {
+    val newPackageCoordToExportNameToKind =
+      packageCoordToExportNameToKind.get(packageCoordinate) match {
         case None => {
-          packageCoordToExportNameToFullName + (packageCoordinate -> Map(exportedName -> fullNameH))
+          packageCoordToExportNameToKind + (packageCoordinate -> Map(exportedName -> kind))
         }
         case Some(exportNameToFullName) => {
           exportNameToFullName.get(exportedName) match {
             case None => {
-              packageCoordToExportNameToFullName + (packageCoordinate -> (exportNameToFullName + (exportedName -> fullNameH)))
+              packageCoordToExportNameToKind + (packageCoordinate -> (exportNameToFullName + (exportedName -> kind)))
             }
             case Some(existingFullName) => {
               vfail("Already exported a `" + exportedName + "` from package `" + packageCoordinate + " : " + existingFullName)
@@ -218,7 +255,6 @@ case class Hamuts(
 
     Hamuts(
       idByFullNameByHumanName,
-      newExportNameToFullName,
       structRefsByRef2,
       structDefsByRef2,
       structDefs,
@@ -227,13 +263,121 @@ case class Hamuts(
       interfaceRefs,
       interfaceDefs,
       functionRefs,
-      functionDefs)
+      functionDefs,
+      packageCoordToExportNameToFunction,
+      newPackageCoordToExportNameToKind,
+      packageCoordToExternNameToFunction,
+      packageCoordToExternNameToKind)
+  }
+
+  def addFunctionExport(function: PrototypeH, packageCoordinate: PackageCoordinate, exportedName: String): Hamuts = {
+    val newPackageCoordToExportNameToFunction =
+      packageCoordToExportNameToFunction.get(packageCoordinate) match {
+        case None => {
+          packageCoordToExportNameToFunction + (packageCoordinate -> Map(exportedName -> function))
+        }
+        case Some(exportNameToFullName) => {
+          exportNameToFullName.get(exportedName) match {
+            case None => {
+              packageCoordToExportNameToFunction + (packageCoordinate -> (exportNameToFullName + (exportedName -> function)))
+            }
+            case Some(existingFullName) => {
+              vfail("Already exported a `" + exportedName + "` from package `" + packageCoordinate + " : " + existingFullName)
+            }
+          }
+        }
+      }
+
+    Hamuts(
+      idByFullNameByHumanName,
+      structRefsByRef2,
+      structDefsByRef2,
+      structDefs,
+      staticSizedArrays,
+      runtimeSizedArrays,
+      interfaceRefs,
+      interfaceDefs,
+      functionRefs,
+      functionDefs,
+      newPackageCoordToExportNameToFunction,
+      packageCoordToExportNameToKind,
+      packageCoordToExternNameToFunction,
+      packageCoordToExternNameToKind)
+  }
+
+  def addKindExtern(kind: KindH, packageCoordinate: PackageCoordinate, exportedName: String): Hamuts = {
+    val newPackageCoordToExternNameToKind =
+      packageCoordToExternNameToKind.get(packageCoordinate) match {
+        case None => {
+          packageCoordToExternNameToKind + (packageCoordinate -> Map(exportedName -> kind))
+        }
+        case Some(exportNameToFullName) => {
+          exportNameToFullName.get(exportedName) match {
+            case None => {
+              packageCoordToExternNameToKind + (packageCoordinate -> (exportNameToFullName + (exportedName -> kind)))
+            }
+            case Some(existingFullName) => {
+              vfail("Already exported a `" + exportedName + "` from package `" + packageCoordinate + " : " + existingFullName)
+            }
+          }
+        }
+      }
+
+    Hamuts(
+      idByFullNameByHumanName,
+      structRefsByRef2,
+      structDefsByRef2,
+      structDefs,
+      staticSizedArrays,
+      runtimeSizedArrays,
+      interfaceRefs,
+      interfaceDefs,
+      functionRefs,
+      functionDefs,
+      packageCoordToExportNameToFunction,
+      packageCoordToExportNameToKind,
+      packageCoordToExternNameToFunction,
+      newPackageCoordToExternNameToKind)
+  }
+
+  def addFunctionExtern(function: PrototypeH, packageCoordinate: PackageCoordinate, exportedName: String): Hamuts = {
+    val newPackageCoordToExternNameToFunction =
+      packageCoordToExternNameToFunction.get(packageCoordinate) match {
+        case None => {
+          packageCoordToExternNameToFunction + (packageCoordinate -> Map(exportedName -> function))
+        }
+        case Some(exportNameToFullName) => {
+          exportNameToFullName.get(exportedName) match {
+            case None => {
+              packageCoordToExternNameToFunction + (packageCoordinate -> (exportNameToFullName + (exportedName -> function)))
+            }
+            case Some(existingFullName) => {
+              vfail("Already exported a `" + exportedName + "` from package `" + packageCoordinate + " : " + existingFullName)
+            }
+          }
+        }
+      }
+
+    Hamuts(
+      idByFullNameByHumanName,
+      structRefsByRef2,
+      structDefsByRef2,
+      structDefs,
+      staticSizedArrays,
+      runtimeSizedArrays,
+      interfaceRefs,
+      interfaceDefs,
+      functionRefs,
+      functionDefs,
+      packageCoordToExportNameToFunction,
+      packageCoordToExportNameToKind,
+      newPackageCoordToExternNameToFunction,
+      packageCoordToExternNameToKind)
   }
 
   def addStaticSizedArray(staticSizedArrayDefinitionTH: StaticSizedArrayDefinitionTH): Hamuts = {
     Hamuts(
       idByFullNameByHumanName,
-      packageCoordToExportNameToFullName,
       structRefsByRef2,
       structDefsByRef2,
       structDefs,
@@ -242,13 +386,16 @@ case class Hamuts(
       interfaceRefs,
       interfaceDefs,
       functionRefs,
-      functionDefs)
+      functionDefs,
+      packageCoordToExportNameToFunction,
+      packageCoordToExportNameToKind,
+      packageCoordToExternNameToFunction,
+      packageCoordToExternNameToKind)
   }
 
   def addRuntimeSizedArray(runtimeSizedArrayDefinitionTH: RuntimeSizedArrayDefinitionTH): Hamuts = {
     Hamuts(
       idByFullNameByHumanName,
-      packageCoordToExportNameToFullName,
       structRefsByRef2,
       structDefsByRef2,
       structDefs,
@@ -257,7 +404,11 @@ case class Hamuts(
       interfaceRefs,
       interfaceDefs,
       functionRefs,
-      functionDefs)
+      functionDefs,
+      packageCoordToExportNameToFunction,
+      packageCoordToExportNameToKind,
+      packageCoordToExternNameToFunction,
+      packageCoordToExternNameToKind)
   }
 
   // This returns a unique ID for that specific human name.
@@ -280,7 +431,6 @@ case class Hamuts(
     val newHamuts =
       Hamuts(
         idByFullNameByHumanNameNew,
-        packageCoordToExportNameToFullName,
         structRefsByRef2,
         structDefsByRef2,
         structDefs,
@@ -289,7 +439,11 @@ case class Hamuts(
         interfaceRefs,
         interfaceDefs,
         functionRefs,
-        functionDefs)
+        functionDefs,
+        packageCoordToExportNameToFunction,
+        packageCoordToExportNameToKind,
+        packageCoordToExternNameToFunction,
+        packageCoordToExternNameToKind)
     (newHamuts, id)
   }
 

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/LetHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/LetHammer.scala
@@ -18,7 +18,7 @@ object LetHammer {
       currentFunctionHeader: FunctionHeader2,
       locals: LocalsBox,
       let2: LetNormal2):
-  ExpressionH[ReferendH] = {
+  ExpressionH[KindH] = {
     val LetNormal2(localVariable, sourceExpr2) = let2
 
     val (sourceExprResultLine, deferreds) =
@@ -48,7 +48,7 @@ object LetHammer {
     currentFunctionHeader: FunctionHeader2,
     locals: LocalsBox,
     let2: LetAndLend2):
-  (ExpressionH[ReferendH]) = {
+  (ExpressionH[KindH]) = {
     val LetAndLend2(localVariable, sourceExpr2) = let2
 
     val (sourceExprResultLine, deferreds) =
@@ -77,12 +77,12 @@ object LetHammer {
     hamuts: HamutsBox,
     currentFunctionHeader: FunctionHeader2,
     locals: LocalsBox,
-    sourceExprResultLine: ExpressionH[ReferendH],
-    sourceResultPointerTypeH: ReferenceH[ReferendH],
+    sourceExprResultLine: ExpressionH[KindH],
+    sourceResultPointerTypeH: ReferenceH[KindH],
     varId: FullName2[IVarName2],
     variability: Variability,
     reference: Coord):
-  ExpressionH[ReferendH] = {
+  ExpressionH[KindH] = {
     val (boxStructRefH) =
       StructHammer.makeBox(hinputs, hamuts, variability, reference, sourceResultPointerTypeH)
     val expectedLocalBoxType = ReferenceH(m.OwnH, YonderH, ReadwriteH, boxStructRefH)
@@ -105,13 +105,13 @@ object LetHammer {
       currentFunctionHeader: FunctionHeader2,
     locals: LocalsBox,
     sourceExpr2: ReferenceExpression2,
-    sourceExprResultLine: ExpressionH[ReferendH],
-    sourceResultPointerTypeH: ReferenceH[ReferendH],
+    sourceExprResultLine: ExpressionH[KindH],
+    sourceResultPointerTypeH: ReferenceH[KindH],
     let2: LetAndLend2,
     varId: FullName2[IVarName2],
     variability: Variability,
     reference: Coord):
-  (ExpressionH[ReferendH]) = {
+  (ExpressionH[KindH]) = {
     val stackifyH =
       translateAddressibleLet(
         hinputs, hamuts, currentFunctionHeader, locals, sourceExprResultLine, sourceResultPointerTypeH, varId, variability, reference)
@@ -134,8 +134,8 @@ object LetHammer {
     hamuts: HamutsBox,
     currentFunctionHeader: FunctionHeader2,
     locals: LocalsBox,
-    sourceExprResultLine: ExpressionH[ReferendH],
-    sourceResultPointerTypeH: ReferenceH[ReferendH],
+    sourceExprResultLine: ExpressionH[KindH],
+    sourceResultPointerTypeH: ReferenceH[KindH],
     varId: FullName2[IVarName2],
     variability: Variability):
   StackifyH = {
@@ -155,12 +155,12 @@ object LetHammer {
       currentFunctionHeader: FunctionHeader2,
       locals: LocalsBox,
       sourceExpr2: ReferenceExpression2,
-      sourceExprResultLine: ExpressionH[ReferendH],
-      sourceResultPointerTypeH: ReferenceH[ReferendH],
+      sourceExprResultLine: ExpressionH[KindH],
+      sourceResultPointerTypeH: ReferenceH[KindH],
       let2: LetAndLend2,
       varId: FullName2[IVarName2],
       variability: Variability):
-    ExpressionH[ReferendH] = {
+    ExpressionH[KindH] = {
 
       val stackifyH =
         translateMundaneLet(
@@ -193,7 +193,7 @@ object LetHammer {
     currentFunctionHeader: FunctionHeader2,
       locals: LocalsBox,
       unlet2: Unlet2):
-  (ExpressionH[ReferendH]) = {
+  (ExpressionH[KindH]) = {
     val local =
       locals.get(unlet2.variable.id) match {
         case None => {
@@ -239,7 +239,7 @@ object LetHammer {
       currentFunctionHeader: FunctionHeader2,
     locals: LocalsBox,
     des2: DestroyStaticSizedArrayIntoLocals2
-  ): ExpressionH[ReferendH] = {
+  ): ExpressionH[KindH] = {
     val DestroyStaticSizedArrayIntoLocals2(sourceExpr2, arrSeqT, destinationReferenceLocalVariables) = des2
 
     val (sourceExprResultLine, sourceExprDeferreds) =
@@ -284,7 +284,7 @@ object LetHammer {
     currentFunctionHeader: FunctionHeader2,
       locals: LocalsBox,
       des2: Destroy2):
-  ExpressionH[ReferendH] = {
+  ExpressionH[KindH] = {
     val Destroy2(sourceExpr2, structRef2, destinationReferenceLocalVariables) = des2
 
     val (sourceExprResultLine, sourceExprDeferreds) =
@@ -304,7 +304,7 @@ object LetHammer {
     // We put List() here to make sure that we've consumed all the destination
     // reference local variables.
     val (List(), localTypes, localIndices) =
-      structDef2.members.foldLeft((destinationReferenceLocalVariables, List[ReferenceH[ReferendH]](), List[Local]()))({
+      structDef2.members.foldLeft((destinationReferenceLocalVariables, List[ReferenceH[KindH]](), List[Local]()))({
         case ((remainingDestinationReferenceLocalVariables, previousLocalTypes, previousLocalIndices), member2) => {
           member2.tyype match {
             case ReferenceMemberType2(memberRefType2) => {

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/LoadHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/LoadHammer.scala
@@ -19,7 +19,7 @@ object LoadHammer {
     currentFunctionHeader: FunctionHeader2,
       locals: LocalsBox,
       load2: SoftLoad2):
-  (ExpressionH[ReferendH], List[Expression2]) = {
+  (ExpressionH[KindH], List[Expression2]) = {
     val SoftLoad2(sourceExpr2, targetOwnership, targetPermission) = load2
 
     val (loadedAccessH, sourceDeferreds) =
@@ -60,7 +60,7 @@ object LoadHammer {
       indexExpr2: ReferenceExpression2,
       targetOwnershipT: t.Ownership,
       targetPermissionT: t.Permission,
-  ): (ExpressionH[ReferendH], List[Expression2]) = {
+  ): (ExpressionH[KindH], List[Expression2]) = {
     val targetOwnership = Conversions.evaluateOwnership(targetOwnershipT)
     val targetPermission = Conversions.evaluatePermission(targetPermissionT)
 
@@ -108,7 +108,7 @@ object LoadHammer {
     indexExpr2: ReferenceExpression2,
     targetOwnershipT: t.Ownership,
     targetPermissionT: t.Permission,
-  ): (ExpressionH[ReferendH], List[Expression2]) = {
+  ): (ExpressionH[KindH], List[Expression2]) = {
     val targetOwnership = Conversions.evaluateOwnership(targetOwnershipT)
     val targetPermission = Conversions.evaluatePermission(targetPermissionT)
 
@@ -158,12 +158,12 @@ object LoadHammer {
       expectedType2: Coord,
       targetOwnershipT: t.Ownership,
       targetPermissionT: t.Permission,
-  ): (ExpressionH[ReferendH], List[Expression2]) = {
+  ): (ExpressionH[KindH], List[Expression2]) = {
     val (structResultLine, structDeferreds) =
       translate(hinputs, hamuts, currentFunctionHeader, locals, structExpr2);
 
     val structRef2 =
-      structExpr2.resultRegister.reference.referend match {
+      structExpr2.resultRegister.reference.kind match {
         case sr @ StructRef2(_) => sr
         case TupleT2(_, sr) => sr
         case PackT2(_, sr) => sr
@@ -225,7 +225,7 @@ object LoadHammer {
 //      resultCoord: Coord,
       targetOwnershipT: t.Ownership,
       targetPermissionT: t.Permission,
-  ): (ExpressionH[ReferendH], List[Expression2]) = {
+  ): (ExpressionH[KindH], List[Expression2]) = {
     val (structResultLine, structDeferreds) =
       translate(hinputs, hamuts, currentFunctionHeader, locals, structExpr2);
 
@@ -235,7 +235,7 @@ object LoadHammer {
 //      TypeHammer.translateReference(hinputs, hamuts, resultCoord);
 
     val structRef2 =
-      structExpr2.resultRegister.reference.referend match {
+      structExpr2.resultRegister.reference.kind match {
         case sr @ StructRef2(_) => sr
         case TupleT2(_, sr) => sr
         case PackT2(_, sr) => sr
@@ -269,7 +269,7 @@ object LoadHammer {
       localReference2: Coord,
       targetOwnershipT: t.Ownership,
       targetPermissionT: t.Permission,
-  ): (ExpressionH[ReferendH], List[Expression2]) = {
+  ): (ExpressionH[KindH], List[Expression2]) = {
     val local = locals.get(varId).get
     vassert(!locals.unstackifiedVars.contains(local.id))
 
@@ -313,7 +313,7 @@ object LoadHammer {
       expectedType2: Coord,
       targetOwnershipT: t.Ownership,
       targetPermissionT: t.Permission,
-  ): (ExpressionH[ReferendH], List[Expression2]) = {
+  ): (ExpressionH[KindH], List[Expression2]) = {
     val targetOwnership = Conversions.evaluateOwnership(targetOwnershipT)
     val targetPermission = Conversions.evaluatePermission(targetPermissionT)
 
@@ -345,7 +345,7 @@ object LoadHammer {
     currentFunctionHeader: FunctionHeader2,
       locals: LocalsBox,
       lookup2: LocalLookup2):
-  (ExpressionH[ReferendH]) = {
+  (ExpressionH[KindH]) = {
     val LocalLookup2(_,localVar, type2, _) = lookup2;
     vassert(type2 == localVar.reference)
 
@@ -375,14 +375,14 @@ object LoadHammer {
     currentFunctionHeader: FunctionHeader2,
       locals: LocalsBox,
       lookup2: AddressMemberLookup2):
-  (ExpressionH[ReferendH], List[Expression2]) = {
+  (ExpressionH[KindH], List[Expression2]) = {
     val AddressMemberLookup2(_,structExpr2, memberName, resultType2, _) = lookup2;
 
     val (structResultLine, structDeferreds) =
       translate(hinputs, hamuts, currentFunctionHeader, locals, structExpr2);
 
     val structRef2 =
-      structExpr2.resultRegister.reference.referend match {
+      structExpr2.resultRegister.reference.kind match {
         case sr @ StructRef2(_) => sr
         case TupleT2(_, sr) => sr
         case PackT2(_, sr) => sr
@@ -431,7 +431,7 @@ object LoadHammer {
     (loadBoxNode, structDeferreds)
   }
 
-  def getBorrowedLocation(memberType: ReferenceH[ReferendH]) = {
+  def getBorrowedLocation(memberType: ReferenceH[KindH]) = {
     (memberType.ownership, memberType.location) match {
       case (OwnH, _) => YonderH
       case (BorrowH, _) => YonderH

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/MutateHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/MutateHammer.scala
@@ -18,7 +18,7 @@ object MutateHammer {
     currentFunctionHeader: FunctionHeader2,
       locals: LocalsBox,
       mutate2: Mutate2):
-  (ExpressionH[ReferendH]) = {
+  (ExpressionH[KindH]) = {
     val Mutate2(destinationExpr2, sourceExpr2) = mutate2
 
     val (sourceExprResultLine, sourceDeferreds) =
@@ -56,10 +56,10 @@ object MutateHammer {
     hamuts: HamutsBox,
     currentFunctionHeader: FunctionHeader2,
     locals: LocalsBox,
-    sourceExprResultLine: ExpressionH[ReferendH],
+    sourceExprResultLine: ExpressionH[KindH],
     arrayExpr2: ReferenceExpression2,
     indexExpr2: ReferenceExpression2
-  ): (ExpressionH[ReferendH], List[Expression2]) = {
+  ): (ExpressionH[KindH], List[Expression2]) = {
     val (destinationResultLine, destinationDeferreds) =
       translate(hinputs, hamuts, currentFunctionHeader, locals, arrayExpr2);
     val (indexExprResultLine, indexDeferreds) =
@@ -84,10 +84,10 @@ object MutateHammer {
                                                     hamuts: HamutsBox,
     currentFunctionHeader: FunctionHeader2,
                                                     locals: LocalsBox,
-                                                    sourceExprResultLine: ExpressionH[ReferendH],
+                                                    sourceExprResultLine: ExpressionH[KindH],
                                                     arrayExpr2: ReferenceExpression2,
                                                     indexExpr2: ReferenceExpression2
-  ): (ExpressionH[ReferendH], List[Expression2]) = {
+  ): (ExpressionH[KindH], List[Expression2]) = {
     val (destinationResultLine, destinationDeferreds) =
       translate(hinputs, hamuts, currentFunctionHeader, locals, arrayExpr2);
     val (indexExprResultLine, indexDeferreds) =
@@ -112,15 +112,15 @@ object MutateHammer {
     hamuts: HamutsBox,
     currentFunctionHeader: FunctionHeader2,
     locals: LocalsBox,
-    sourceExprResultLine: ExpressionH[ReferendH],
+    sourceExprResultLine: ExpressionH[KindH],
     structExpr2: ReferenceExpression2,
     memberName: FullName2[IVarName2]
-  ): (ExpressionH[ReferendH], List[Expression2]) = {
+  ): (ExpressionH[KindH], List[Expression2]) = {
     val (destinationResultLine, destinationDeferreds) =
       translate(hinputs, hamuts, currentFunctionHeader, locals, structExpr2);
 
     val structRef2 =
-      structExpr2.resultRegister.reference.referend match {
+      structExpr2.resultRegister.reference.kind match {
         case sr @ StructRef2(_) => sr
         case TupleT2(_, sr) => sr
         case PackT2(_, sr) => sr
@@ -176,15 +176,15 @@ object MutateHammer {
     hamuts: HamutsBox,
     currentFunctionHeader: FunctionHeader2,
     locals: LocalsBox,
-    sourceExprResultLine: ExpressionH[ReferendH],
+    sourceExprResultLine: ExpressionH[KindH],
     structExpr2: ReferenceExpression2,
     memberName: FullName2[IVarName2]
-  ): (ExpressionH[ReferendH], List[Expression2]) = {
+  ): (ExpressionH[KindH], List[Expression2]) = {
     val (destinationResultLine, destinationDeferreds) =
       translate(hinputs, hamuts, currentFunctionHeader, locals, structExpr2);
 
     val structRef2 =
-      structExpr2.resultRegister.reference.referend match {
+      structExpr2.resultRegister.reference.kind match {
         case sr @ StructRef2(_) => sr
       }
     val structDef2 = hinputs.lookupStruct(structRef2)
@@ -211,12 +211,12 @@ object MutateHammer {
     hamuts: HamutsBox,
     currentFunctionHeader: FunctionHeader2,
     locals: LocalsBox,
-    sourceExprResultLine: ExpressionH[ReferendH],
-    sourceResultPointerTypeH: ReferenceH[ReferendH],
+    sourceExprResultLine: ExpressionH[KindH],
+    sourceResultPointerTypeH: ReferenceH[KindH],
     varId: FullName2[IVarName2],
     variability: Variability,
     reference: Coord
-  ): (ExpressionH[ReferendH], List[Expression2]) = {
+  ): (ExpressionH[KindH], List[Expression2]) = {
     val local = locals.get(varId).get
     val (boxStructRefH) =
       StructHammer.makeBox(hinputs, hamuts, variability, reference, sourceResultPointerTypeH)
@@ -248,9 +248,9 @@ object MutateHammer {
                                            hamuts: HamutsBox,
     currentFunctionHeader: FunctionHeader2,
                                            locals: LocalsBox,
-                                           sourceExprResultLine: ExpressionH[ReferendH],
+                                           sourceExprResultLine: ExpressionH[KindH],
                                            varId: FullName2[IVarName2]
-  ): (ExpressionH[ReferendH], List[Expression2]) = {
+  ): (ExpressionH[KindH], List[Expression2]) = {
     val local = locals.get(varId).get
     vassert(!locals.unstackifiedVars.contains(local.id))
     val newStoreNode =

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/NameHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/NameHammer.scala
@@ -136,7 +136,7 @@ object NameHammer {
       "PackageCoordinate",
       None,
       Vector(
-        VonMember("module", VonStr(module)),
-        VonMember("paackage", VonArray(None, paackage.map(VonStr).toVector))))
+        VonMember("project", VonStr(module)),
+        VonMember("packageSteps", VonArray(None, paackage.map(VonStr).toVector))))
   }
 }

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/NameHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/NameHammer.scala
@@ -80,18 +80,22 @@ object NameHammer {
     hamuts: HamutsBox,
     fullName2: FullName2[IName2]
   ): FullNameH = {
-    val FullName2(PackageCoordinate(project, packageSteps), _, _) = fullName2
+    val FullName2(packageCoord @ PackageCoordinate(project, packageSteps), _, _) = fullName2
     val newNameParts =
-      (VonStr(project) :: packageSteps.map(VonStr)) ++
+//      (VonStr(project) :: packageSteps.map(VonStr)) ++
       fullName2.steps.map(step => VonHammer.translateName(hinputs, hamuts, step))
-    val readableName = getReadableName(fullName2.last)
+    val readableName =
+//      (if (packageCoord.module != "") packageCoord.module + "." else "") +
+//      packageSteps.map(_ + ".") +
+      getReadableName(fullName2.last)
+
     val id =
       if (fullName2.last.isInstanceOf[ExternFunctionName2]) {
         -1
       } else {
-        hamuts.getNameId(readableName, newNameParts)
+        hamuts.getNameId(readableName, packageCoord, newNameParts)
       }
-    FullNameH(readableName, id, newNameParts)
+    FullNameH(readableName, id, packageCoord, newNameParts)
   }
 
   // Adds a step to the name.
@@ -101,8 +105,8 @@ object NameHammer {
     s: String):
   FullNameH = {
     val newNameParts = fullName.parts :+ VonStr(s)
-    val id = hamuts.getNameId(s, newNameParts)
-    FullNameH(s, id, newNameParts)
+    val id = hamuts.getNameId(s, fullName.packageCoordinate, newNameParts)
+    FullNameH(s, id, fullName.packageCoordinate, newNameParts)
   }
 
   def translateCodeLocation(location: CodeLocation2): VonObject = {
@@ -118,11 +122,21 @@ object NameHammer {
   def translateFileCoordinate(coord: FileCoordinate): VonObject = {
     val FileCoordinate(module, paackage, filename) = coord
     VonObject(
-      "CodeLocation",
+      "FileCoordinate",
       None,
       Vector(
         VonMember("module", VonStr(module)),
         VonMember("paackage", VonArray(None, paackage.map(VonStr).toVector)),
         VonMember("filename", VonStr(filename))))
+  }
+
+  def translatePackageCoordinate(coord: PackageCoordinate): VonObject = {
+    val PackageCoordinate(module, paackage) = coord
+    VonObject(
+      "PackageCoordinate",
+      None,
+      Vector(
+        VonMember("module", VonStr(module)),
+        VonMember("paackage", VonArray(None, paackage.map(VonStr).toVector))))
   }
 }

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/StructHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/StructHammer.scala
@@ -2,7 +2,7 @@ package net.verdagon.vale.hammer
 
 import net.verdagon.vale.hinputs.{ETable2, Hinputs, TetrisTable}
 import net.verdagon.vale.metal.{Immutable => _, Mutable => _, Variability => _, Varying => _, _}
-import net.verdagon.vale.{PackageCoordinate, vassert, vassertSome, metal => m}
+import net.verdagon.vale.{PackageCoordinate, vassert, vassertSome, vfail, metal => m}
 import net.verdagon.vale.templar._
 import net.verdagon.vale.templar.templata.{CoordTemplata, Export2, FunctionHeader2}
 import net.verdagon.vale.templar.types._
@@ -81,8 +81,16 @@ object StructHammer {
         hamuts.addInterface(interfaceRef2, interfaceDefH)
         vassert(interfaceDefH.getRef == temporaryInterfaceRefH)
 
-        if (maybeExport.nonEmpty) {
-          Hammer.exportName(hamuts, maybeExport.get, interfaceDef2.fullName, interfaceDefH.fullName)
+        maybeExport match {
+          case None =>
+          case Some(exportPackageCoord) => {
+            val exportedName =
+              interfaceRef2.fullName.last match {
+                case CitizenName2(humanName, _) => humanName
+                case _ => vfail("Can't export something that doesn't have a human readable name!")
+              }
+            hamuts.addKindExport(interfaceDefH.getRef, exportPackageCoord, exportedName)
+          }
         }
 
         (interfaceDefH.getRef)
@@ -138,8 +146,16 @@ object StructHammer {
         hamuts.addStructOriginatingFromTemplar(structRef2, structDefH)
         vassert(structDefH.getRef == temporaryStructRefH)
 
-        if (maybeExport.nonEmpty) {
-          Hammer.exportName(hamuts, maybeExport.get, structDef2.fullName, structDefH.fullName)
+        maybeExport match {
+          case None =>
+          case Some(exportPackageCoord) => {
+            val exportedName =
+              structRef2.fullName.last match {
+                case CitizenName2(humanName, _) => humanName
+                case _ => vfail("Can't export something that doesn't have a human readable name!")
+              }
+            hamuts.addKindExport(structDefH.getRef, exportPackageCoord, exportedName)
+          }
         }
 
         (structDefH.getRef)
@@ -152,7 +168,7 @@ object StructHammer {
     hamuts: HamutsBox,
     conceptualVariability: Variability,
     type2: Coord,
-    typeH: ReferenceH[ReferendH]):
+    typeH: ReferenceH[KindH]):
   (StructRefH) = {
     val boxFullName2 = FullName2(PackageCoordinate.BUILTIN, List(), CitizenName2(BOX_HUMAN_NAME, List(CoordTemplata(type2))))
     val boxFullNameH = NameHammer.translateFullName(hinputs, hamuts, boxFullName2)

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/TypeHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/TypeHammer.scala
@@ -62,7 +62,7 @@ object TypeHammer {
   //  }
 
   def translateKind(hinputs: Hinputs, hamuts: HamutsBox, tyype: Kind):
-  (ReferendH) = {
+  (KindH) = {
     tyype match {
       case Never2() => NeverH()
       case Int2() => IntH()
@@ -95,7 +95,7 @@ object TypeHammer {
       hinputs: Hinputs,
       hamuts: HamutsBox,
       coord: Coord):
-  (ReferenceH[ReferendH]) = {
+  (ReferenceH[KindH]) = {
     val Coord(ownership, permission, innerType) = coord;
     val location = {
       (ownership, innerType) match {
@@ -127,7 +127,7 @@ object TypeHammer {
       hinputs: Hinputs,
       hamuts: HamutsBox,
       references2: List[Coord]):
-  (List[ReferenceH[ReferendH]]) = {
+  (List[ReferenceH[KindH]]) = {
     references2 match {
       case Nil => Nil
       case headReference2 :: tailPointers2 => {
@@ -145,7 +145,7 @@ object TypeHammer {
 //    }
 //  }
 
-  def checkConversion(expected: ReferenceH[ReferendH], actual: ReferenceH[ReferendH]): Unit = {
+  def checkConversion(expected: ReferenceH[KindH], actual: ReferenceH[KindH]): Unit = {
     if (actual != expected) {
       vfail("Expected a " + expected + " but was a " + actual);
     }

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/VonHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/VonHammer.scala
@@ -22,11 +22,30 @@ object VonHammer {
           "packages",
           VonArray(
             None,
-            packages.flatMap({ case (packageCoord, paackage) => vonifyPackage(packageCoord, paackage) }).toVector))))
+            packages.flatMap({ case (packageCoord, paackage) =>
+              VonObject(
+                "Entry",
+                None,
+                Vector(
+                  VonMember("packageCoordinate", NameHammer.translatePackageCoordinate(packageCoord)),
+                  VonMember("package", vonifyPackage(packageCoord, paackage))
+                ))
+            }).toVector))))
   }
 
   def vonifyPackage(packageCoord: PackageCoordinate, paackage: PackageH): IVonData = {
-    val PackageH(interfaces, structs, externs, functions, staticSizedArrays, runtimeSizedArrays, immDestructorsByKind, exportNameToFullName, externNameToFullName) = paackage
+    val PackageH(
+      interfaces,
+      structs,
+      functions,
+      staticSizedArrays,
+      runtimeSizedArrays,
+      immDestructorsByKind,
+      exportNameToFunction,
+      exportNameToKind,
+      externNameToFunction,
+      externNameToKind,
+    ) = paackage
 
 //    val exports =
 //      exportNameToFullName.map({ case (moduleName, exportNameToExportee) =>
@@ -44,16 +63,12 @@ object VonHammer {
         VonMember("name", NameHammer.translatePackageCoordinate(packageCoord)),
         VonMember("interfaces", VonArray(None, interfaces.map(vonifyInterface).toVector)),
         VonMember("structs", VonArray(None, structs.map(vonfiyStruct).toVector)),
-        VonMember("externFunctions", VonArray(None, externs.map(vonifyPrototype).toVector)),
-        VonMember("exportFunctions", VonArray(None, externs.map(vonifyPrototype).toVector)),
-        VonMember("exportStructs", VonArray(None, externs.map(vonifyPrototype).toVector)),
-        VonMember("exportInterfaces", VonArray(None, externs.map(vonifyPrototype).toVector)),
         VonMember("functions", VonArray(None, functions.map(vonifyFunction).toVector)),
         VonMember("staticSizedArrays", VonArray(None, staticSizedArrays.map(vonifyStaticSizedArrayDefinition).toVector)),
         VonMember("runtimeSizedArrays", VonArray(None, runtimeSizedArrays.map(vonifyRuntimeSizedArrayDefinition).toVector)),
-        VonMember("emptyTupleStructReferend", vonifyKind(ProgramH.emptyTupleStructRef)),
+        VonMember("emptyTupleStructKind", vonifyKind(ProgramH.emptyTupleStructRef)),
         VonMember(
-          "immDestructorsByReferend",
+          "immDestructorsByKind",
           VonArray(
             None,
             immDestructorsByKind.toVector.map({ case (kind, destructor) =>
@@ -61,47 +76,71 @@ object VonHammer {
                 "Entry",
                 None,
                 Vector(
-                  VonMember("referend", vonifyKind(kind)),
+                  VonMember("kind", vonifyKind(kind)),
                   VonMember("destructor", vonifyPrototype(destructor))))
             }))),
         VonMember(
-          "exportNameToFullName",
+          "exportNameToFunction",
           VonArray(
             None,
-            exportNameToFullName.toVector.map({ case (exportName, fullName) =>
+            exportNameToFunction.toVector.map({ case (exportName, prototype) =>
               VonObject(
                 "Entry",
                 None,
                 Vector(
                   VonMember("exportName", VonStr(exportName)),
-                  VonMember("fullName", VonStr(fullName.toReadableString))))
+                  VonMember("prototype", vonifyPrototype(prototype))))
             }))),
         VonMember(
-          "externNameToExtern",
+          "exportNameToKind",
           VonArray(
             None,
-            externNameToFullName.toVector.map({ case (externName, fullName) =>
+            exportNameToKind.toVector.map({ case (exportName, kind) =>
+              VonObject(
+                "Entry",
+                None,
+                Vector(
+                  VonMember("exportName", VonStr(exportName)),
+                  VonMember("kind", vonifyKind(kind))))
+            }))),
+        VonMember(
+          "externNameToFunction",
+          VonArray(
+            None,
+            externNameToFunction.toVector.map({ case (externName, prototype) =>
               VonObject(
                 "Entry",
                 None,
                 Vector(
                   VonMember("externName", VonStr(externName)),
-                  VonMember("fullName", VonStr(fullName.toReadableString))))
+                  VonMember("prototype", vonifyPrototype(prototype))))
+            }))),
+        VonMember(
+          "externNameToKind",
+          VonArray(
+            None,
+            externNameToKind.toVector.map({ case (externName, kind) =>
+              VonObject(
+                "Entry",
+                None,
+                Vector(
+                  VonMember("externName", VonStr(externName)),
+                  VonMember("kind", vonifyKind(kind))))
             })))))
   }
 
   def vonifyRegion(region: RegionH): IVonData = {
-    val RegionH(name, referends) = region
+    val RegionH(name, kinds) = region
 
     VonObject(
       "Region",
       None,
       Vector(
         VonMember(
-          "referends",
+          "kinds",
           VonArray(
             None,
-            referends.map(vonifyKind).toVector))))
+            kinds.map(vonifyKind).toVector))))
   }
 
   def vonifyStructRef(ref: StructRefH): IVonData = {
@@ -111,7 +150,7 @@ object VonHammer {
       "StructId",
       None,
       Vector(
-        VonMember("name", VonStr(fullName.toReadableString()))))
+        VonMember("name", vonifyName(fullName))))
   }
 
   def vonifyInterfaceRef(ref: InterfaceRefH): IVonData = {
@@ -121,7 +160,7 @@ object VonHammer {
       "InterfaceId",
       None,
       Vector(
-        VonMember("name", VonStr(fullName.toReadableString()))))
+        VonMember("name", vonifyName(fullName))))
   }
 
   def vonifyInterfaceMethod(interfaceMethodH: InterfaceMethodH): IVonData = {
@@ -142,8 +181,8 @@ object VonHammer {
       "Interface",
       None,
       Vector(
-        VonMember("name", VonStr(fullName.toReadableString())),
-        VonMember("referend", vonifyInterfaceRef(interface.getRef)),
+        VonMember("name", vonifyName(fullName)),
+        VonMember("kind", vonifyInterfaceRef(interface.getRef)),
         VonMember("export", VonBool(export)),
         VonMember("weakable", VonBool(weakable)),
         VonMember("mutability", vonifyMutability(mutability)),
@@ -158,8 +197,8 @@ object VonHammer {
       "Struct",
       None,
       Vector(
-        VonMember("name", VonStr(fullName.toReadableString())),
-        VonMember("referend", vonifyStructRef(struct.getRef)),
+        VonMember("name", vonifyName(fullName)),
+        VonMember("kind", vonifyStructRef(struct.getRef)),
         VonMember("weakable", VonBool(weakable)),
         VonMember("export", VonBool(export)),
         VonMember("mutability", vonifyMutability(mutability)),
@@ -203,13 +242,13 @@ object VonHammer {
       "Prototype",
       None,
       Vector(
-        VonMember("name", VonStr(fullName.toReadableString())),
+        VonMember("name", vonifyName(fullName)),
         VonMember("params", VonArray(None, params.map(vonifyCoord).toVector)),
         VonMember("return", vonifyCoord(returnType))))
   }
 
-  def vonifyCoord(coord: ReferenceH[ReferendH]): IVonData = {
-    val ReferenceH(ownership, location, permission, referend) = coord
+  def vonifyCoord(coord: ReferenceH[KindH]): IVonData = {
+    val ReferenceH(ownership, location, permission, kind) = coord
 
 //    val vonDataWithoutDebugStr =
 //      VonObject(
@@ -218,7 +257,7 @@ object VonHammer {
 //        Vector(
 //          VonMember("ownership", vonifyOwnership(ownership)),
 //          VonMember("location", vonifyLocation(location)),
-//          VonMember("referend", vonifyKind(referend))))
+//          VonMember("kind", vonifyKind(kind))))
     VonObject(
       "Ref",
       None,
@@ -226,7 +265,7 @@ object VonHammer {
         VonMember("ownership", vonifyOwnership(ownership)),
         VonMember("location", vonifyLocation(location)),
         VonMember("permission", vonifyPermission(permission)),
-        VonMember("referend", vonifyKind(referend))))
+        VonMember("kind", vonifyKind(kind))))
 //        VonMember(
 //          "debugStr",
 //          VonStr(
@@ -284,7 +323,7 @@ object VonHammer {
       "StructMember",
       None,
       Vector(
-        VonMember("fullName", VonStr(name.toReadableString())),
+        VonMember("fullName", vonifyName(name)),
         VonMember("name", VonStr(name.readableName)),
         VonMember("variability", vonifyVariability(variability)),
         VonMember("type", vonifyCoord(tyype))))
@@ -296,8 +335,8 @@ object VonHammer {
       "RuntimeSizedArrayDefinition",
       None,
       Vector(
-        VonMember("name", VonStr(name.toReadableString())),
-        VonMember("referend", vonifyKind(rsaDef.referend)),
+        VonMember("name", vonifyName(name)),
+        VonMember("kind", vonifyKind(rsaDef.kind)),
         VonMember("array", vonifyRawArray(rawArray))))
   }
 
@@ -307,14 +346,14 @@ object VonHammer {
       "StaticSizedArrayDefinition",
       None,
       Vector(
-        VonMember("name", VonStr(name.toReadableString())),
-        VonMember("referend", vonifyKind(ssaDef.referend)),
+        VonMember("name", vonifyName(name)),
+        VonMember("kind", vonifyKind(ssaDef.kind)),
         VonMember("size", VonInt(size)),
         VonMember("array", vonifyRawArray(rawArray))))
   }
 
-  def vonifyKind(referend: ReferendH): IVonData = {
-    referend match {
+  def vonifyKind(kind: KindH): IVonData = {
+    kind match {
       case NeverH() => VonObject("Never", None, Vector())
       case IntH() => VonObject("Int", None, Vector())
       case BoolH() => VonObject("Bool", None, Vector())
@@ -327,14 +366,14 @@ object VonHammer {
           "RuntimeSizedArray",
           None,
           Vector(
-            VonMember("name", VonStr(name.toReadableString()))))
+            VonMember("name", vonifyName(name))))
       }
       case StaticSizedArrayTH(name) => {
         VonObject(
           "StaticSizedArray",
           None,
           Vector(
-            VonMember("name", VonStr(name.toReadableString()))))
+            VonMember("name", vonifyName(name))))
       }
     }
   }
@@ -364,7 +403,7 @@ object VonHammer {
         VonMember("block", vonifyExpression(body))))
   }
 
-  def vonifyExpression(node: ExpressionH[ReferendH]): IVonData = {
+  def vonifyExpression(node: ExpressionH[KindH]): IVonData = {
     node match {
       case ConstantBoolH(value) => {
         VonObject(
@@ -410,9 +449,9 @@ object VonHammer {
           Vector(
             VonMember("sourceExpr", vonifyExpression(sourceExpr)),
             VonMember("sourceType", vonifyCoord(sourceExpr.resultType)),
-            VonMember("sourceReferend", vonifyKind(sourceExpr.resultType.kind)),
+            VonMember("sourceKind", vonifyKind(sourceExpr.resultType.kind)),
             VonMember("resultType", vonifyCoord(wa.resultType)),
-            VonMember("resultReferend", vonifyKind(wa.resultType.kind))))
+            VonMember("resultKind", vonifyKind(wa.resultType.kind))))
       }
       case AsSubtypeH(sourceExpr, targetType, resultResultType, okConstructor, errConstructor) => {
         VonObject(
@@ -422,15 +461,15 @@ object VonHammer {
             VonMember("sourceExpr", vonifyExpression(sourceExpr)),
             VonMember("sourceType", vonifyCoord(sourceExpr.resultType)),
             VonMember("sourceKnownLive", VonBool(false)),
-            VonMember("targetReferend", vonifyKind(targetType)),
+            VonMember("targetKind", vonifyKind(targetType)),
             VonMember("okConstructor", vonifyPrototype(okConstructor)),
             VonMember("okType", vonifyCoord(okConstructor.returnType)),
-            VonMember("okReferend", vonifyKind(okConstructor.returnType.kind)),
+            VonMember("okKind", vonifyKind(okConstructor.returnType.kind)),
             VonMember("errConstructor", vonifyPrototype(errConstructor)),
             VonMember("errType", vonifyCoord(errConstructor.returnType)),
-            VonMember("errReferend", vonifyKind(errConstructor.returnType.kind)),
+            VonMember("errKind", vonifyKind(errConstructor.returnType.kind)),
             VonMember("resultResultType", vonifyCoord(resultResultType)),
-            VonMember("resultResultReferend", vonifyKind(resultResultType.kind))))
+            VonMember("resultResultKind", vonifyKind(resultResultType.kind))))
       }
       case LockWeakH(sourceExpr, resultOptType, someConstructor, noneConstructor) => {
         VonObject(
@@ -442,12 +481,12 @@ object VonHammer {
             VonMember("sourceKnownLive", VonBool(false)),
             VonMember("someConstructor", vonifyPrototype(someConstructor)),
             VonMember("someType", vonifyCoord(someConstructor.returnType)),
-            VonMember("someReferend", vonifyKind(someConstructor.returnType.kind)),
+            VonMember("someKind", vonifyKind(someConstructor.returnType.kind)),
             VonMember("noneConstructor", vonifyPrototype(noneConstructor)),
             VonMember("noneType", vonifyCoord(noneConstructor.returnType)),
-            VonMember("noneReferend", vonifyKind(noneConstructor.returnType.kind)),
+            VonMember("noneKind", vonifyKind(noneConstructor.returnType.kind)),
             VonMember("resultOptType", vonifyCoord(resultOptType)),
-            VonMember("resultOptReferend", vonifyKind(resultOptType.kind))))
+            VonMember("resultOptKind", vonifyKind(resultOptType.kind))))
       }
       case ReturnH(sourceExpr) => {
         VonObject(
@@ -480,7 +519,7 @@ object VonHammer {
           Vector(
             VonMember("sourceExprs", VonArray(None, sourceExprs.map(vonifyExpression).toVector)),
             VonMember("resultType", vonifyCoord(resultType)),
-            VonMember("resultReferend", vonifyKind(resultType.kind))))
+            VonMember("resultKind", vonifyKind(resultType.kind))))
       }
       case NewStructH(sourceExprs, targetMemberNames, resultType) => {
         VonObject(
@@ -492,7 +531,7 @@ object VonHammer {
               VonArray(None, sourceExprs.map(vonifyExpression).toVector)),
             VonMember(
               "memberNames",
-              VonArray(None, targetMemberNames.map(n => VonStr(n.toReadableString)).toVector)),
+              VonArray(None, targetMemberNames.map(n => vonifyName(n)).toVector)),
             VonMember("resultType", vonifyCoord(resultType))))
       }
       case StackifyH(sourceExpr, local, name) => {
@@ -503,7 +542,7 @@ object VonHammer {
             VonMember("sourceExpr", vonifyExpression(sourceExpr)),
             VonMember("local", vonifyLocal(local)),
             VonMember("knownLive", VonBool(false)),
-            VonMember("optName", vonifyOptional[FullNameH](name, n => VonStr(n.toReadableString())))))
+            VonMember("optName", vonifyOptional[FullNameH](name, n => vonifyName(n)))))
       }
       case UnstackifyH(local) => {
         VonObject(
@@ -538,7 +577,7 @@ object VonHammer {
           Vector(
             VonMember("arrayExpr", vonifyExpression(arrayExpr)),
             VonMember("arrayType", vonifyCoord(arrayExpr.resultType)),
-            VonMember("arrayReferend", vonifyKind(arrayExpr.resultType.kind)),
+            VonMember("arrayKind", vonifyKind(arrayExpr.resultType.kind)),
             VonMember("consumerExpr", vonifyExpression(consumerExpr)),
             VonMember("consumerType", vonifyCoord(consumerExpr.resultType)),
             VonMember("consumerMethod", vonifyPrototype(consumerMethod)),
@@ -583,10 +622,10 @@ object VonHammer {
           Vector(
             VonMember("arrayExpr", vonifyExpression(arrayExpr)),
             VonMember("arrayType", vonifyCoord(arrayExpr.resultType)),
-            VonMember("arrayReferend", vonifyKind(arrayExpr.resultType.kind)),
+            VonMember("arrayKind", vonifyKind(arrayExpr.resultType.kind)),
             VonMember("consumerExpr", vonifyExpression(consumerExpr)),
             VonMember("consumerType", vonifyCoord(consumerExpr.resultType)),
-            VonMember("consumerReferend", vonifyKind(consumerExpr.resultType.kind)),
+            VonMember("consumerKind", vonifyKind(consumerExpr.resultType.kind)),
             VonMember("consumerMethod", vonifyPrototype(consumerMethod)),
             VonMember("arrayElementType", vonifyCoord(arrayElementType)),
             VonMember("consumerKnownLive", VonBool(false))))
@@ -598,9 +637,9 @@ object VonHammer {
           Vector(
             VonMember("sourceExpr", vonifyExpression(sourceExpr)),
             VonMember("sourceStructType", vonifyCoord(sourceExpr.resultType)),
-            VonMember("sourceStructReferend", vonifyStructRef(sourceExpr.resultType.kind)),
+            VonMember("sourceStructKind", vonifyStructRef(sourceExpr.resultType.kind)),
             VonMember("targetInterfaceType", vonifyCoord(si.resultType)),
-            VonMember("targetInterfaceReferend", vonifyInterfaceRef(targetInterfaceRef))))
+            VonMember("targetInterfaceKind", vonifyInterfaceRef(targetInterfaceRef))))
       }
       case InterfaceToInterfaceUpcastH(sourceExpr, targetInterfaceRef) => {
         vimpl()
@@ -612,7 +651,7 @@ object VonHammer {
           Vector(
             VonMember("local", vonifyLocal(local)),
             VonMember("sourceExpr", vonifyExpression(sourceExpr)),
-            VonMember("localName", VonStr(localName.toReadableString())),
+            VonMember("localName", vonifyName(localName)),
             VonMember("knownLive", VonBool(false))))
       }
       case LocalLoadH(local, targetOwnership, targetPermission, localName) => {
@@ -623,7 +662,7 @@ object VonHammer {
             VonMember("local", vonifyLocal(local)),
             VonMember("targetOwnership", vonifyOwnership(targetOwnership)),
             VonMember("targetPermission", vonifyPermission(targetPermission)),
-            VonMember("localName", VonStr(localName.toReadableString()))))
+            VonMember("localName", vonifyName(localName))))
       }
       case MemberStoreH(resultType, structExpr, memberIndex, sourceExpr, memberName) => {
         VonObject(
@@ -636,7 +675,7 @@ object VonHammer {
             VonMember("structKnownLive", VonBool(false)),
             VonMember("memberIndex", VonInt(memberIndex)),
             VonMember("sourceExpr", vonifyExpression(sourceExpr)),
-            VonMember("memberName", VonStr(memberName.toReadableString()))))
+            VonMember("memberName", vonifyName(memberName))))
       }
       case ml @ MemberLoadH(structExpr, memberIndex, expectedMemberType, resultType, memberName) => {
         VonObject(
@@ -652,7 +691,7 @@ object VonHammer {
             VonMember("targetPermission", vonifyPermission(resultType.permission)),
             VonMember("expectedMemberType", vonifyCoord(expectedMemberType)),
             VonMember("expectedResultType", vonifyCoord(resultType)),
-            VonMember("memberName", VonStr(memberName.toReadableString()))))
+            VonMember("memberName", vonifyName(memberName))))
       }
       case StaticSizedArrayStoreH(arrayExpr, indexExpr, sourceExpr, resultType) => {
         VonObject(
@@ -673,14 +712,14 @@ object VonHammer {
           Vector(
             VonMember("arrayExpr", vonifyExpression(arrayExpr)),
             VonMember("arrayType", vonifyCoord(arrayExpr.resultType)),
-            VonMember("arrayReferend", vonifyKind(arrayExpr.resultType.kind)),
+            VonMember("arrayKind", vonifyKind(arrayExpr.resultType.kind)),
             VonMember("arrayKnownLive", VonBool(false)),
             VonMember("indexExpr", vonifyExpression(indexExpr)),
             VonMember("indexType", vonifyCoord(indexExpr.resultType)),
-            VonMember("indexReferend", vonifyKind(indexExpr.resultType.kind)),
+            VonMember("indexKind", vonifyKind(indexExpr.resultType.kind)),
             VonMember("sourceExpr", vonifyExpression(sourceExpr)),
             VonMember("sourceType", vonifyCoord(sourceExpr.resultType)),
-            VonMember("sourceReferend", vonifyKind(sourceExpr.resultType.kind)),
+            VonMember("sourceKind", vonifyKind(sourceExpr.resultType.kind)),
             VonMember("sourceKnownLive", VonBool(false)),
             VonMember("resultType", vonifyCoord(resultType))))
       }
@@ -691,11 +730,11 @@ object VonHammer {
           Vector(
             VonMember("arrayExpr", vonifyExpression(arrayExpr)),
             VonMember("arrayType", vonifyCoord(arrayExpr.resultType)),
-            VonMember("arrayReferend", vonifyKind(arrayExpr.resultType.kind)),
+            VonMember("arrayKind", vonifyKind(arrayExpr.resultType.kind)),
             VonMember("arrayKnownLive", VonBool(false)),
             VonMember("indexExpr", vonifyExpression(indexExpr)),
             VonMember("indexType", vonifyCoord(indexExpr.resultType)),
-            VonMember("indexReferend", vonifyKind(indexExpr.resultType.kind)),
+            VonMember("indexKind", vonifyKind(indexExpr.resultType.kind)),
             VonMember("resultType", vonifyCoord(rsal.resultType)),
             VonMember("targetOwnership", vonifyOwnership(targetOwnership)),
             VonMember("targetPermission", vonifyPermission(targetPermission)),
@@ -709,10 +748,10 @@ object VonHammer {
           Vector(
             VonMember("sizeExpr", vonifyExpression(sizeExpr)),
             VonMember("sizeType", vonifyCoord(sizeExpr.resultType)),
-            VonMember("sizeReferend", vonifyKind(sizeExpr.resultType.kind)),
+            VonMember("sizeKind", vonifyKind(sizeExpr.resultType.kind)),
             VonMember("generatorExpr", vonifyExpression(generatorExpr)),
             VonMember("generatorType", vonifyCoord(generatorExpr.resultType)),
-            VonMember("generatorReferend", vonifyKind(generatorExpr.resultType.kind)),
+            VonMember("generatorKind", vonifyKind(generatorExpr.resultType.kind)),
             VonMember("generatorMethod", vonifyPrototype(generatorMethod)),
             VonMember("generatorKnownLive", VonBool(false)),
             VonMember("resultType", vonifyCoord(resultType)),
@@ -725,7 +764,7 @@ object VonHammer {
           Vector(
             VonMember("generatorExpr", vonifyExpression(generatorExpr)),
             VonMember("generatorType", vonifyCoord(generatorExpr.resultType)),
-            VonMember("generatorReferend", vonifyKind(generatorExpr.resultType.kind)),
+            VonMember("generatorKind", vonifyKind(generatorExpr.resultType.kind)),
             VonMember("generatorMethod", vonifyPrototype(generatorMethod)),
             VonMember("generatorKnownLive", VonBool(false)),
             VonMember("resultType", vonifyCoord(resultType)),
@@ -738,7 +777,7 @@ object VonHammer {
           Vector(
             VonMember("arrayExpr", vonifyExpression(arrayExpr)),
             VonMember("arrayType", vonifyCoord(arrayExpr.resultType)),
-            VonMember("arrayReferend", vonifyKind(arrayExpr.resultType.kind)),
+            VonMember("arrayKind", vonifyKind(arrayExpr.resultType.kind)),
             VonMember("arrayKnownLive", VonBool(false)),
             VonMember("indexExpr", vonifyExpression(indexExpr)),
             VonMember("resultType", vonifyCoord(ssal.resultType)),
@@ -857,7 +896,7 @@ object VonHammer {
         VonMember("height", VonInt(number)),
         VonMember(
           "optName",
-          vonifyOptional[FullNameH](maybeName, x => VonStr(x.toReadableString())))))
+          vonifyOptional[FullNameH](maybeName, x => vonifyName(x)))))
   }
 
   def vonifyOptional[T](opt: Option[T], func: (T) => IVonData): IVonData = {
@@ -1310,5 +1349,17 @@ object VonHammer {
           Vector())
       }
     }
+  }
+
+  def vonifyName(h: FullNameH): IVonData = {
+    val FullNameH(readableName, id, packageCoordinate, parts) = h
+    VonObject(
+      "Name",
+      None,
+      Vector(
+        VonMember("readableName", VonStr(readableName)),
+        VonMember("id", VonInt(id)),
+        VonMember("packageCoordinate", NameHammer.translatePackageCoordinate(packageCoordinate)),
+        VonMember("parts", VonArray(None, parts.map(MetalPrinter.print).map(VonStr).toVector))))
   }
 }

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/VonHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/VonHammer.scala
@@ -60,7 +60,7 @@ object VonHammer {
       "Package",
       None,
       Vector(
-        VonMember("name", NameHammer.translatePackageCoordinate(packageCoord)),
+        VonMember("packageCoordinate", NameHammer.translatePackageCoordinate(packageCoord)),
         VonMember("interfaces", VonArray(None, interfaces.map(vonifyInterface).toVector)),
         VonMember("structs", VonArray(None, structs.map(vonfiyStruct).toVector)),
         VonMember("functions", VonArray(None, functions.map(vonifyFunction).toVector)),

--- a/Valestrom/Hammer/test/net/verdagon/vale/hammer/HammerTest.scala
+++ b/Valestrom/Hammer/test/net/verdagon/vale/hammer/HammerTest.scala
@@ -42,7 +42,8 @@ class HammerTest extends FunSuite with Matchers {
           |}
           |""".stripMargin)
     val hamuts = compile.getHamuts()
-    val main = hamuts.functions.find(_.`export`).get
+    val main = hamuts.lookupPackage(PackageCoordinate.TEST_TLD).lookupFunction("main")
+    vassert(main.`export`)
     val stackifies = recursiveCollect(main, { case s @ StackifyH(_, _, _) => s })
     val localIds = stackifies.map(_.local.id.number).sorted
     localIds shouldEqual localIds.distinct

--- a/Valestrom/Hinputs/src/net/verdagon/vale/hinputs/Hinputs.scala
+++ b/Valestrom/Hinputs/src/net/verdagon/vale/hinputs/Hinputs.scala
@@ -1,6 +1,6 @@
 package net.verdagon.vale.hinputs
 
-import net.verdagon.vale.templar.{CitizenName2, Edge2, ExportAs2, FullName2, Function2, FunctionName2, IFunctionName2, Impl2, InterfaceEdgeBlueprint, LambdaCitizenName2, Program2, simpleName}
+import net.verdagon.vale.templar.{CitizenName2, Edge2, FullName2, Function2, FunctionExport2, FunctionExtern2, FunctionName2, IFunctionName2, Impl2, InterfaceEdgeBlueprint, KindExport2, KindExtern2, LambdaCitizenName2, Program2, simpleName}
 import net.verdagon.vale.templar.templata.{FunctionBanner2, Prototype2, Signature2}
 import net.verdagon.vale.templar.types.{InterfaceDefinition2, InterfaceRef2, Kind, StructDefinition2, StructRef2}
 import net.verdagon.vale.{PackageCoordinate, vassertSome, vfail}
@@ -10,15 +10,17 @@ import scala.collection.immutable.List
 case class ETable2(struct: StructRef2, table: TetrisTable[InterfaceRef2, InterfaceRef2])
 
 case class Hinputs(
-  interfaces: List[InterfaceDefinition2],
-  structs: List[StructDefinition2],
-  emptyPackStructRef: StructRef2,
-  functions: List[Function2],
-  exports: List[ExportAs2],
-  kindToDestructor: Map[Kind, Prototype2],
-  packageToExternNameToExtern: Map[PackageCoordinate, Map[String, Prototype2]],
-  edgeBlueprintsByInterface: Map[InterfaceRef2, InterfaceEdgeBlueprint],
-  edges: List[Edge2]) {
+    interfaces: List[InterfaceDefinition2],
+    structs: List[StructDefinition2],
+    emptyPackStructRef: StructRef2,
+    functions: List[Function2],
+    kindToDestructor: Map[Kind, Prototype2],
+    edgeBlueprintsByInterface: Map[InterfaceRef2, InterfaceEdgeBlueprint],
+    edges: List[Edge2],
+    kindExports: List[KindExport2],
+    functionExports: List[FunctionExport2],
+    kindExterns: List[KindExtern2],
+    functionExterns: List[FunctionExtern2]) {
 
   def lookupStruct(structRef: StructRef2): StructDefinition2 = {
     structs.find(_.getRef == structRef) match {

--- a/Valestrom/Hinputs/src/net/verdagon/vale/hinputs/Hinputs.scala
+++ b/Valestrom/Hinputs/src/net/verdagon/vale/hinputs/Hinputs.scala
@@ -16,7 +16,7 @@ case class Hinputs(
   functions: List[Function2],
   exports: List[ExportAs2],
   kindToDestructor: Map[Kind, Prototype2],
-  moduleNameToExternNameToExtern: Map[String, Map[String, (PackageCoordinate, Prototype2)]],
+  packageToExternNameToExtern: Map[PackageCoordinate, Map[String, Prototype2]],
   edgeBlueprintsByInterface: Map[InterfaceRef2, InterfaceEdgeBlueprint],
   edges: List[Edge2]) {
 

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ArithmeticTestsA.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ArithmeticTestsA.scala
@@ -14,6 +14,6 @@ import org.scalatest.{FunSuite, Matchers}
 class ArithmeticTestsA extends FunSuite with Matchers {
   test("Dividing") {
     val compile = RunCompilation.test("fn main() int export {5 / 2}")
-    compile.evalForReferend(Vector()) shouldEqual VonInt(2)
+    compile.evalForKind(Vector()) shouldEqual VonInt(2)
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ArrayListTest.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ArrayListTest.scala
@@ -47,7 +47,7 @@ class ArrayListTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 
   test("Array list with optionals") {
@@ -71,7 +71,7 @@ class ArrayListTest extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 
   test("Array list zero-constructor") {
@@ -87,7 +87,7 @@ class ArrayListTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 
   test("Array list len") {
@@ -103,7 +103,7 @@ class ArrayListTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
   test("Array list set") {
@@ -120,7 +120,7 @@ class ArrayListTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(11)
+    compile.evalForKind(Vector()) shouldEqual VonInt(11)
   }
 
   test("Array list with optionals with mutable element") {
@@ -145,7 +145,7 @@ class ArrayListTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 
   test("Mutate mutable from in lambda") {
@@ -168,7 +168,7 @@ class ArrayListTest extends FunSuite with Matchers {
     val main = temputs.lookupFunction("main");
     main.variables.collect({ case AddressibleLocalVariable2(FullName2(_, _, CodeVarName2("m")), Varying, _) => })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 
   test("Move mutable from in lambda") {
@@ -190,7 +190,7 @@ class ArrayListTest extends FunSuite with Matchers {
     val main = temputs.lookupFunction("main");
     main.variables.collect({ case AddressibleLocalVariable2(FullName2(_, _, CodeVarName2("m")), Varying, _) => })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(6)
+    compile.evalForKind(Vector()) shouldEqual VonInt(6)
   }
 
 
@@ -215,7 +215,7 @@ class ArrayListTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector())
+    compile.evalForKind(Vector())
   }
 
 
@@ -237,6 +237,6 @@ class ArrayListTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector())
+    compile.evalForKind(Vector())
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ArrayListTest.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ArrayListTest.scala
@@ -200,7 +200,7 @@ class ArrayListTest extends FunSuite with Matchers {
           |import panicutils.*;
           |struct Marine { hp int; }
           |
-          |fn main() {
+          |fn main() export {
           |  l = List<Marine>();
           |  add(&!l, Marine(5));
           |  add(&!l, Marine(7));
@@ -227,7 +227,7 @@ class ArrayListTest extends FunSuite with Matchers {
           |import panicutils.*;
           |struct Marine { hp int; }
           |
-          |fn main() {
+          |fn main() export {
           |  l = List<Marine>();
           |  add(&!l, Marine(5));
           |  add(&!l, Marine(7));

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ArrayTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ArrayTests.scala
@@ -423,7 +423,7 @@ class ArrayTests extends FunSuite with Matchers {
           |struct MyIntIdentity {}
           |impl IFunction1<mut, int, int> for MyIntIdentity;
           |fn __call(this &!MyIntIdentity impl IFunction1<mut, int, int>, i int) int { i }
-          |fn main() {
+          |fn main() export {
           |  m = MyIntIdentity();
           |  arr = MakeArray(10, &!m);
           |  lam = { print(str(arr.6)); };
@@ -564,7 +564,7 @@ class ArrayTests extends FunSuite with Matchers {
         """
           |import array.make.*;
           |import array.each.*;
-          |fn main() {
+          |fn main() export {
           |  planets = []["Venus", "Earth", "Mars"];
           |  each planets (planet){
           |    print(planet);

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ArrayTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ArrayTests.scala
@@ -18,7 +18,7 @@ class ArrayTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Simple static array and runtime index lookup") {
@@ -37,7 +37,7 @@ class ArrayTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(4)
+    compile.evalForKind(Vector()) shouldEqual VonInt(4)
   }
 
   test("Unspecified-mutability static array from lambda defaults to mutable") {
@@ -57,7 +57,7 @@ class ArrayTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Immutable static array from lambda") {
@@ -70,7 +70,7 @@ class ArrayTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Mutable static array from lambda") {
@@ -83,7 +83,7 @@ class ArrayTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Immutable static array from values") {
@@ -96,7 +96,7 @@ class ArrayTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Mutable static array from values") {
@@ -109,7 +109,7 @@ class ArrayTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Unspecified-mutability runtime array from lambda defaults to mutable") {
@@ -129,7 +129,7 @@ class ArrayTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Immutable runtime array from lambda") {
@@ -142,7 +142,7 @@ class ArrayTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Mutable runtime array from lambda") {
@@ -155,7 +155,7 @@ class ArrayTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   //m [<mut> 3 * [<mut> 3 * int]] = [mut][ [mut][1, 2, 3], [mut][4, 5, 6], [mut][7, 8, 9] ];
@@ -171,7 +171,7 @@ class ArrayTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Borrow arraysequence as a parameter") {
@@ -190,7 +190,7 @@ class ArrayTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(4)
+    compile.evalForKind(Vector()) shouldEqual VonInt(4)
   }
 
   // the argument to __Array doesnt even have to be a struct or a lambda or an
@@ -212,7 +212,7 @@ class ArrayTests extends FunSuite with Matchers {
       case ConstructArray2(RuntimeSizedArrayT2(RawArrayT2(Coord(Share, Readonly, Int2()), Immutable, _)), _, _, _) =>
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
   test("array map with lambda") {
@@ -235,7 +235,7 @@ class ArrayTests extends FunSuite with Matchers {
       case ConstructArray2(RuntimeSizedArrayT2(RawArrayT2(Coord(Share, Readonly, Int2()), Immutable, _)), _, _, _) =>
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
   test("MakeArray map with struct") {
@@ -252,7 +252,7 @@ class ArrayTests extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
   test("MakeArray map with lambda") {
@@ -265,7 +265,7 @@ class ArrayTests extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
   test("array map with interface") {
@@ -283,7 +283,7 @@ class ArrayTests extends FunSuite with Matchers {
       case ConstructArray2(RuntimeSizedArrayT2(RawArrayT2(Coord(Share, Readonly, Int2()), Immutable, _)), _, _, _) =>
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
   test("Array map taking a closure which captures something") {
@@ -295,7 +295,7 @@ class ArrayTests extends FunSuite with Matchers {
           |  = a.3;
           |}
         """.stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(10)
+    compile.evalForKind(Vector()) shouldEqual VonInt(10)
   }
 
   test("Simple array map with runtime index lookup") {
@@ -320,7 +320,7 @@ class ArrayTests extends FunSuite with Matchers {
 //        |}
 //      """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Nested array") {
@@ -331,7 +331,7 @@ class ArrayTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(2)
+    compile.evalForKind(Vector()) shouldEqual VonInt(2)
   }
 
 
@@ -347,7 +347,7 @@ class ArrayTests extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
   test("Array with capture") {
@@ -364,7 +364,7 @@ class ArrayTests extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(7)
+    compile.evalForKind(Vector()) shouldEqual VonInt(7)
   }
 
   test("Capture") {
@@ -388,7 +388,7 @@ class ArrayTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(7)
+    compile.evalForKind(Vector()) shouldEqual VonInt(7)
   }
 
 
@@ -414,7 +414,7 @@ class ArrayTests extends FunSuite with Matchers {
 //        |}
 //      """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(1337)
+    compile.evalForKind(Vector()) shouldEqual VonInt(1337)
   }
 
   test("Capture mutable array") {
@@ -450,7 +450,7 @@ class ArrayTests extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(4)
+    compile.evalForKind(Vector()) shouldEqual VonInt(4)
   }
 
 
@@ -462,7 +462,7 @@ class ArrayTests extends FunSuite with Matchers {
           |  = len(&a);
           |}
         """.stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(11)
+    compile.evalForKind(Vector()) shouldEqual VonInt(11)
   }
 
   test("Map using array construct") {
@@ -504,7 +504,7 @@ class ArrayTests extends FunSuite with Matchers {
 //        |}
 //      """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(4)
+    compile.evalForKind(Vector()) shouldEqual VonInt(4)
   }
 
   test("Map from hardcoded values") {
@@ -519,7 +519,7 @@ class ArrayTests extends FunSuite with Matchers {
           |  [imm][6, 4, 3, 5, 2, 8].toArray<mut>()[3]
           |}
           |""".stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Nested imm arrays") {
@@ -530,7 +530,7 @@ class ArrayTests extends FunSuite with Matchers {
         |  [imm][[imm][6, 60].toImmArray(), [imm][4, 40].toImmArray(), [imm][3, 30].toImmArray()].toImmArray()[2][1]
         |}
         |""".stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(30)
+    compile.evalForKind(Vector()) shouldEqual VonInt(30)
   }
 
   test("Array foreach") {
@@ -544,7 +544,7 @@ class ArrayTests extends FunSuite with Matchers {
         |  = sum;
         |}
         |""".stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(169)
+    compile.evalForKind(Vector()) shouldEqual VonInt(169)
   }
 
   test("Array has") {
@@ -555,7 +555,7 @@ class ArrayTests extends FunSuite with Matchers {
           |  [][6, 60, 103].has(103)
           |}
           |""".stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonBool(true)
+    compile.evalForKind(Vector()) shouldEqual VonBool(true)
   }
 
 
@@ -584,7 +584,7 @@ class ArrayTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonStr("3")
+    compile.evalForKind(Vector()) shouldEqual VonStr("3")
   }
 
 //  test("Destroy lambda with mutable captures") {
@@ -606,7 +606,7 @@ class ArrayTests extends FunSuite with Matchers {
 //          |  = newArray.0;
 //          |}
 //          |""".stripMargin)
-//    compile.evalForReferend(Vector()) shouldEqual VonInt(0)
+//    compile.evalForKind(Vector()) shouldEqual VonInt(0)
 //  }
 
 
@@ -615,7 +615,7 @@ class ArrayTests extends FunSuite with Matchers {
 //    val compile = RunCompilation.test(
 //      """
 //        |fn map
-//        |:(n: Int, T: reference, F: referend)
+//        |:(n: Int, T: reference, F: kind)
 //        |(arr: &[n T], generator: &F) {
 //        |  Array<mut>(n, (i){ generator(arr.(i))})
 //        |}
@@ -626,7 +626,7 @@ class ArrayTests extends FunSuite with Matchers {
 //        |}
 //      """.stripMargin)
 //
-//    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+//    compile.evalForKind(Vector()) shouldEqual VonInt(3)
 //  }
 
 

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/BlockTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/BlockTests.scala
@@ -21,7 +21,7 @@ class BlockTests extends FunSuite with Matchers {
     val main = scoutput.lookupFunction("main")
     main.body match { case CodeBody1(BodySE(_, _,BlockSE(_, _,List(BlockSE(_, _,_), _)))) => }
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
   test("Simple block with a variable") {
     val compile = RunCompilation.test(
@@ -41,7 +41,7 @@ class BlockTests extends FunSuite with Matchers {
       case LocalVariable1(CodeVarNameS("y"), FinalP, NotUsed, NotUsed, NotUsed, NotUsed, NotUsed, NotUsed) =>
     }
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
   test("Simple block with a variable, another variable outside with same name") {
     val compile = RunCompilation.test(
@@ -56,6 +56,6 @@ class BlockTests extends FunSuite with Matchers {
       """.stripMargin)
     val scoutput = compile.getScoutput().getOrDie()
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ClosureTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ClosureTests.scala
@@ -217,7 +217,7 @@ class ClosureTests extends FunSuite with Matchers {
   test("Read from inside a closure inside a closure") {
     val compile = RunCompilation.test(
       """
-        |fn main() int {
+        |fn main() int export {
         |  x = 42;
         |  = { { x }() }();
         |}

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ClosureTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ClosureTests.scala
@@ -103,7 +103,7 @@ class ClosureTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 
   test("Test closure's local variables") {
@@ -171,7 +171,7 @@ class ClosureTests extends FunSuite with Matchers {
       case LocalLookup2(_,ReferenceLocalVariable2(FullName2(_, _,ClosureParamName2()),Final,_),_, _) =>
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(4)
+    compile.evalForKind(Vector()) shouldEqual VonInt(4)
   }
 
   test("Mutates from inside a closure") {
@@ -205,13 +205,13 @@ class ClosureTests extends FunSuite with Matchers {
       case AddressibleLocalVariable2(_, Varying, _) =>
     }).size shouldEqual 1
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Mutates from inside a closure inside a closure") {
     val compile = RunCompilation.test("fn main() int export { x! = 4; { { set x = x + 1; }!(); }!(); = x; }")
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Read from inside a closure inside a closure") {
@@ -223,7 +223,7 @@ class ClosureTests extends FunSuite with Matchers {
         |}
         |""".stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Mutable lambda") {
@@ -240,6 +240,6 @@ class ClosureTests extends FunSuite with Matchers {
         }
       }).get
     vassert(closureStruct.mutability == Mutable)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ConjunctionTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ConjunctionTests.scala
@@ -6,12 +6,12 @@ import org.scalatest.{FunSuite, Matchers}
 class ConjunctionTests extends FunSuite with Matchers {
   test("And") {
     val compile = RunCompilation.test("fn main() bool export {true and true}")
-    compile.evalForReferend(Vector()) shouldEqual VonBool(true)
+    compile.evalForKind(Vector()) shouldEqual VonBool(true)
   }
 
   test("Or") {
     val compile = RunCompilation.test("fn main() bool export {true or false}")
-    compile.evalForReferend(Vector()) shouldEqual VonBool(true)
+    compile.evalForKind(Vector()) shouldEqual VonBool(true)
   }
 
   test("And short-circuiting") {

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/FloatTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/FloatTests.scala
@@ -26,18 +26,18 @@ class FloatTests extends FunSuite with Matchers {
   test("Float arithmetic") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/floatarithmetic.vale"))
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Float equals") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/floateq.vale"))
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Concat string and float") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/concatstrfloat.vale"))
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/HammerTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/HammerTests.scala
@@ -19,8 +19,9 @@ class HammerTests extends FunSuite with Matchers {
       "fn main() int export {3}")
     val hamuts = compile.getHamuts()
 
-    vassert(hamuts.getAllUserFunctions.size == 1)
-    hamuts.getAllUserFunctions.head.prototype.fullName.toFullString() shouldEqual """"test":F("main")"""
+    val testPackage = hamuts.lookupPackage(PackageCoordinate.TEST_TLD)
+    vassert(testPackage.getAllUserFunctions.size == 1)
+    testPackage.getAllUserFunctions.head.prototype.fullName.toFullString() shouldEqual """test::F("main")"""
   }
 
 //  // Make sure a ListNode struct made it out
@@ -47,14 +48,14 @@ class HammerTests extends FunSuite with Matchers {
         |
         |fn main(a *MySome<int>, b *MyNone<int>) {}
       """.stripMargin)
-    val hamuts = compile.getHamuts()
-    hamuts.interfaces.find(_.fullName.toFullString() == """"test":C("MyOption",[TR(R(*,<,#,i))])""").get;
+    val packageH = compile.getHamuts().lookupPackage(PackageCoordinate.TEST_TLD)
+    packageH.interfaces.find(_.fullName.toFullString() == """test::C("MyOption",[TR(R(*,<,#,i))])""").get;
 
-    val mySome = hamuts.structs.find(_.fullName.toFullString() == """"test":C("MySome",[TR(R(*,<,#,i))])""").get;
+    val mySome = packageH.structs.find(_.fullName.toFullString() == """test::C("MySome",[TR(R(*,<,#,i))])""").get;
     vassert(mySome.members.size == 1);
     vassert(mySome.members.head.tyype == ReferenceH[IntH](m.ShareH, InlineH, ReadonlyH, IntH()))
 
-    val myNone = hamuts.structs.find(_.fullName.toFullString() == """"test":C("MyNone",[TR(R(*,<,#,i))])""").get;
+    val myNone = packageH.structs.find(_.fullName.toFullString() == """test::C("MyNone",[TR(R(*,<,#,i))])""").get;
     vassert(myNone.members.isEmpty);
   }
 
@@ -70,12 +71,12 @@ class HammerTests extends FunSuite with Matchers {
         |impl Blark for MyStruct;
         |fn wot(b *MyStruct impl Blark) int { 9 }
       """.stripMargin)
-    val hamuts = compile.getHamuts()
-    hamuts.nonExternFunctions.find(f => f.prototype.fullName.toFullString().startsWith("""F("wot"""")).get;
-    hamuts.nonExternFunctions.find(f => f.prototype.fullName.toFullString() == """F("MyStruct")""").get;
-    vassert(hamuts.abstractFunctions.size == 2)
-    vassert(hamuts.getAllUserImplementedFunctions.size == 1)
-    vassert(hamuts.getAllUserFunctions.size == 1)
+    val packageH = compile.getHamuts().lookupPackage(PackageCoordinate.TEST_TLD)
+    packageH.nonExternFunctions.find(f => f.prototype.fullName.toFullString().startsWith("""F("wot"""")).get;
+    packageH.nonExternFunctions.find(f => f.prototype.fullName.toFullString() == """F("MyStruct")""").get;
+    vassert(packageH.abstractFunctions.size == 2)
+    vassert(packageH.getAllUserImplementedFunctions.size == 1)
+    vassert(packageH.getAllUserFunctions.size == 1)
   }
 
   test("Tests stripping things after panic") {
@@ -87,8 +88,8 @@ class HammerTests extends FunSuite with Matchers {
         |  = a;
         |}
       """.stripMargin)
-    val hamuts = compile.getHamuts()
-    val main = hamuts.lookupFunction("main")
+    val packageH = compile.getHamuts().lookupPackage(PackageCoordinate.TEST_TLD)
+    val main = packageH.lookupFunction("main")
     main.body match {
       case BlockH(CallH(PrototypeH(fullNameH, List(), ReferenceH(_, _, ReadonlyH, NeverH())), List())) => {
         vassert(fullNameH.toFullString().contains("__panic"))
@@ -101,10 +102,9 @@ class HammerTests extends FunSuite with Matchers {
       """
         |fn moo() int export { 42 }
         |""".stripMargin)
-    val hamuts = compile.getHamuts()
-    val moo = hamuts.lookupFunction("moo")
-    hamuts.moduleNameToExportedNameToExportee(FileCoordinateMap.TEST_MODULE)("moo") shouldEqual
-      (PackageCoordinate(FileCoordinateMap.TEST_MODULE, List()), moo.fullName)
+    val packageH = compile.getHamuts().lookupPackage(PackageCoordinate.TEST_TLD)
+    val moo = packageH.lookupFunction("moo")
+    packageH.exportNameToFullName("moo") shouldEqual moo.fullName
   }
 
   test("Tests export struct") {
@@ -112,10 +112,9 @@ class HammerTests extends FunSuite with Matchers {
       """
         |struct Moo export { }
         |""".stripMargin)
-    val hamuts = compile.getHamuts()
-    val moo = hamuts.lookupStruct("Moo")
-    hamuts.moduleNameToExportedNameToExportee(FileCoordinateMap.TEST_MODULE)("Moo") shouldEqual
-      (PackageCoordinate(FileCoordinateMap.TEST_MODULE, List()), moo.fullName)
+    val packageH = compile.getHamuts().lookupPackage(PackageCoordinate.TEST_TLD)
+    val moo = packageH.lookupStruct("Moo")
+    packageH.exportNameToFullName("Moo") shouldEqual moo.fullName
   }
 
   test("Tests export struct twice") {
@@ -124,12 +123,10 @@ class HammerTests extends FunSuite with Matchers {
         |struct Moo export { }
         |export Moo as Bork;
         |""".stripMargin)
-    val hamuts = compile.getHamuts()
-    val moo = hamuts.lookupStruct("Moo")
-    hamuts.moduleNameToExportedNameToExportee(FileCoordinateMap.TEST_MODULE)("Moo") shouldEqual
-      (PackageCoordinate(FileCoordinateMap.TEST_MODULE, List()), moo.fullName)
-    hamuts.moduleNameToExportedNameToExportee(FileCoordinateMap.TEST_MODULE)("Bork") shouldEqual
-      (PackageCoordinate(FileCoordinateMap.TEST_MODULE, List()), moo.fullName)
+    val packageH = compile.getHamuts().lookupPackage(PackageCoordinate.TEST_TLD)
+    val moo = packageH.lookupStruct("Moo")
+    packageH.exportNameToFullName("Moo") shouldEqual moo.fullName
+    packageH.exportNameToFullName("Bork") shouldEqual moo.fullName
   }
 
   test("Tests export interface") {
@@ -137,27 +134,9 @@ class HammerTests extends FunSuite with Matchers {
       """
         |interface Moo export { }
         |""".stripMargin)
-    val hamuts = compile.getHamuts()
-    val moo = hamuts.lookupInterface("Moo")
-    hamuts.moduleNameToExportedNameToExportee(FileCoordinateMap.TEST_MODULE)("Moo") shouldEqual
-      (PackageCoordinate(FileCoordinateMap.TEST_MODULE, List()), moo.fullName)
-  }
-
-  test("Tests recovering directory from export") {
-    val compile =
-      new RunCompilation(
-        List(PackageCoordinate.BUILTIN, PackageCoordinate("moduleA", List("someDir", "someOtherDir"))),
-        Builtins.getCodeMap()
-          .or(
-            FileCoordinateMap(Map())
-              .add("moduleA", List("someDir", "someOtherDir"), "StructA.vale", "struct StructA export { a int; }"))
-          .or(Tests.getPackageToResourceResolver),
-        FullCompilationOptions())
-    val hamuts = compile.getHamuts()
-
-    hamuts.moduleNameToExportedNameToExportee("moduleA")("StructA") match {
-      case (PackageCoordinate("moduleA", List("someDir", "someOtherDir")), _) =>
-    }
+    val packageH = compile.getHamuts().lookupPackage(PackageCoordinate.TEST_TLD)
+    val moo = packageH.lookupInterface("Moo")
+    packageH.exportNameToFullName("Moo") shouldEqual moo.fullName
   }
 
   test("Tests exports from two modules, different names") {
@@ -173,20 +152,16 @@ class HammerTests extends FunSuite with Matchers {
         FullCompilationOptions())
     val hamuts = compile.getHamuts()
 
-    val fullNameA =
-      hamuts.moduleNameToExportedNameToExportee("moduleA")("StructA") match {
-        case (PackageCoordinate("moduleA", List()), fullName) => fullName
-      }
+    val packageA = hamuts.lookupPackage(PackageCoordinate("moduleA", List()))
+    val fullNameA = vassertSome(packageA.exportNameToFullName.get("StructA"))
 
-    val fullNameB =
-      hamuts.moduleNameToExportedNameToExportee("moduleB")("StructB") match {
-        case (PackageCoordinate("moduleB", List()), fullName) => fullName
-      }
+    val packageB = hamuts.lookupPackage(PackageCoordinate("moduleB", List()))
+    val fullNameB = vassertSome(packageB.exportNameToFullName.get("StructB"))
 
     vassert(fullNameA != fullNameB)
   }
 
-  // Intentional failure, we want these to be invisible to each other and both make it through
+  // Intentional failure, need to separate things internally inside Hammer
   test("Tests exports from two modules, same name") {
     val compile =
       new RunCompilation(
@@ -200,15 +175,11 @@ class HammerTests extends FunSuite with Matchers {
         FullCompilationOptions())
     val hamuts = compile.getHamuts()
 
-    val fullNameA =
-      hamuts.moduleNameToExportedNameToExportee("moduleA")("MyStruct") match {
-        case (PackageCoordinate("moduleA", List()), fullName) => fullName
-      }
+    val packageA = hamuts.lookupPackage(PackageCoordinate("moduleA", List()))
+    val fullNameA = vassertSome(packageA.exportNameToFullName.get("StructA"))
 
-    val fullNameB =
-      hamuts.moduleNameToExportedNameToExportee("moduleB")("MyStruct") match {
-        case (PackageCoordinate("moduleB", List()), fullName) => fullName
-      }
+    val packageB = hamuts.lookupPackage(PackageCoordinate("moduleB", List()))
+    val fullNameB = vassertSome(packageB.exportNameToFullName.get("StructA"))
 
     vassert(fullNameA != fullNameB)
   }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/HammerTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/HammerTests.scala
@@ -104,7 +104,7 @@ class HammerTests extends FunSuite with Matchers {
         |""".stripMargin)
     val packageH = compile.getHamuts().lookupPackage(PackageCoordinate.TEST_TLD)
     val moo = packageH.lookupFunction("moo")
-    packageH.exportNameToFullName("moo") shouldEqual moo.fullName
+    packageH.exportNameToFunction("moo") shouldEqual moo.prototype
   }
 
   test("Tests export struct") {
@@ -114,7 +114,7 @@ class HammerTests extends FunSuite with Matchers {
         |""".stripMargin)
     val packageH = compile.getHamuts().lookupPackage(PackageCoordinate.TEST_TLD)
     val moo = packageH.lookupStruct("Moo")
-    packageH.exportNameToFullName("Moo") shouldEqual moo.fullName
+    packageH.exportNameToKind("Moo") shouldEqual moo.getRef
   }
 
   test("Tests export struct twice") {
@@ -125,8 +125,8 @@ class HammerTests extends FunSuite with Matchers {
         |""".stripMargin)
     val packageH = compile.getHamuts().lookupPackage(PackageCoordinate.TEST_TLD)
     val moo = packageH.lookupStruct("Moo")
-    packageH.exportNameToFullName("Moo") shouldEqual moo.fullName
-    packageH.exportNameToFullName("Bork") shouldEqual moo.fullName
+    packageH.exportNameToKind("Moo") shouldEqual moo.getRef
+    packageH.exportNameToKind("Bork") shouldEqual moo.getRef
   }
 
   test("Tests export interface") {
@@ -136,7 +136,7 @@ class HammerTests extends FunSuite with Matchers {
         |""".stripMargin)
     val packageH = compile.getHamuts().lookupPackage(PackageCoordinate.TEST_TLD)
     val moo = packageH.lookupInterface("Moo")
-    packageH.exportNameToFullName("Moo") shouldEqual moo.fullName
+    packageH.exportNameToKind("Moo") shouldEqual moo.getRef
   }
 
   test("Tests exports from two modules, different names") {
@@ -153,10 +153,10 @@ class HammerTests extends FunSuite with Matchers {
     val hamuts = compile.getHamuts()
 
     val packageA = hamuts.lookupPackage(PackageCoordinate("moduleA", List()))
-    val fullNameA = vassertSome(packageA.exportNameToFullName.get("StructA"))
+    val fullNameA = vassertSome(packageA.exportNameToKind.get("StructA"))
 
     val packageB = hamuts.lookupPackage(PackageCoordinate("moduleB", List()))
-    val fullNameB = vassertSome(packageB.exportNameToFullName.get("StructB"))
+    val fullNameB = vassertSome(packageB.exportNameToKind.get("StructB"))
 
     vassert(fullNameA != fullNameB)
   }
@@ -176,10 +176,10 @@ class HammerTests extends FunSuite with Matchers {
     val hamuts = compile.getHamuts()
 
     val packageA = hamuts.lookupPackage(PackageCoordinate("moduleA", List()))
-    val fullNameA = vassertSome(packageA.exportNameToFullName.get("StructA"))
+    val fullNameA = vassertSome(packageA.exportNameToKind.get("StructA"))
 
     val packageB = hamuts.lookupPackage(PackageCoordinate("moduleB", List()))
-    val fullNameB = vassertSome(packageB.exportNameToFullName.get("StructA"))
+    val fullNameB = vassertSome(packageB.exportNameToKind.get("StructA"))
 
     vassert(fullNameA != fullNameB)
   }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/HashMapTest.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/HashMapTest.scala
@@ -22,7 +22,7 @@ class HashMapTest extends FunSuite with Matchers {
           |}
           |""".stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(108)
+    compile.evalForKind(Vector()) shouldEqual VonInt(108)
   }
 
   test("Hash map collisions") {
@@ -61,7 +61,7 @@ class HashMapTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(111)
+    compile.evalForKind(Vector()) shouldEqual VonInt(111)
   }
 
   test("Hash map with functors") {
@@ -79,7 +79,7 @@ class HashMapTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(100)
+    compile.evalForKind(Vector()) shouldEqual VonInt(100)
   }
 
   test("Hash map with struct as key") {
@@ -114,7 +114,7 @@ class HashMapTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(100)
+    compile.evalForKind(Vector()) shouldEqual VonInt(100)
   }
 
   test("Hash map has") {
@@ -139,7 +139,7 @@ class HashMapTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(111)
+    compile.evalForKind(Vector()) shouldEqual VonInt(111)
   }
 
   test("Hash map keys") {
@@ -163,7 +163,7 @@ class HashMapTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(1337)
+    compile.evalForKind(Vector()) shouldEqual VonInt(1337)
   }
 
   test("Hash map values") {
@@ -187,7 +187,7 @@ class HashMapTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(1337)
+    compile.evalForKind(Vector()) shouldEqual VonInt(1337)
   }
 
   test("Hash map with mutable values") {
@@ -213,7 +213,7 @@ class HashMapTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(1337)
+    compile.evalForKind(Vector()) shouldEqual VonInt(1337)
   }
 
   test("Hash map remove") {
@@ -239,7 +239,7 @@ class HashMapTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(1337)
+    compile.evalForKind(Vector()) shouldEqual VonInt(1337)
   }
 
   test("Hash map remove 2") {
@@ -267,6 +267,6 @@ class HashMapTest extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(1337)
+    compile.evalForKind(Vector()) shouldEqual VonInt(1337)
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/IfTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/IfTests.scala
@@ -93,7 +93,7 @@ class IfTests extends FunSuite with Matchers {
     val compile = RunCompilation.test(
       """
         |struct Marine { x int; }
-        |fn main() str {
+        |fn main() str export {
         |  m = Marine(5);
         |  = if (m.x == 5) { "#" }
         |  else if (0 == 0) { "?" }
@@ -173,7 +173,7 @@ class IfTests extends FunSuite with Matchers {
         |  bork Bork;
         |}
         |
-        |fn main() {
+        |fn main() export {
         |  zork! = 0;
         |  while (zork < 4) {
         |    moo = Moo(Bork(5));

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/IfTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/IfTests.scala
@@ -22,7 +22,7 @@ class IfTests extends FunSuite with Matchers {
     val temputs = compile.expectTemputs()
     temputs.lookupFunction("main").only({ case If2(_, _, _) => })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
   test("Simple false branch returning an int") {
@@ -33,7 +33,7 @@ class IfTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Ladder") {
@@ -56,7 +56,7 @@ class IfTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Moving from inside if") {
@@ -86,7 +86,7 @@ class IfTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("If with complex condition") {
@@ -105,7 +105,7 @@ class IfTests extends FunSuite with Matchers {
     val ifs = temputs.lookupFunction("main").all({ case if2 @ If2(_, _, _) => if2 })
     ifs.foreach(iff => iff.resultRegister.reference shouldEqual Coord(Share, Readonly, Str2()))
 
-    compile.evalForReferend(Vector()) shouldEqual VonStr("#")
+    compile.evalForKind(Vector()) shouldEqual VonStr("#")
   }
 
   test("Ret from inside if will destroy locals") {
@@ -194,7 +194,7 @@ class IfTests extends FunSuite with Matchers {
 
   test("If nevers") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/if/ifnevers.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Toast") {
@@ -213,7 +213,7 @@ class IfTests extends FunSuite with Matchers {
         |""".stripMargin)
 
     val main = compile.expectTemputs().lookupFunction("main")
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ImportTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ImportTests.scala
@@ -36,7 +36,7 @@ class ImportTests extends FunSuite with Matchers {
           .or(Tests.getPackageToResourceResolver),
         FullCompilationOptions())
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Tests non-imported module isn't brought in") {
@@ -66,7 +66,7 @@ class ImportTests extends FunSuite with Matchers {
 
     vassert(!compile.getParseds().getOrDie().moduleToPackagesToFilenameToContents.contains("moduleB"))
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Tests import with paackage") {
@@ -96,7 +96,7 @@ class ImportTests extends FunSuite with Matchers {
           .or(Tests.getPackageToResourceResolver),
         FullCompilationOptions())
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Tests import of directory with no vale files") {
@@ -121,7 +121,7 @@ class ImportTests extends FunSuite with Matchers {
           .or({ case PackageCoordinate("moduleB", List("bork")) => Some(Map()) }),
     FullCompilationOptions())
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/InferTemplateTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/InferTemplateTests.scala
@@ -25,7 +25,7 @@ class InferTemplateTests extends FunSuite with Matchers {
     moo.header.fullName.last.templateArgs shouldEqual
       List(CoordTemplata(Coord(Own,Readwrite,StructRef2(FullName2(PackageCoordinate.TEST_TLD, List(),CitizenName2("Muta",List()))))), CoordTemplata(Coord(Constraint,Readonly,StructRef2(FullName2(PackageCoordinate.TEST_TLD, List(),CitizenName2("Muta",List()))))))
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(10)
+    compile.evalForKind(Vector()) shouldEqual VonInt(10)
   }
   test("Test inferring a borrowed static sized array") {
     val compile = RunCompilation.test(
@@ -38,7 +38,7 @@ class InferTemplateTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(10)
+    compile.evalForKind(Vector()) shouldEqual VonInt(10)
   }
   test("Test inferring an owning static sized array") {
     val compile = RunCompilation.test(
@@ -51,6 +51,6 @@ class InferTemplateTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(10)
+    compile.evalForKind(Vector()) shouldEqual VonInt(10)
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/IntegrationTestsA.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/IntegrationTestsA.scala
@@ -5,13 +5,13 @@ import net.verdagon.vale.astronomer.{ICompileErrorA, ProgramA}
 import java.io.FileNotFoundException
 import net.verdagon.vale.templar._
 import net.verdagon.vale.{metal => m}
-import net.verdagon.vale.vivem.{ConstraintViolatedException, Heap, IntV, PrimitiveReferendV, ReferenceV, StructInstanceV, Vivem}
+import net.verdagon.vale.vivem.{ConstraintViolatedException, Heap, IntV, PrimitiveKindV, ReferenceV, StructInstanceV, Vivem}
 import net.verdagon.von.{IVonData, VonBool, VonFloat, VonInt, VonObject}
 import org.scalatest.{FunSuite, Matchers}
 import net.verdagon.vale.driver.{FullCompilation, FullCompilationOptions}
 import net.verdagon.vale.hammer.VonHammer
 import net.verdagon.vale.hinputs.Hinputs
-import net.verdagon.vale.metal.{FullNameH, IntH, ProgramH, ReadonlyH, ReadwriteH, YonderH}
+import net.verdagon.vale.metal.{FullNameH, IntH, ProgramH, PrototypeH, ReadonlyH, ReadwriteH, YonderH}
 import net.verdagon.vale.parser.{FailedParse, FileP}
 import net.verdagon.vale.scout.{ICompileErrorS, ProgramS}
 import net.verdagon.vale.templar.templata.Signature2
@@ -48,102 +48,102 @@ class RunCompilation(
   def expectTemputs(): Hinputs = fullCompilation.expectTemputs()
   def getHamuts(): ProgramH = fullCompilation.getHamuts()
 
-  def evalForReferend(heap: Heap, args: Vector[ReferenceV]): IVonData = {
+  def evalForKind(heap: Heap, args: Vector[ReferenceV]): IVonData = {
     Vivem.executeWithHeap(getHamuts(), heap, args, System.out, Vivem.emptyStdin, Vivem.regularStdout)
   }
   def run(heap: Heap, args: Vector[ReferenceV]): Unit = {
     Vivem.executeWithHeap(getHamuts(), heap, args, System.out, Vivem.emptyStdin, Vivem.regularStdout)
   }
-  def run(args: Vector[PrimitiveReferendV]): Unit = {
+  def run(args: Vector[PrimitiveKindV]): Unit = {
     Vivem.executeWithPrimitiveArgs(getHamuts(), args, System.out, Vivem.emptyStdin, Vivem.regularStdout)
   }
-  def evalForReferend(args: Vector[PrimitiveReferendV]): IVonData = {
+  def evalForKind(args: Vector[PrimitiveKindV]): IVonData = {
     Vivem.executeWithPrimitiveArgs(getHamuts(), args, System.out, Vivem.emptyStdin, Vivem.regularStdout)
   }
-  def evalForReferend(
-    args: Vector[PrimitiveReferendV],
+  def evalForKind(
+    args: Vector[PrimitiveKindV],
     stdin: List[String]):
   IVonData = {
     Vivem.executeWithPrimitiveArgs(getHamuts(), args, System.out, Vivem.stdinFromList(stdin), Vivem.regularStdout)
   }
-  def evalForStdout(args: Vector[PrimitiveReferendV]): String = {
+  def evalForStdout(args: Vector[PrimitiveKindV]): String = {
     val (stdoutStringBuilder, stdoutFunc) = Vivem.stdoutCollector()
     Vivem.executeWithPrimitiveArgs(getHamuts(), args, System.out, Vivem.emptyStdin, stdoutFunc)
     stdoutStringBuilder.mkString
   }
-  def evalForReferendAndStdout(args: Vector[PrimitiveReferendV]): (IVonData, String) = {
+  def evalForKindAndStdout(args: Vector[PrimitiveKindV]): (IVonData, String) = {
     val (stdoutStringBuilder, stdoutFunc) = Vivem.stdoutCollector()
-    val referend = Vivem.executeWithPrimitiveArgs(getHamuts(), args, System.out, Vivem.emptyStdin, stdoutFunc)
-    (referend, stdoutStringBuilder.mkString)
+    val kind = Vivem.executeWithPrimitiveArgs(getHamuts(), args, System.out, Vivem.emptyStdin, stdoutFunc)
+    (kind, stdoutStringBuilder.mkString)
   }
 }
 
 class IntegrationTestsA extends FunSuite with Matchers {
   test("Simple program returning an int") {
     val compile = RunCompilation.test("fn main() int export {3}")
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
   test("Hardcoding negative numbers") {
     val compile = RunCompilation.test("fn main() int export {-3}")
-    compile.evalForReferend(Vector()) shouldEqual VonInt(-3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(-3)
   }
 
   test("Taking an argument and returning it") {
     val compile = RunCompilation.test("fn main(a int) export int {a}")
-    compile.evalForReferend(Vector(IntV(5))) shouldEqual VonInt(5)
+    compile.evalForKind(Vector(IntV(5))) shouldEqual VonInt(5)
   }
 
   test("Tests adding two numbers") {
     val compile = RunCompilation.test("fn main() int export { +(2, 3) }")
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Tests adding two floats") {
     val compile = RunCompilation.test("fn main() float export { +(2.5, 3.5) }")
-    compile.evalForReferend(Vector()) shouldEqual VonFloat(6.0f)
+    compile.evalForKind(Vector()) shouldEqual VonFloat(6.0f)
   }
 
   test("Tests inline adding") {
     val compile = RunCompilation.test("fn main() int export { 2 + 3 }")
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Test constraint ref") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/constraintRef.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(8)
+    compile.evalForKind(Vector()) shouldEqual VonInt(8)
   }
 
   test("Tests inline adding more") {
     val compile = RunCompilation.test("fn main() int export { 2 + 3 + 4 + 5 + 6 }")
-    compile.evalForReferend(Vector()) shouldEqual VonInt(20)
+    compile.evalForKind(Vector()) shouldEqual VonInt(20)
   }
 
   test("Simple lambda") {
     val compile = RunCompilation.test("fn main() int export {{7}()}")
-    compile.evalForReferend(Vector()) shouldEqual VonInt(7)
+    compile.evalForKind(Vector()) shouldEqual VonInt(7)
   }
 
   test("Lambda with one magic arg") {
     val compile = RunCompilation.test("fn main() int export {{_}(3)}")
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
 
   // Test that the lambda's arg is the right type, and the name is right
   test("Lambda with a type specified param") {
     val compile = RunCompilation.test("fn main() int export {(a int){ +(a,a)}(3)}");
-    compile.evalForReferend(Vector()) shouldEqual VonInt(6)
+    compile.evalForKind(Vector()) shouldEqual VonInt(6)
   }
 
   test("Test overloads") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/functions/overloads.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(6)
+    compile.evalForKind(Vector()) shouldEqual VonInt(6)
   }
 
   test("Test block") {
     val compile = RunCompilation.test("fn main() int export {true; 200; = 300;}")
-    compile.evalForReferend(Vector()) shouldEqual VonInt(300)
+    compile.evalForKind(Vector()) shouldEqual VonInt(300)
   }
 
   test("Test templates") {
@@ -152,7 +152,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
         |fn ~<T>(a T, b T) T { a }
         |fn main() int export {true ~ false; 2 ~ 2; = 3 ~ 3;}
       """.stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
   test("Test mutating a local var") {
@@ -162,7 +162,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
 
   test("Test returning a local mutable var") {
     val compile = RunCompilation.test("fn main() int export {a! = 3; set a = 4; = a;}")
-    compile.evalForReferend(Vector()) shouldEqual VonInt(4)
+    compile.evalForKind(Vector()) shouldEqual VonInt(4)
   }
 
   test("Test taking a callable param") {
@@ -171,7 +171,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
         |fn do(callable) infer-ret {callable()}
         |fn main() int export {do({ 3 })}
       """.stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
   test("Stamps an interface template via a function parameter") {
@@ -199,7 +199,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
 
   test("Tests unstackifying a variable multiple times in a function") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/multiUnstackify.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Reads a struct member") {
@@ -208,7 +208,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
         |struct MyStruct { a int; }
         |fn main() int export { ms = MyStruct(7); = ms.a; }
       """.stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(7)
+    compile.evalForKind(Vector()) shouldEqual VonInt(7)
   }
 
   test("=== true") {
@@ -220,7 +220,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
         |  = &a === &a;
         |}
       """.stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonBool(true)
+    compile.evalForKind(Vector()) shouldEqual VonBool(true)
   }
 
   test("=== false") {
@@ -233,17 +233,17 @@ class IntegrationTestsA extends FunSuite with Matchers {
         |  = &a === &b;
         |}
       """.stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonBool(false)
+    compile.evalForKind(Vector()) shouldEqual VonBool(false)
   }
 
   test("set swapping locals") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/mutswaplocals.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("imm tuple access") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/tuples/immtupleaccess.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   // Known failure 2020-08-20
@@ -289,7 +289,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
         |
         |""".stripMargin)
     val hamuts = compile.getHamuts();
-    compile.evalForReferend(Vector()) shouldEqual VonInt(60)
+    compile.evalForKind(Vector()) shouldEqual VonInt(60)
   }
 
   test("Tests single expression and single statement functions' returns") {
@@ -310,7 +310,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
         |  MySome<int>(4).value
         |}
       """.stripMargin)
-    compile.evalForReferend(Vector())
+    compile.evalForKind(Vector())
   }
 
   test("Test int generic") {
@@ -327,7 +327,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
         |  = v.values.2;
         |}
       """.stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Tests upcasting from a struct to an interface") {
@@ -337,7 +337,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
 
   test("Tests upcasting from if") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/if/upcastif.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Tests from file") {
@@ -347,12 +347,12 @@ class IntegrationTestsA extends FunSuite with Matchers {
 
   test("Tests from subdir file") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/virtuals/round.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(8)
+    compile.evalForKind(Vector()) shouldEqual VonInt(8)
   }
 
   test("Tests calling a virtual function") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/virtuals/calling.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(7)
+    compile.evalForKind(Vector()) shouldEqual VonInt(7)
   }
 
   test("Tests making a variable with a pattern") {
@@ -373,31 +373,31 @@ class IntegrationTestsA extends FunSuite with Matchers {
         |	= doSomething(x);
         |}
       """.stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 
 
   test("Tests a linked list") {
     val compile = RunCompilation.test(
       Tests.loadExpected("programs/virtuals/ordinarylinkedlist.vale"))
-    compile.evalForReferend(Vector())
+    compile.evalForKind(Vector())
   }
 
   test("Tests a templated linked list") {
     val compile = RunCompilation.test(
         Tests.loadExpected("programs/genericvirtuals/templatedlinkedlist.vale"))
-    compile.evalForReferend(Vector())
+    compile.evalForKind(Vector())
   }
 
   test("Tests calling an abstract function") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/genericvirtuals/callingAbstract.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(4)
+    compile.evalForKind(Vector()) shouldEqual VonInt(4)
   }
 
   test("Template overrides are stamped") {
     val compile = RunCompilation.test(
         Tests.loadExpected("programs/genericvirtuals/templatedoption.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(1)
+    compile.evalForKind(Vector()) shouldEqual VonInt(1)
   }
 
   test("Tests a foreach for a linked list") {
@@ -415,12 +415,12 @@ class IntegrationTestsA extends FunSuite with Matchers {
   test("Stamp multiple ancestors") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/genericvirtuals/stampMultipleAncestors.vale"))
     val temputs = compile.expectTemputs()
-    compile.evalForReferend(Vector())
+    compile.evalForKind(Vector())
   }
 
   test("Tests recursion") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/functions/recursion.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(120)
+    compile.evalForKind(Vector()) shouldEqual VonInt(120)
   }
 
   test("Tests floats") {
@@ -433,13 +433,13 @@ class IntegrationTestsA extends FunSuite with Matchers {
         |  7
         |}
       """.stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(7)
+    compile.evalForKind(Vector()) shouldEqual VonInt(7)
   }
 
   test("getOr function") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/genericvirtuals/getOr.vale"))
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 
   test("Function return without ret upcasts") {
@@ -465,7 +465,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
       case StructToInterfaceUpcast2(_, _) =>
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
   test("Function return with ret upcasts") {
@@ -477,7 +477,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
       case StructToInterfaceUpcast2(_, _) =>
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
   test("Map function") {
@@ -485,7 +485,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
         Tests.loadExpected("programs/genericvirtuals/mapFunc.vale"))
     compile.expectTemputs()
 
-    compile.evalForReferend(Vector()) shouldEqual VonBool(true)
+    compile.evalForKind(Vector()) shouldEqual VonBool(true)
   }
 
   test("Test shaking") {
@@ -528,7 +528,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
 //        |""".stripMargin)
 //    val temputs = compile.getTemputs()
 //
-//    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+//    compile.evalForKind(Vector()) shouldEqual VonInt(42)
 //  }
 
   test("Test returning empty seq") {
@@ -558,13 +558,15 @@ class IntegrationTestsA extends FunSuite with Matchers {
     val packageH = compile.getHamuts().lookupPackage(PackageCoordinate("math", List()))
 
     // The extern we make should have the name we expect
-    vassert(packageH.externs.exists(_.fullName.readableName == "sqrt"))
+    vassertSome(packageH.externNameToFunction.get("sqrt")) match {
+      case PrototypeH(FullNameH("sqrt",_,PackageCoordinate("math",List()),_),_,_) =>
+    }
 
     // We also made an internal function that contains an extern call
     val externSqrt = packageH.lookupFunction("sqrt")
     vassert(externSqrt.isExtern)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(4)
+    compile.evalForKind(Vector()) shouldEqual VonInt(4)
   }
 
   test("Test narrowing between borrow and owning overloads") {
@@ -592,13 +594,13 @@ class IntegrationTestsA extends FunSuite with Matchers {
         |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Test catch deref after drop") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/invalidaccess.vale"))
     try {
-      compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+      compile.evalForKind(Vector()) shouldEqual VonInt(42)
       vfail()
     } catch {
       case ConstraintViolatedException(_) => // good!
@@ -626,7 +628,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
         |  ret bork(&Moo());
         |}
         |""".stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
 
@@ -650,17 +652,17 @@ class IntegrationTestsA extends FunSuite with Matchers {
         |  ret bork(Moo());
         |}
         |""".stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("exporting array") {
     val compilation = RunCompilation.test("export Array<mut, vary, int> as IntArray;")
     val hamuts = compilation.getHamuts()
     val testPackage = hamuts.lookupPackage(PackageCoordinate.TEST_TLD)
-    val fullNameH = testPackage.exportNameToFullName("IntArray")
+    val kindH = vassertSome(testPackage.exportNameToKind.get("IntArray"))
 
     val builtinPackage = hamuts.lookupPackage(PackageCoordinate.BUILTIN)
-    val rsa = vassertSome(builtinPackage.runtimeSizedArrays.find(_.name == fullNameH))
+    val rsa = vassertSome(builtinPackage.runtimeSizedArrays.find(_.kind == kindH))
     rsa.rawArray.elementType.kind shouldEqual IntH()
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/OptTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/OptTests.scala
@@ -17,7 +17,7 @@ class OptTests extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 
   test("Test empty and get for None") {
@@ -30,7 +30,7 @@ class OptTests extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(0)
+    compile.evalForKind(Vector()) shouldEqual VonInt(0)
   }
 
   test("Test empty and get for borrow") {
@@ -48,6 +48,6 @@ class OptTests extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/OwnershipTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/OwnershipTests.scala
@@ -63,7 +63,7 @@ class OwnershipTests extends FunSuite with Matchers {
         |  Muta() = m;
         |}
         |
-        |fn main() {
+        |fn main() export {
         |  Muta();
         |}
       """.stripMargin)
@@ -110,7 +110,7 @@ class OwnershipTests extends FunSuite with Matchers {
         |  Muta() = m;
         |}
         |
-        |fn main() {
+        |fn main() export {
         |  a = Muta();
         |}
       """.stripMargin)
@@ -138,7 +138,7 @@ class OwnershipTests extends FunSuite with Matchers {
         |fn moo(m ^Muta) {
         |}
         |
-        |fn main() {
+        |fn main() export {
         |  a = Muta();
         |  moo(a);
         |}
@@ -218,7 +218,7 @@ class OwnershipTests extends FunSuite with Matchers {
     val compile = RunCompilation.test(
       """
         |struct Muta { }
-        |fn main() {
+        |fn main() export {
         |  __checkvarrc(&Muta(), 1)
         |}
       """.stripMargin)
@@ -234,7 +234,7 @@ class OwnershipTests extends FunSuite with Matchers {
     val compile = RunCompilation.test(
       """
         |struct Muta { }
-        |fn main() {
+        |fn main() export {
         |  a = Muta();
         |  __checkvarrc(&a, 1);
         |}

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/OwnershipTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/OwnershipTests.scala
@@ -31,7 +31,7 @@ class OwnershipTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 
   test("Owning ref method call") {
@@ -48,7 +48,7 @@ class OwnershipTests extends FunSuite with Matchers {
       """.stripMargin)
 
     val main = compile.expectTemputs().lookupFunction("main")
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 
   test("When statement result is an owning ref, calls destructor") {
@@ -95,7 +95,7 @@ class OwnershipTests extends FunSuite with Matchers {
     val main = compile.expectTemputs().lookupFunction("main")
     main.only({ case FunctionCall2(functionName(CallTemplar.MUT_DESTRUCTOR_NAME), _) => })
 
-    compile.evalForReferendAndStdout(Vector()) shouldEqual (VonInt(10), "Destroying!\n")
+    compile.evalForKindAndStdout(Vector()) shouldEqual (VonInt(10), "Destroying!\n")
   }
 
   test("Calls destructor on local var") {
@@ -187,7 +187,7 @@ class OwnershipTests extends FunSuite with Matchers {
     main.only({ case FunctionCall2(functionName(CallTemplar.MUT_DESTRUCTOR_NAME), _) => })
     main.all({ case FunctionCall2(_, _) => }).size shouldEqual 2
 
-    compile.evalForReferendAndStdout(Vector()) shouldEqual (VonInt(10), "Destroying!\n")
+    compile.evalForKindAndStdout(Vector()) shouldEqual (VonInt(10), "Destroying!\n")
   }
 
   test("Gets from temporary struct a member's member") {
@@ -204,7 +204,7 @@ class OwnershipTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(10)
+    compile.evalForKind(Vector()) shouldEqual VonInt(10)
   }
 
   // test that when we create a block closure, we hoist to the beginning its constructor,
@@ -281,7 +281,7 @@ class OwnershipTests extends FunSuite with Matchers {
 //        |}
 //      """.stripMargin)
 //
-//    compile.evalForReferend(Vector()) shouldEqual VonInt(1)
+//    compile.evalForKind(Vector()) shouldEqual VonInt(1)
 //  }
 //
 //  test("Wingman catches hanging borrow") {
@@ -299,7 +299,7 @@ class OwnershipTests extends FunSuite with Matchers {
 //      """.stripMargin)
 //
 //    try {
-//      compile.evalForReferend(Vector())
+//      compile.evalForKind(Vector())
 //      fail();
 //    } catch {
 //      case VivemPanic("Dangling borrow") =>

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/PackTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/PackTests.scala
@@ -19,7 +19,7 @@ class PackTests extends FunSuite with Matchers {
     val main = temputs.lookupFunction("main")
     main.all({ case TupleE2(List(_, _, _), _, _) => }).size shouldEqual 1
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Nested seqs") {
@@ -42,7 +42,7 @@ class PackTests extends FunSuite with Matchers {
         _) =>
     }).size shouldEqual 1
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(6)
+    compile.evalForKind(Vector()) shouldEqual VonInt(6)
   }
 
   test("Nested tuples") {
@@ -58,7 +58,7 @@ class PackTests extends FunSuite with Matchers {
     val main = temputs.lookupFunction("main")
     main .all({ case TupleE2(List(_, TupleE2(List(_, _), _, _)), _, _) => }).size shouldEqual 1
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/PatternTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/PatternTests.scala
@@ -14,7 +14,7 @@ class PatternTests extends FunSuite with Matchers {
   //  compile.getTemputs()
   //  val main = temputs.lookupFunction("main")
   //  main.header.returnType shouldEqual Coord(Share, Readonly, Int2())
-  //  compile.evalForReferend(Vector()) shouldEqual VonInt(4)
+  //  compile.evalForKind(Vector()) shouldEqual VonInt(4)
   //}
 
   test("Test matching a multiple-member seq of immutables") {
@@ -23,7 +23,7 @@ class PatternTests extends FunSuite with Matchers {
     val temputs = compile.expectTemputs()
     val main = temputs.lookupFunction("main")
     main.header.returnType shouldEqual Coord(Share, Readonly, Int2())
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Test matching a multiple-member seq of mutables") {
@@ -36,7 +36,7 @@ class PatternTests extends FunSuite with Matchers {
     val temputs = compile.expectTemputs()
     val main = temputs.lookupFunction("main");
     main.header.returnType shouldEqual Coord(Share, Readonly, Int2())
-    compile.evalForReferend(Vector()) shouldEqual VonInt(8)
+    compile.evalForKind(Vector()) shouldEqual VonInt(8)
   }
 
   test("Test matching a multiple-member pack of immutable and own") {
@@ -48,7 +48,7 @@ class PatternTests extends FunSuite with Matchers {
       """.stripMargin)
     val temputs = compile.expectTemputs()
     temputs.functions.head.header.returnType == Coord(Share, Readonly, Int2())
-    compile.evalForReferend(Vector()) shouldEqual VonInt(8)
+    compile.evalForKind(Vector()) shouldEqual VonInt(8)
   }
 
   test("Test matching a multiple-member pack of immutable and borrow") {
@@ -64,7 +64,7 @@ class PatternTests extends FunSuite with Matchers {
       """.stripMargin)
     val temputs = compile.expectTemputs()
     temputs.functions.head.header.returnType == Coord(Share, Readonly, Int2())
-    compile.evalForReferend(Vector()) shouldEqual VonInt(8)
+    compile.evalForKind(Vector()) shouldEqual VonInt(8)
   }
 
   // Intentional failure 2021.02.28, we never implemented pattern destructuring
@@ -95,6 +95,6 @@ class PatternTests extends FunSuite with Matchers {
         |""".stripMargin)
     val temputs = compile.expectTemputs()
     temputs.functions.head.header.returnType == Coord(Share, Readonly, Int2())
-    compile.evalForReferend(Vector()) shouldEqual VonInt(8)
+    compile.evalForKind(Vector()) shouldEqual VonInt(8)
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/PatternTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/PatternTests.scala
@@ -73,7 +73,7 @@ class PatternTests extends FunSuite with Matchers {
     val compile = RunCompilation.test(
       """
         |
-        |struct Vec3 { x int; y int; z int; } fn main() { refuelB(Vec3(1, 2, 3), 2); }
+        |struct Vec3 { x int; y int; z int; } fn main() export { refuelB(Vec3(1, 2, 3), 2); }
         |// Using above Vec3
         |
         |// Without destructuring:

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/PrintTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/PrintTests.scala
@@ -7,7 +7,7 @@ class PrintTests extends FunSuite with Matchers {
     val compile = RunCompilation.test(
       """
         |import printutils.*;
-        |fn main() {
+        |fn main() export {
         |  println(6);
         |}
       """.stripMargin)
@@ -19,7 +19,7 @@ class PrintTests extends FunSuite with Matchers {
     val compile = RunCompilation.test(
       """
         |import printutils.*;
-        |fn main() {
+        |fn main() export {
         |  println(true);
         |}
       """.stripMargin)

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/PureFunctionTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/PureFunctionTests.scala
@@ -29,6 +29,6 @@ class PureFunctionTests extends FunSuite with Matchers {
           |  = pfunc(&s);
           |}
           |""".stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(10)
+    compile.evalForKind(Vector()) shouldEqual VonInt(10)
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ResultTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ResultTests.scala
@@ -18,7 +18,7 @@ class ResultTests extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Test is_err and borrow expect_err for Err") {
@@ -34,7 +34,7 @@ class ResultTests extends FunSuite with Matchers {
           |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonStr("file not found!")
+    compile.evalForKind(Vector()) shouldEqual VonStr("file not found!")
   }
 
   test("Test owning expect") {
@@ -49,7 +49,7 @@ class ResultTests extends FunSuite with Matchers {
         |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Test owning expect_err") {
@@ -64,7 +64,7 @@ class ResultTests extends FunSuite with Matchers {
         |}
         """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonStr("file not found!")
+    compile.evalForKind(Vector()) shouldEqual VonStr("file not found!")
   }
 
   test("Test expect() panics for Err") {
@@ -80,7 +80,7 @@ class ResultTests extends FunSuite with Matchers {
         """.stripMargin)
 
     try {
-      compile.evalForReferend(Vector())
+      compile.evalForKind(Vector())
       vfail()
     } catch {
       case PanicException() =>
@@ -100,7 +100,7 @@ class ResultTests extends FunSuite with Matchers {
         """.stripMargin)
 
     try {
-      compile.evalForReferend(Vector())
+      compile.evalForKind(Vector())
       vfail()
     } catch {
       case PanicException() =>

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/StringTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/StringTests.scala
@@ -16,7 +16,7 @@ class StringTests extends FunSuite with Matchers {
     val temputs = compile.expectTemputs()
     temputs.lookupFunction("main").only({ case StrLiteral2("sprogwoggle") => })
 
-    compile.evalForReferend(Vector()) shouldEqual VonStr("sprogwoggle")
+    compile.evalForKind(Vector()) shouldEqual VonStr("sprogwoggle")
   }
 
   test("String with escapes") {
@@ -30,7 +30,7 @@ class StringTests extends FunSuite with Matchers {
     val temputs = compile.expectTemputs()
     temputs.lookupFunction("main").only({ case StrLiteral2("sprog\nwoggle") => })
 
-    compile.evalForReferend(Vector()) shouldEqual VonStr("sprog\nwoggle")
+    compile.evalForKind(Vector()) shouldEqual VonStr("sprog\nwoggle")
   }
 
   test("String with hex escape") {
@@ -48,13 +48,13 @@ class StringTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonStr("sprog\u001bwoggle")
+    compile.evalForKind(Vector()) shouldEqual VonStr("sprog\u001bwoggle")
   }
 
   test("String length") {
     val compile = RunCompilation.test( Tests.loadExpected("programs/strings/strlen.vale"))
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(11)
+    compile.evalForKind(Vector()) shouldEqual VonInt(11)
   }
 
   test("String interpolate") {
@@ -63,7 +63,7 @@ class StringTests extends FunSuite with Matchers {
       "fn ns(i int) int { i }\n" +
       "fn main() str export { \"\"\"bl\"{ns(4)}rg\"\"\" }")
 
-    compile.evalForReferend(Vector()) shouldEqual VonStr("bl\"4rg")
+    compile.evalForKind(Vector()) shouldEqual VonStr("bl\"4rg")
   }
 
   test("Slice a slice") {
@@ -116,6 +116,6 @@ class StringTests extends FunSuite with Matchers {
           |}
           |""".stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/StringTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/StringTests.scala
@@ -8,7 +8,7 @@ class StringTests extends FunSuite with Matchers {
   test("Simple string") {
     val compile = RunCompilation.test(
       """
-        |fn main() str {
+        |fn main() str export {
         |  "sprogwoggle"
         |}
       """.stripMargin)
@@ -22,7 +22,7 @@ class StringTests extends FunSuite with Matchers {
   test("String with escapes") {
     val compile = RunCompilation.test(
       """
-        |fn main() str {
+        |fn main() str export {
         |  "sprog\nwoggle"
         |}
         |""".stripMargin)
@@ -36,7 +36,7 @@ class StringTests extends FunSuite with Matchers {
   test("String with hex escape") {
     val compile = RunCompilation.test(
       """
-        |fn main() str {
+        |fn main() str export {
         |  "sprog\u001bwoggle"
         |}
         |""".stripMargin)
@@ -61,7 +61,7 @@ class StringTests extends FunSuite with Matchers {
     val compile = RunCompilation.test(
       "fn +(s str, i int) str { s + str(i) }\n" +
       "fn ns(i int) int { i }\n" +
-      "fn main() str { \"\"\"bl\"{ns(4)}rg\"\"\" }")
+      "fn main() str export { \"\"\"bl\"{ns(4)}rg\"\"\" }")
 
     compile.evalForReferend(Vector()) shouldEqual VonStr("bl\"4rg")
   }
@@ -111,7 +111,7 @@ class StringTests extends FunSuite with Matchers {
           |  = newStrSlice(s.string, newGlyphBeginOffset, newGlyphEndOffset);
           |}
           |
-          |fn main() int {
+          |fn main() int export {
           |  "hello".slice().slice(1, 4).len()
           |}
           |""".stripMargin)

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/StructTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/StructTests.scala
@@ -9,7 +9,7 @@ class StructTests extends FunSuite with Matchers {
     val compile = RunCompilation.test(
       """
         |struct Marine {}
-        |fn main() {
+        |fn main() export {
         |  Marine();
         |}
       """.stripMargin)
@@ -27,7 +27,7 @@ class StructTests extends FunSuite with Matchers {
     val compile = RunCompilation.test(
       """
         |struct Marine { hp int; }
-        |fn main() {
+        |fn main() export {
         |  Marine(9);
         |}
       """.stripMargin)
@@ -96,7 +96,7 @@ class StructTests extends FunSuite with Matchers {
         |  println("Destroying marine!");
         |  Marine(weapon) = marine;
         |}
-        |fn main() {
+        |fn main() export {
         |  Marine(Weapon());
         |}
       """.stripMargin)
@@ -132,7 +132,7 @@ class StructTests extends FunSuite with Matchers {
         |  set marine.weapon.owner = None<&Marine>();
         |  Marine(weapon) = marine;
         |}
-        |fn main() {
+        |fn main() export {
         |  m = Marine(Weapon("Sword", None<&Marine>()));
         |  set m.weapon.owner = Some(&m);
         |  set m.weapon = Weapon("Spear", Some(&m));

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/StructTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/StructTests.scala
@@ -20,7 +20,7 @@ class StructTests extends FunSuite with Matchers {
   test("Constructor with this") {
     val compile = RunCompilation.test( Tests.loadExpected("programs/structs/constructor.vale"))
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(10)
+    compile.evalForKind(Vector()) shouldEqual VonInt(10)
   }
 
   test("Make struct") {
@@ -37,12 +37,12 @@ class StructTests extends FunSuite with Matchers {
 
   test("Make struct and get member") {
     val compile = RunCompilation.test( Tests.loadExpected("programs/structs/getMember.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 
   test("Mutate struct") {
     val compile = RunCompilation.test( Tests.loadExpected("programs/structs/mutate.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(4)
+    compile.evalForKind(Vector()) shouldEqual VonInt(4)
   }
 
   test("Normal destructure") {
@@ -59,7 +59,7 @@ class StructTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(7)
+    compile.evalForKind(Vector()) shouldEqual VonInt(7)
   }
 
   test("Sugar destructure") {
@@ -76,7 +76,7 @@ class StructTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 
   test("Destroy members at right times") {
@@ -172,7 +172,7 @@ class StructTests extends FunSuite with Matchers {
       """.stripMargin)
 
     try {
-      compile.evalForReferend(Vector())
+      compile.evalForKind(Vector())
       vfail() // It should panic instead
     } catch {
       case PanicException() =>
@@ -189,6 +189,6 @@ class StructTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(6)
+    compile.evalForKind(Vector()) shouldEqual VonInt(6)
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/TupleTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/TupleTests.scala
@@ -40,7 +40,7 @@ class TupleTests extends FunSuite with Matchers {
       """
         |fn moo(a [int, int]) int { a.1 }
         |
-        |fn main() int {
+        |fn main() int export {
         |  moo([3, 4])
         |}
         |""".stripMargin)

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/TupleTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/TupleTests.scala
@@ -15,23 +15,23 @@ class TupleTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Simple tuple with one int") {
     val compile = RunCompilation.test( "fn main() int export { [9].0 }")
 
     val temputs = compile.expectTemputs()
-    temputs.lookupFunction("main").header.returnType.referend shouldEqual Int2()
+    temputs.lookupFunction("main").header.returnType.kind shouldEqual Int2()
     // Funny story, theres no such thing as a one element tuple! It becomes a one element array.
     temputs.lookupFunction("main").only({ case TupleE2(_, _, _) => })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 
   test("Tuple with two things") {
     val compile = RunCompilation.test( "fn main() bool export { [9, true].1 }")
-    compile.evalForReferend(Vector()) shouldEqual VonBool(true)
+    compile.evalForKind(Vector()) shouldEqual VonBool(true)
   }
 
 
@@ -44,7 +44,7 @@ class TupleTests extends FunSuite with Matchers {
         |  moo([3, 4])
         |}
         |""".stripMargin)
-    compile.evalForReferend(Vector()) shouldEqual VonInt(4)
+    compile.evalForKind(Vector()) shouldEqual VonInt(4)
   }
 
   // todo: indexing into it with a variable, to get a union type

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/VirtualTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/VirtualTests.scala
@@ -141,31 +141,31 @@ class VirtualTests extends FunSuite with Matchers {
           |}
         """.stripMargin)
     val temputs = compile.getHamuts()
-    compile.evalForReferend(Vector()) shouldEqual VonInt(3)
+    compile.evalForKind(Vector()) shouldEqual VonInt(3)
   }
 
   test("Successful constraint downcast with as") {
     val compile = RunCompilation.test(
       Tests.loadExpected("programs/downcast/downcastConstraintSuccessful.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Failed constraint downcast with as") {
     val compile = RunCompilation.test(
       Tests.loadExpected("programs/downcast/downcastConstraintFailed.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Successful owning downcast with as") {
     val compile = RunCompilation.test(
       Tests.loadExpected("programs/downcast/downcastOwningSuccessful.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Failed owning downcast with as") {
     val compile = RunCompilation.test(
       Tests.loadExpected("programs/downcast/downcastOwningFailed.vale"))
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/WeakTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/WeakTests.scala
@@ -24,14 +24,14 @@ class WeakTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(7)
+    compile.evalForKind(Vector()) shouldEqual VonInt(7)
   }
 
   test("Destroy own then locking gives none, with struct") {
     val compile = RunCompilation.test(
         Tests.loadExpected("programs/weaks/dropThenLockStruct.vale"))
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Drop while locked, with struct") {
@@ -39,7 +39,7 @@ class WeakTests extends FunSuite with Matchers {
         Tests.loadExpected("programs/weaks/dropWhileLockedStruct.vale"))
 
     try {
-      compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+      compile.evalForKind(Vector()) shouldEqual VonInt(42)
       vfail()
     } catch {
       case ConstraintViolatedException(_) =>
@@ -55,7 +55,7 @@ class WeakTests extends FunSuite with Matchers {
 
     vassert(main.body.all({ case SoftLoad2(_, Weak, Readonly) => true }).size >= 1)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(7)
+    compile.evalForKind(Vector()) shouldEqual VonInt(7)
   }
 
   test("Make and lock weak ref from borrow then destroy own, with struct") {
@@ -66,7 +66,7 @@ class WeakTests extends FunSuite with Matchers {
 
     vassert(main.body.all({ case SoftLoad2(_, Weak, Readonly) => true }).size >= 1)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(7)
+    compile.evalForKind(Vector()) shouldEqual VonInt(7)
   }
 
   test("Make weak ref from temporary") {
@@ -79,7 +79,7 @@ class WeakTests extends FunSuite with Matchers {
 
     val main = compile.expectTemputs().lookupFunction("main")
     main.body.only({ case WeakAlias2(_) => })
-    compile.evalForReferend(Vector()) shouldEqual VonInt(7)
+    compile.evalForKind(Vector()) shouldEqual VonInt(7)
   }
 
   test("Cant make weak ref to non-weakable") {
@@ -153,14 +153,14 @@ class WeakTests extends FunSuite with Matchers {
       }
     })
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(7)
+    compile.evalForKind(Vector()) shouldEqual VonInt(7)
   }
 
   test("Destroy own then locking gives none, with interface") {
     val compile = RunCompilation.test(
         Tests.loadExpected("programs/weaks/dropThenLockInterface.vale"))
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Drop while locked, with interface") {
@@ -168,7 +168,7 @@ class WeakTests extends FunSuite with Matchers {
         Tests.loadExpected("programs/weaks/dropWhileLockedInterface.vale"))
 
     try {
-      compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+      compile.evalForKind(Vector()) shouldEqual VonInt(42)
       vfail()
     } catch {
       case ConstraintViolatedException(_) =>
@@ -184,7 +184,7 @@ class WeakTests extends FunSuite with Matchers {
 
     vassert(main.body.all({ case SoftLoad2(_, Weak, Readonly) => true }).size >= 1)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(7)
+    compile.evalForKind(Vector()) shouldEqual VonInt(7)
   }
 
   test("Make and lock weak ref from borrow then destroy own, with interface") {
@@ -195,7 +195,7 @@ class WeakTests extends FunSuite with Matchers {
 
     vassert(main.body.all({ case SoftLoad2(_, Weak, Readonly) => true }).size >= 1)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(7)
+    compile.evalForKind(Vector()) shouldEqual VonInt(7)
   }
 
   test("Call weak-self method, after drop") {
@@ -208,7 +208,7 @@ class WeakTests extends FunSuite with Matchers {
 
     val hamuts = compile.getHamuts()
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(0)
+    compile.evalForKind(Vector()) shouldEqual VonInt(0)
   }
 
   test("Call weak-self method, while alive") {
@@ -221,7 +221,7 @@ class WeakTests extends FunSuite with Matchers {
 
     val hamuts = compile.getHamuts()
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
   test("Weak yonder member") {
@@ -253,7 +253,7 @@ class WeakTests extends FunSuite with Matchers {
 
     val hamuts = compile.getHamuts()
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(42)
+    compile.evalForKind(Vector()) shouldEqual VonInt(42)
   }
 
 

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/WhileTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/WhileTests.scala
@@ -13,7 +13,7 @@ class WhileTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(5)
+    compile.evalForKind(Vector()) shouldEqual VonInt(5)
   }
 
   test("Test a for-ish while loop") {
@@ -28,7 +28,7 @@ class WhileTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(4)
+    compile.evalForKind(Vector()) shouldEqual VonInt(4)
   }
 
   test("Tests a while loop with a complex condition") {
@@ -44,7 +44,7 @@ class WhileTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector(), List("A", "B", "c")) shouldEqual VonInt(99)
+    compile.evalForKind(Vector(), List("A", "B", "c")) shouldEqual VonInt(99)
   }
 
   test("Tests a while loop with a != in it") {
@@ -63,7 +63,7 @@ class WhileTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector(), List("A", "B", "c")) shouldEqual VonInt(99)
+    compile.evalForKind(Vector(), List("A", "B", "c")) shouldEqual VonInt(99)
   }
 
   test("Return from infinite while loop") {
@@ -77,7 +77,7 @@ class WhileTests extends FunSuite with Matchers {
         |}
       """.stripMargin)
 
-    compile.evalForReferend(Vector()) shouldEqual VonInt(9)
+    compile.evalForKind(Vector()) shouldEqual VonInt(9)
   }
 //
 //  test("Tests a while loop with a move in it") {
@@ -96,6 +96,6 @@ class WhileTests extends FunSuite with Matchers {
 //
 //    // should fail
 //
-//    compile.evalForReferend(Vector()) shouldEqual VonInt(4)
+//    compile.evalForKind(Vector()) shouldEqual VonInt(4)
 //  }
 }

--- a/Valestrom/Metal/src/net/verdagon/vale/metal/types.scala
+++ b/Valestrom/Metal/src/net/verdagon/vale/metal/types.scala
@@ -4,22 +4,22 @@ import net.verdagon.vale.{FileCoordinate, PackageCoordinate, vassert, vfail}
 
 // Represents a reference type.
 // A reference contains these things:
-// - The referend; the thing that this reference points at.
-// - The ownership; this reference's relationship to the referend. This can be:
-//   - Share, which means the references all share ownership of the referend. This
-//     means that the referend will only be deallocated once all references to it are
-//     gone. Share references can only point at immutable referends, and immutable
-//     referends can *only* be pointed at by share references.
+// - The kind; the thing that this reference points at.
+// - The ownership; this reference's relationship to the kind. This can be:
+//   - Share, which means the references all share ownership of the kind. This
+//     means that the kind will only be deallocated once all references to it are
+//     gone. Share references can only point at immutable kinds, and immutable
+//     kinds can *only* be pointed at by share references.
 //   - Owning, which means this reference owns the object, and when this reference
 //     disappears (without being moved), the object should disappear (this is taken
-//     care of by the typing stage). Owning refs can only point at mutable referends.
-//   - Constraint, which means this reference doesn't own the referend. The referend
+//     care of by the typing stage). Owning refs can only point at mutable kinds.
+//   - Constraint, which means this reference doesn't own the kind. The kind
 //     is guaranteed not to die while this constraint ref is active (indeed if it did
-//     the program would panic). Constraint refs can only point at mutable referends.
+//     the program would panic). Constraint refs can only point at mutable kinds.
 //   - Raw, which is a weird ownership and should go away. We point at Void with this.
 //     TODO: Get rid of raw.
 //   - (in the future) Weak, which is a reference that will null itself out when the
-//     referend is destroyed. Weak refs can only point at mutable referends.
+//     kind is destroyed. Weak refs can only point at mutable kinds.
 // - Permission, how one can modify the object through this reference.
 //   - Readonly, we cannot modify the object through this reference.
 //   - Readwrite, we can.
@@ -27,7 +27,7 @@ import net.verdagon.vale.{FileCoordinate, PackageCoordinate, vassert, vfail}
 //   isn't actually a pointer, it's just the value itself, like C's Car vs Car*.
 // In previous stages, this is referred to as a "coord", because these four things can be
 // thought of as dimensions of a coordinate.
-case class ReferenceH[+T <: ReferendH](
+case class ReferenceH[+T <: KindH](
     ownership: OwnershipH, location: LocationH, permission: PermissionH, kind: T) {
   (ownership, location) match {
     case (OwnH, YonderH) =>
@@ -96,43 +96,43 @@ case class ReferenceH[+T <: ReferendH](
 }
 
 // A value, a thing that can be pointed at. See ReferenceH for more information.
-sealed trait ReferendH {
+sealed trait KindH {
   def packageCoord: PackageCoordinate
 }
 
-case class IntH() extends ReferendH {
+case class IntH() extends KindH {
   override def packageCoord: PackageCoordinate = PackageCoordinate.BUILTIN
 }
-case class BoolH() extends ReferendH {
+case class BoolH() extends KindH {
   override def packageCoord: PackageCoordinate = PackageCoordinate.BUILTIN
 }
-case class StrH() extends ReferendH {
+case class StrH() extends KindH {
   override def packageCoord: PackageCoordinate = PackageCoordinate.BUILTIN
 }
-case class FloatH() extends ReferendH {
+case class FloatH() extends KindH {
   override def packageCoord: PackageCoordinate = PackageCoordinate.BUILTIN
 }
 // A primitive which can never be instantiated. If something returns this, it
 // means that it will never actually return. For example, the return type of
 // __panic() is a NeverH.
-// TODO: This feels weird being a referend in metal. Figure out a way to not
-// have this? Perhaps replace all referends with Optional[Optional[ReferendH]],
+// TODO: This feels weird being a kind in metal. Figure out a way to not
+// have this? Perhaps replace all kinds with Optional[Optional[KindH]],
 // where None is never, Some(None) is Void, and Some(Some(_)) is a normal thing.
-case class NeverH() extends ReferendH {
+case class NeverH() extends KindH {
   override def packageCoord: PackageCoordinate = PackageCoordinate.BUILTIN
 }
 
 case class InterfaceRefH(
   // Unique identifier for the interface.
   fullName: FullNameH
-) extends ReferendH {
+) extends KindH {
   override def packageCoord: PackageCoordinate = fullName.packageCoordinate
 }
 
 case class StructRefH(
   // Unique identifier for the interface.
   fullName: FullNameH
-) extends ReferendH {
+) extends KindH {
   override def packageCoord: PackageCoordinate = fullName.packageCoordinate
 }
 
@@ -141,7 +141,7 @@ case class StructRefH(
 case class StaticSizedArrayTH(
   // This is useful for naming the Midas struct that wraps this array and its ref count.
   name: FullNameH,
-) extends ReferendH {
+) extends KindH {
   override def packageCoord: PackageCoordinate = name.packageCoordinate
 }
 
@@ -155,13 +155,13 @@ case class StaticSizedArrayDefinitionTH(
   // The underlying array.
   rawArray: RawArrayTH
 ) {
-  def referend = StaticSizedArrayTH(name)
+  def kind = StaticSizedArrayTH(name)
 }
 
 case class RuntimeSizedArrayTH(
   // This is useful for naming the Midas struct that wraps this array and its ref count.
   name: FullNameH,
-) extends ReferendH {
+) extends KindH {
   override def packageCoord: PackageCoordinate = name.packageCoordinate
 }
 
@@ -171,15 +171,15 @@ case class RuntimeSizedArrayDefinitionTH(
   // The underlying array.
   rawArray: RawArrayTH
 ) {
-  def referend = RuntimeSizedArrayTH(name)
+  def kind = RuntimeSizedArrayTH(name)
 }
 
-// This is not a referend, but instead has the common fields of RuntimeSizedArrayTH/StaticSizedArrayTH,
+// This is not a kind, but instead has the common fields of RuntimeSizedArrayTH/StaticSizedArrayTH,
 // and lets us handle their code similarly.
 case class RawArrayTH(
   mutability: Mutability,
   variability: Variability,
-  elementType: ReferenceH[ReferendH])
+  elementType: ReferenceH[KindH])
 
 // Place in the original source code that something came from. Useful for uniquely
 // identifying templates.
@@ -187,7 +187,7 @@ case class CodeLocation(
   file: FileCoordinate,
   offset: Int)
 
-// Ownership is the way a reference relates to the referend's lifetime, see
+// Ownership is the way a reference relates to the kind's lifetime, see
 // ReferenceH for explanation.
 sealed trait OwnershipH
 case object OwnH extends OwnershipH
@@ -201,16 +201,16 @@ sealed trait PermissionH
 case object ReadonlyH extends PermissionH
 case object ReadwriteH extends PermissionH
 
-//// Permission says whether a reference can modify the referend it's pointing at.
+//// Permission says whether a reference can modify the kind it's pointing at.
 //// See ReferenceH for explanation.
 //sealed trait Permission
 //case object Readonly extends Permission
 //case object Readwrite extends Permission
 //case object ExclusiveReadwrite extends Permission
 
-// Location says whether a reference contains the referend's location (yonder) or
-// contains the referend itself (inline).
-// Yes, it's weird to consider a reference containing a referend, but it makes a
+// Location says whether a reference contains the kind's location (yonder) or
+// contains the kind itself (inline).
+// Yes, it's weird to consider a reference containing a kind, but it makes a
 // lot of things simpler for the language.
 // Examples (with C++ translations):
 //   This will create a variable `car` that lives on the stack ("inline"):
@@ -230,9 +230,9 @@ case object ReadwriteH extends PermissionH
 // Note that the compiler will often automatically add an `inl` onto whatever
 // local variables it can, to speed up the program.
 sealed trait LocationH
-// Means that the referend will be in the containing stack frame or struct.
+// Means that the kind will be in the containing stack frame or struct.
 case object InlineH extends LocationH
-// Means that the referend will be allocated separately, in the heap.
+// Means that the kind will be allocated separately, in the heap.
 case object YonderH extends LocationH
 
 // Used to say whether an object can be modified or not.
@@ -272,8 +272,8 @@ case object Mutable extends Mutability
 //       x->numWheels = 6;
 // In other words, variability affects whether the variable (or member) can be
 // changed to point at something different, but it doesn't affect whether we can
-// change anything inside the referend (this reference's permission and the
-// referend struct's member's variability affect that).
+// change anything inside the kind (this reference's permission and the
+// kind struct's member's variability affect that).
 sealed trait Variability
 case object Final extends Variability
 case object Varying extends Variability

--- a/Valestrom/Parser/test/net/verdagon/vale/parser/LoadTests.scala
+++ b/Valestrom/Parser/test/net/verdagon/vale/parser/LoadTests.scala
@@ -35,7 +35,7 @@ class LoadTests extends FunSuite with Matchers with Collector {
 
   // Known failure 2020-11-16
   test("round trip") {
-    val originalFile = Parser.runParser("""fn main() { 42 }""").get()
+    val originalFile = Parser.runParser("""fn main() export { 42 }""").get()
     val von = ParserVonifier.vonifyFile(originalFile)
     val json = new VonPrinter(JsonSyntax, 120).print(von)
     val loadedFile = ParsedLoader.load(json).get()

--- a/Valestrom/Scout/test/net/verdagon/vale/scout/ScoutTests.scala
+++ b/Valestrom/Scout/test/net/verdagon/vale/scout/ScoutTests.scala
@@ -496,7 +496,7 @@ class ScoutTests extends FunSuite with Matchers {
   test("Reports when we forget set") {
     val err = compileForError(
       """
-        |fn main() {
+        |fn main() export {
         |  x = "world!";
         |  x = "changed";
         |}

--- a/Valestrom/Scout/test/net/verdagon/vale/scout/ScoutVariableTests.scala
+++ b/Valestrom/Scout/test/net/verdagon/vale/scout/ScoutVariableTests.scala
@@ -44,7 +44,7 @@ class ScoutVariableTests extends FunSuite with Matchers {
   }
 
   test("Reports defining same-name variable") {
-    compileProgramForError("fn main() { x = 4; x = 5; }") match {
+    compileProgramForError("fn main() export { x = 4; x = 5; }") match {
       case VariableNameAlreadyExists(_, CodeVarNameS("x")) =>
     }
   }

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/ArrayTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/ArrayTemplar.scala
@@ -125,7 +125,7 @@ class ArrayTemplar(
   (StaticSizedArrayT2) = {
 //    val tupleMutability =
 //      StructTemplarCore.getCompoundTypeMutability(temputs, List(type2))
-//    val tupleMutability = Templar.getMutability(temputs, type2.referend)
+//    val tupleMutability = Templar.getMutability(temputs, type2.kind)
     val rawArrayT2 = RawArrayT2(type2, mutability, variability)
 
     temputs.getStaticSizedArrayType(size, rawArrayT2) match {

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/ConvertHelper.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/ConvertHelper.scala
@@ -54,14 +54,14 @@ class ConvertHelper(
       return sourceExpr
     }
 
-    if (sourceExpr.resultRegister.reference.referend == Never2()) {
+    if (sourceExpr.resultRegister.reference.kind == Never2()) {
       return sourceExpr
     }
 
     val Coord(targetOwnership, targetPermission, targetType) = targetPointerType;
     val Coord(sourceOwnership, sourcePermission, sourceType) = sourcePointerType;
 
-    vcurious(targetPointerType.referend != Never2())
+    vcurious(targetPointerType.kind != Never2())
 
     // We make the hammer aware of nevers.
 //    if (sourceType == Never2()) {

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/EdgeTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/EdgeTemplar.scala
@@ -83,7 +83,7 @@ object EdgeTemplar {
               if (index != virtualIndex) {
                 paramType
               } else {
-                paramType.copy(referend = superInterface)
+                paramType.copy(kind = superInterface)
               }
             })
 

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/OverloadTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/OverloadTemplar.scala
@@ -369,7 +369,7 @@ class OverloadTemplar(
   private def getParamEnvironments(temputs: Temputs, paramFilters: List[ParamFilter]):
   List[IEnvironment] = {
     paramFilters.flatMap({ case ParamFilter(tyype, virtuality) =>
-      (tyype.referend match {
+      (tyype.kind match {
         case sr @ StructRef2(_) => List(temputs.getEnvForStructRef(sr))
         case ir @ InterfaceRef2(_) => List(temputs.getEnvForInterfaceRef(ir))
         case _ => List()

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/Templar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/Templar.scala
@@ -108,7 +108,7 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
             FunctionHeader2(namedEnv.fullName, List(), paramCoords, maybeReturnType2.get, maybeOriginFunction1)
           temputs.declareFunctionReturnType(header.toSignature, header.returnType)
 
-          val sourceKind = vassertSome(paramCoords.headOption).tyype.referend
+          val sourceKind = vassertSome(paramCoords.headOption).tyype.kind
           val KindTemplata(targetKind) = vassertSome(namedEnv.fullName.last.templateArgs.headOption)
 
           val sourceCitizen =
@@ -133,8 +133,8 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
 
 
           val incomingCoord = paramCoords(0).tyype
-          val incomingSubkind = incomingCoord.referend
-          val targetCoord = incomingCoord.copy(referend = targetKind)
+          val incomingSubkind = incomingCoord.kind
+          val targetCoord = incomingCoord.copy(kind = targetKind)
           val (resultCoord, okConstructor, errConstructor) =
             expressionTemplar.getResult(temputs, namedEnv, callRange, targetCoord, incomingCoord)
           val asSubtypeExpr: ReferenceExpression2 =
@@ -604,12 +604,12 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
           val typeRuneT = NameTranslator.translateRune(typeRuneA)
           val templataByRune =
             inferTemplar.inferOrdinaryRules(env11, temputs, rules, typeByRune, Set(typeRuneA))
-          val referend =
+          val kind =
             templataByRune.get(typeRuneT) match {
-              case Some(KindTemplata(referend)) => referend
+              case Some(KindTemplata(kind)) => kind
               case _ => vfail()
             }
-          temputs.addExport(referend, range.file.packageCoordinate, exportedName)
+          temputs.addKindExport(kind, range.file.packageCoordinate, exportedName)
         })
 
         profiler.newProfile("StampOverridesUntilSettledProbe", "", () => {
@@ -718,11 +718,13 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
             reachableStructs.toList,
             Program2.emptyTupleStructRef,
             reachableFunctions.toList,
-            temputs.getExports,
             reachableDestructors.toMap,
-            temputs.getExternPrototypes,
             edgeBlueprintsByInterface,
-            edges)
+            edges,
+            temputs.getKindExports,
+            temputs.getFunctionExports,
+            temputs.getKindExterns,
+            temputs.getFunctionExterns)
 
         Ok(hinputs)
       })

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/Templar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/Templar.scala
@@ -496,7 +496,7 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
   def evaluate(packageToProgramA: PackageCoordinateMap[ProgramA]): Result[Hinputs, ICompileErrorT] = {
     try {
       profiler.newProfile("Templar.evaluate", "", () => {
-        val programsA = packageToProgramA.moduleToPackagesToFilenameToContents.values.flatMap(_.values)
+        val programsA = packageToProgramA.moduleToPackagesToContents.values.flatMap(_.values)
 
         val structsA = programsA.flatMap(_.structs)
         val interfacesA = programsA.flatMap(_.interfaces)

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/TemplataTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/TemplataTemplar.scala
@@ -74,12 +74,12 @@ class TemplataTemplar(
     makeInner().evaluateTemplexes(env, temputs, templexes)
   }
 
-  def pointifyReferend(
+  def pointifyKind(
     temputs: Temputs,
-    referend: Kind,
+    kind: Kind,
     ownershipIfMutable: Ownership):
   Coord = {
-    makeInner().pointifyReferend(temputs, referend, ownershipIfMutable)
+    makeInner().pointifyKind(temputs, kind, ownershipIfMutable)
   }
 
   def isTypeConvertible(
@@ -143,7 +143,7 @@ class TemplataTemplar(
 //      case Some(osb) => {
 //        val structRef =
 //          StructTemplar.getStructRef(env.globalEnv, temputs, osb)
-//        return (Some(ReferendTemplata(structRef)))
+//        return (Some(KindTemplata(structRef)))
 //      }
 //      case None =>
 //    }
@@ -151,7 +151,7 @@ class TemplataTemplar(
 //      case Some(oib) => {
 //        val structRef =
 //          StructTemplar.getInterfaceRef(env.globalEnv, temputs, oib)
-//        return (Some(ReferendTemplata(structRef)))
+//        return (Some(KindTemplata(structRef)))
 //      }
 //      case None =>
 //    }
@@ -209,15 +209,15 @@ class TemplataTemplar(
         //val elementCoord =
         //  templateArgTemplatas match {
         //    case List(ReferenceTemplata(ref)) => ref
-        //    // todo: coerce referend into reference here... or somehow reuse all the machinery we have for
+        //    // todo: coerce kind into reference here... or somehow reuse all the machinery we have for
         //    // regular templates?
         //  }
-        //val elementMutability = Templar.getMutability(state, elementCoord.referend)
+        //val elementMutability = Templar.getMutability(state, elementCoord.kind)
         //if (arrayMutability == Immutable && elementMutability == Mutable) {
         //  throw new Exception("Can't have an immutable array of mutables")
         //}
         //val arrayType = RuntimeSizedArrayT2(RawArrayT2(elementCoord, arrayMutability))
-        //(state, ReferendTemplata(arrayType))
+        //(state, KindTemplata(arrayType))
 
         override def getAncestorInterfaceDistance(
           temputs: Temputs,

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/Temputs.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/Temputs.scala
@@ -24,7 +24,7 @@ case class Temputs() {
   private val envByFunctionSignature: mutable.HashMap[Signature2, FunctionEnvironment] = mutable.HashMap()
 
   // Prototypes for extern functions
-  private val moduleNameToExternNameToExtern: mutable.HashMap[String, mutable.HashMap[String, (PackageCoordinate, Prototype2)]] = mutable.HashMap()
+  private val packageToExternNameToExtern: mutable.HashMap[PackageCoordinate, mutable.HashMap[String, Prototype2]] = mutable.HashMap()
 
   // One must fill this in when putting things into declaredStructs/Interfaces.
   private val mutabilitiesByCitizenRef: mutable.HashMap[CitizenRef2, Mutability] = mutable.HashMap()
@@ -197,15 +197,15 @@ case class Temputs() {
       prototype2.fullName.last match {
         case ExternFunctionName2(externName, _) => externName
       }
-    moduleNameToExternNameToExtern.get(prototype2.fullName.packageCoord.module) match {
+    packageToExternNameToExtern.get(prototype2.fullName.packageCoord) match {
       case None => {
-        moduleNameToExternNameToExtern.put(
-          prototype2.fullName.packageCoord.module,
-          mutable.HashMap(externName -> (prototype2.fullName.packageCoord, prototype2)))
+        packageToExternNameToExtern.put(
+          prototype2.fullName.packageCoord,
+          mutable.HashMap(externName -> prototype2))
       }
       case Some(externNameToExtern) => {
         externNameToExtern.get(externName) match {
-          case None => externNameToExtern.put(externName, (prototype2.fullName.packageCoord, prototype2))
+          case None => externNameToExtern.put(externName, prototype2)
           case Some(_) => vfail("Extern already exists: " + externName)
         }
       }
@@ -338,8 +338,8 @@ case class Temputs() {
   def getRuntimeSizedArray(array: RawArrayT2): Option[RuntimeSizedArrayT2] = {
     runtimeSizedArrayTypes.get(array)
   }
-  def getExternPrototypes: Map[String, Map[String, (PackageCoordinate, Prototype2)]] = {
-    moduleNameToExternNameToExtern.map({ case (moduleName, externNameToExtern) =>
+  def getExternPrototypes: Map[PackageCoordinate, Map[String, Prototype2]] = {
+    packageToExternNameToExtern.map({ case (moduleName, externNameToExtern) =>
       (moduleName -> externNameToExtern.toMap)
     }).toMap
   }

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/citizen/StructTemplarCore.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/citizen/StructTemplarCore.scala
@@ -547,7 +547,7 @@ class StructTemplarCore(
           })
 
         // The args for the call inside the forwarding function.
-        val lambdaCoord = Coord(if (lambda.ownership == Share) Share else Constraint, lambda.permission, lambda.referend)
+        val lambdaCoord = Coord(if (lambda.ownership == Share) Share else Constraint, lambda.permission, lambda.kind)
         val forwardedCallArgs = (lambdaCoord :: forwarderHeader.paramTypes.tail).map(ParamFilter(_, None))
 
 //        start here
@@ -595,7 +595,7 @@ class StructTemplarCore(
             ArgLookup2(index + 1, param.tyype)
           })
 
-        if (lambdaFunctionPrototype.returnType.referend != Never2() &&
+        if (lambdaFunctionPrototype.returnType.kind != Never2() &&
           forwarderHeader.returnType != lambdaFunctionPrototype.returnType) {
           throw CompileErrorExceptionT(LambdaReturnDoesntMatchInterfaceConstructor(range))
         }

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/expression/BlockTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/expression/BlockTemplar.scala
@@ -60,8 +60,8 @@ class BlockTemplar(
     val unreversedVariablesToDestruct = getUnmovedVariablesIntroducedSince(startingFate, fate)
 
     val unresultifiedUndestructedExpressions =
-      if (unneveredUnresultifiedUndestructedExpressions.exists(_.referend == Never2()) &&
-          unneveredUnresultifiedUndestructedExpressions.last.referend != Never2()) {
+      if (unneveredUnresultifiedUndestructedExpressions.exists(_.kind == Never2()) &&
+          unneveredUnresultifiedUndestructedExpressions.last.kind != Never2()) {
         unneveredUnresultifiedUndestructedExpressions :+ UnreachableMootE2(VoidLiteral2())
       } else {
         unneveredUnresultifiedUndestructedExpressions
@@ -70,7 +70,7 @@ class BlockTemplar(
     val newExpressionsList =
       if (unreversedVariablesToDestruct.isEmpty) {
         unresultifiedUndestructedExpressions
-      } else if (unresultifiedUndestructedExpressions.last.referend == Never2()) {
+      } else if (unresultifiedUndestructedExpressions.last.kind == Never2()) {
         val moots = mootAll(temputs, fate, unreversedVariablesToDestruct)
         unresultifiedUndestructedExpressions ++ moots
       } else {
@@ -147,7 +147,7 @@ class BlockTemplar(
             (perhapsUndestructedFirstExpr2) // Do nothing
           } else {
             // This isn't the last expression
-            perhapsUndestructedFirstExpr2.resultRegister.referend match {
+            perhapsUndestructedFirstExpr2.resultRegister.kind match {
               case Void2() => perhapsUndestructedFirstExpr2
               case _ => destructorTemplar.drop(fate, temputs, perhapsUndestructedFirstExpr2)
             }

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/expression/CallTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/expression/CallTemplar.scala
@@ -36,9 +36,9 @@ class CallTemplar(
       explicitlySpecifiedTemplateArgTemplexesS: List[ITemplexS],
       givenArgsExprs2: List[ReferenceExpression2]):
   (FunctionCall2) = {
-    callableExpr.resultRegister.reference.referend match {
+    callableExpr.resultRegister.reference.kind match {
       case Never2() | Bool2() => {
-        throw CompileErrorExceptionT(RangedInternalErrorT(range, "wot " + callableExpr.resultRegister.reference.referend))
+        throw CompileErrorExceptionT(RangedInternalErrorT(range, "wot " + callableExpr.resultRegister.reference.kind))
       }
       case structRef @ StructRef2(_) => {
         evaluateClosureCall(
@@ -98,7 +98,7 @@ class CallTemplar(
 //
 //        val argsPointerTypes2 = argsExprs2.map(_.resultRegister.expectReference().reference)
 //
-//        val callableType = callableExpr.resultRegister.reference.referend.asInstanceOf[FunctionT2]
+//        val callableType = callableExpr.resultRegister.reference.kind.asInstanceOf[FunctionT2]
 //
 //        checkTypes(temputs, callableType.paramTypes, argsPointerTypes2, exact = true);
 //

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/expression/LocalHelper.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/expression/LocalHelper.scala
@@ -41,7 +41,7 @@ class LocalHelper(
     val unlet = unletLocal(fate, rlv)
     val destructExpr2 =
       destructorTemplar.drop(fate, temputs, unlet)
-    vassert(destructExpr2.referend == Void2())
+    vassert(destructExpr2.kind == Void2())
 
     // No Discard here because the destructor already returns void.
 
@@ -91,7 +91,7 @@ class LocalHelper(
       throw CompileErrorExceptionT(RangedInternalErrorT(range, "There's already a variable named " + varId))
     }
 
-    val mutable = Templar.getMutability(temputs, referenceType2.referend)
+    val mutable = Templar.getMutability(temputs, referenceType2.kind)
     val addressible = LocalHelper.determineIfLocalIsAddressible(mutable, localVariableA)
 
     val fullVarName = fate.fullName.addStep(varId)
@@ -193,13 +193,13 @@ class LocalHelper(
 
   def borrowSoftLoad(temputs: Temputs, expr2: AddressExpression2):
   ReferenceExpression2 = {
-    val ownership = getBorrowOwnership(temputs, expr2.resultRegister.reference.referend)
+    val ownership = getBorrowOwnership(temputs, expr2.resultRegister.reference.kind)
     SoftLoad2(expr2, ownership, expr2.resultRegister.reference.permission)
   }
 
-  def getBorrowOwnership(temputs: Temputs, referend: Kind):
+  def getBorrowOwnership(temputs: Temputs, kind: Kind):
   Ownership = {
-    referend match {
+    kind match {
       case Int2() => Share
       case Bool2() => Share
       case Float2() => Share

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/expression/PatternTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/expression/PatternTemplar.scala
@@ -153,7 +153,7 @@ class PatternTemplar(
           localHelper.softLoad(
             fate, range, LocalLookup2(range, export, inputExpr.resultRegister.reference, Final), UseP)
 
-        expectedCoord.referend match {
+        expectedCoord.kind match {
           case StructRef2(_) => {
             // Example:
             //   struct Marine { bork: Bork; }
@@ -206,8 +206,8 @@ class PatternTemplar(
 //        // Our resulting variable will have this ownership
 //        val expectedCitizenDef2 =
 //          expectedCitizenRef2 match {
-//            case ReferendTemplata(sr @ StructRef2(_)) => temputs.lookupCitizen(sr)
-//            case ReferendTemplata(ir @ InterfaceRef2(_)) => temputs.lookupCitizen(ir)
+//            case KindTemplata(sr @ StructRef2(_)) => temputs.lookupCitizen(sr)
+//            case KindTemplata(ir @ InterfaceRef2(_)) => temputs.lookupCitizen(ir)
 //          }
 //
 //        val expectedOwnership =
@@ -235,7 +235,7 @@ class PatternTemplar(
 //            unborrowedTargetReference
 //          } else {
 ////            if (expectBorrow) {
-////              Coord(Borrow, unborrowedTargetReference.referend)
+////              Coord(Borrow, unborrowedTargetReference.kind)
 ////            } else {
 //              unborrowedTargetReference
 ////            }
@@ -427,7 +427,7 @@ class PatternTemplar(
                 val memberPermissionInStruct = structDef2.members(index).tyype.reference.permission
                 val resultOwnership = if (memberCoord.ownership == Own) Constraint else memberCoord.ownership
                 val resultPermission = Templar.intersectPermission(memberPermissionInStruct, structPermission)
-//                val resultCoord = Coord(resultOwnership, resultPermission, memberCoord.referend)
+//                val resultCoord = Coord(resultOwnership, resultPermission, memberCoord.kind)
 
                 val loadExpr =
                   SoftLoad2(

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/function/BodyTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/function/BodyTemplar.scala
@@ -155,7 +155,7 @@ class BodyTemplar(
         case None => lastUnconvertedUnreturnedExpr
         case Some(expectedResultType) => {
           if (templataTemplar.isTypeTriviallyConvertible(temputs, lastUnconvertedUnreturnedExpr.resultRegister.reference, expectedResultType)) {
-            if (lastUnconvertedUnreturnedExpr.referend == Never2()) {
+            if (lastUnconvertedUnreturnedExpr.kind == Never2()) {
               lastUnconvertedUnreturnedExpr
             } else {
               convertHelper.convert(funcOuterEnv.snapshot, temputs, body1.range, lastUnconvertedUnreturnedExpr, expectedResultType);
@@ -168,7 +168,7 @@ class BodyTemplar(
 
 
     // If the function doesn't end in a ret, then add one for it.
-    val lastExpr = if (lastUnreturnedExpr.referend == Never2()) lastUnreturnedExpr else Return2(lastUnreturnedExpr)
+    val lastExpr = if (lastUnreturnedExpr.kind == Never2()) lastUnreturnedExpr else Return2(lastUnreturnedExpr)
     // Add that result type to the returns, since we just added a Return for it.
     val returnsMaybeWithNever = returnsFromInsideMaybeWithNever + lastUnreturnedExpr.resultRegister.reference
     // If we already had a return, then the above will add a Never to the returns, but that's fine, it will be filtered

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/function/DestructorTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/function/DestructorTemplar.scala
@@ -23,7 +23,7 @@ class DestructorTemplar(
     temputs: Temputs,
     type2: Coord):
   (Prototype2) = {
-    type2.referend match {
+    type2.kind match {
       case PackT2(_, _) | StructRef2(_) => { // | OrdinaryClosure2(_, _, _) | TemplatedClosure2(_, _, _) => {
         overloadTemplar.scoutExpectedFunctionForPrototype(
           env,
@@ -72,7 +72,7 @@ class DestructorTemplar(
     temputs: Temputs,
     type2: Coord):
   (Prototype2) = {
-    type2.referend match {
+    type2.kind match {
       case StaticSizedArrayT2(_, _) | RuntimeSizedArrayT2(_) =>
     }
     overloadTemplar.scoutExpectedFunctionForPrototype(
@@ -129,9 +129,9 @@ class DestructorTemplar(
   (ReferenceExpression2) = {
     val resultExpr2 =
       undestructedExpr2.resultRegister.reference match {
-        case r@Coord(Own, Readwrite, referend) => {
+        case r@Coord(Own, Readwrite, kind) => {
           val destructorPrototype =
-            referend match {
+            kind match {
               case PackT2(_, understructRef) => {
                 getCitizenDestructor(fate.snapshot, temputs, Coord(Own, Readwrite, understructRef))
               }
@@ -168,7 +168,7 @@ class DestructorTemplar(
 
 
           val unshareExpr2 =
-            undestructedExpr2.resultRegister.reference.referend match {
+            undestructedExpr2.resultRegister.reference.kind match {
               case Never2() => undestructedExpr2
               case Int2() | Str2() | Bool2() | Float2() | Void2() => {
                 Discard2(undestructedExpr2)
@@ -190,15 +190,15 @@ class DestructorTemplar(
                 destroySharedArray(temputs, underarrayReference2)
               }
               case OverloadSet(overloadSetEnv, name, voidStructRef) => {
-                val understructReference2 = undestructedExpr2.resultRegister.reference.copy(referend = voidStructRef)
+                val understructReference2 = undestructedExpr2.resultRegister.reference.copy(kind = voidStructRef)
                 destroySharedCitizen(temputs, understructReference2)
               }
               case PackT2(_, understruct2) => {
-                val understructReference2 = undestructedExpr2.resultRegister.reference.copy(referend = understruct2)
+                val understructReference2 = undestructedExpr2.resultRegister.reference.copy(kind = understruct2)
                 destroySharedCitizen(temputs, understructReference2)
               }
               case TupleT2(_, understruct2) => {
-                val understructReference2 = undestructedExpr2.resultRegister.reference.copy(referend = understruct2)
+                val understructReference2 = undestructedExpr2.resultRegister.reference.copy(kind = understruct2)
                 destroySharedCitizen(temputs, understructReference2)
               }
               case StructRef2(_) | InterfaceRef2(_) => {

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/function/FunctionTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/function/FunctionTemplar.scala
@@ -82,7 +82,7 @@ class FunctionTemplar(
           // See "Captured own is borrow" test for why we do this
           val tyype =
             reference.ownership match {
-              case Own => ReferenceMemberType2(Coord(Constraint, reference.permission, reference.referend))
+              case Own => ReferenceMemberType2(Coord(Constraint, reference.permission, reference.kind))
               case Constraint | Share => ReferenceMemberType2(reference)
             }
           (variability, tyype)
@@ -94,7 +94,7 @@ class FunctionTemplar(
           // See "Captured own is borrow" test for why we do this
           val tyype =
             reference.ownership match {
-              case Own => ReferenceMemberType2(Coord(Constraint, reference.permission, reference.referend))
+              case Own => ReferenceMemberType2(Coord(Constraint, reference.permission, reference.kind))
               case Constraint | Share => ReferenceMemberType2(reference)
             }
           (variability, tyype)

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/function/FunctionTemplarCore.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/function/FunctionTemplarCore.scala
@@ -212,7 +212,7 @@ class FunctionTemplarCore(
 
         val externFullName = FullName2(fullName.packageCoord, List(), ExternFunctionName2(humanName, params))
         val externPrototype = Prototype2(externFullName, header.returnType)
-        temputs.addExternPrototype(externPrototype)
+        temputs.addFunctionExtern(externPrototype, fullName.packageCoord, humanName)
 
         val argLookups =
           header.params.zipWithIndex.map({ case (param2, index) => ArgLookup2(index, param2.tyype) })

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/function/VirtualTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/function/VirtualTemplar.scala
@@ -36,7 +36,7 @@ class VirtualTemplar(opts: TemplarOptions, overloadTemplar: OverloadTemplar) {
             if (index != virtualIndex) {
               paramType
             } else {
-              paramType.copy(referend = superInterfaceRef2)
+              paramType.copy(kind = superInterfaceRef2)
             }
           })
 

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/infer/InfererEquator.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/infer/InfererEquator.scala
@@ -163,7 +163,7 @@ class InfererEquator[Env, State](
 //        vfail()
 //      }
 //      case (CallableTypeSR, KindTemplata(_)) => {
-//        // Gotta check if the referend is callable
+//        // Gotta check if the kind is callable
 //        vfail("unimplemented")
 //      }
 //      case _ => false

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/infer/InfererEvaluator.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/infer/InfererEvaluator.scala
@@ -173,7 +173,7 @@ class InfererEvaluator[Env, State](
     val patternCoordRune2 = NameTranslator.translateRune(patternCoordRuneA)
 
     val (rulesFromType, runesAddedForType) =
-      paramFilterInstance.tyype.referend match {
+      paramFilterInstance.tyype.kind match {
         case c: CitizenRef2 => {
           val ancestorInterfaces = delegate.getAncestorInterfaces(state, c)
           val selfAndAncestors = List(c) ++ ancestorInterfaces
@@ -264,7 +264,7 @@ class InfererEvaluator[Env, State](
     paramLocation: List[Int]
   ): IInferEvaluateResult[List[IRulexTR]] = {
     val incomingMembers =
-      getMemberCoords(state, inferences, incomingContainerCoord.referend, invocationRange, patternDestructures.size) match {
+      getMemberCoords(state, inferences, incomingContainerCoord.kind, invocationRange, patternDestructures.size) match {
         case iec@InferEvaluateConflict(_, _, _, _) => return InferEvaluateConflict(inferences.inferences, invocationRange, "Failed getting incomingMembers for destructure", List(iec))
         case InferEvaluateSuccess(m, true) => m
       }
@@ -531,7 +531,7 @@ class InfererEvaluator[Env, State](
           }
 
         val List(KindTemplata(kind)) = argTemplatas
-        val coord = templataTemplar.pointifyReferend(state, kind, Own)
+        val coord = templataTemplar.pointifyKind(state, kind, Own)
         (InferEvaluateSuccess(CoordTemplata(coord), deeplySatisfied))
       }
       case "passThroughIfConcrete" => {

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/infer/InfererMatcher.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/infer/InfererMatcher.scala
@@ -110,7 +110,7 @@ class InfererMatcher[Env, State](
     }
   }
 
-  private[infer] def matchReferend2AgainstRuneSP(
+  private[infer] def matchKind2AgainstRuneSP(
     env: Env,
     state: State,
       typeByRune: Map[IRune2, ITemplataType],
@@ -147,7 +147,7 @@ class InfererMatcher[Env, State](
   (IInferMatchResult) = {
 
     val structMemberTypes =
-      delegate.lookupMemberTypes(state, instance.referend, expectedNumMembers = parts.size) match {
+      delegate.lookupMemberTypes(state, instance.kind, expectedNumMembers = parts.size) match {
         case None => throw CompileErrorExceptionT(RangedInternalErrorT(range, "this thing cant be destructured, has no member types!"))
         case Some(x) => x
       }
@@ -202,7 +202,7 @@ class InfererMatcher[Env, State](
         case (Some(Abstract2), _) => return (InferMatchConflict(inferences.inferences, patternRange, s"ParamFilter virtuality didn't match rule:\n${instance.virtuality}\n${virtuality}", List()))
         case (Some(Override2(instanceSuperInterfaceRef2)), Some(OverrideSP(range, kindRuneS))) => {
           val kindRuneA = Astronomer.translateRune(kindRuneS)
-          matchReferend2AgainstRuneSP(env, state, typeByRune, localRunes, inferences, range, instanceSuperInterfaceRef2, NameTranslator.translateRune(kindRuneA)) match {
+          matchKind2AgainstRuneSP(env, state, typeByRune, localRunes, inferences, range, instanceSuperInterfaceRef2, NameTranslator.translateRune(kindRuneA)) match {
             case imc @ InferMatchConflict(_, _, _, _) => return imc
             case (InferMatchSuccess(ds)) => (ds)
           }
@@ -852,11 +852,11 @@ class InfererMatcher[Env, State](
     }
 
     instance match {
-      case KindTemplata(actualReferend) => {
+      case KindTemplata(actualKind) => {
         vcheck(components.size == 1, "Wrong number of components for kind")
         val List(mutabilityRule) = components
 
-        val actualMutability = delegate.getMutability(state, actualReferend)
+        val actualMutability = delegate.getMutability(state, actualKind)
         matchTemplataAgainstRulexTR(
           env, state, typeByRune, localRunes, inferences, MutabilityTemplata(actualMutability), mutabilityRule)
       }
@@ -875,7 +875,7 @@ class InfererMatcher[Env, State](
             case imc @ InferMatchConflict(_, _, _, _) => return imc
             case (InferMatchSuccess(ods)) => (ods)
           }
-        val actualKind = KindTemplata(actualReference.referend)
+        val actualKind = KindTemplata(actualReference.kind)
         val kindDeeplySatisfied =
           matchTemplataAgainstRulexTR(env, state, typeByRune, localRunes, inferences, actualKind, kindRule) match {
             case imc @ InferMatchConflict(_, _, _, _) => return imc
@@ -1024,7 +1024,7 @@ class InfererMatcher[Env, State](
 //        .flatMap(interfaceRef2 => {
 //          println("dont do this?")
 //          val subTemplar = new InferTemplarMatcher(env, State, delegate, rules, inferences)
-//          if (subTemplar.matchReferend2AgainstReferendRefSP(interfaceRef2, Some(overrideRule.tyype))) {
+//          if (subTemplar.matchKind2AgainstKindRefSP(interfaceRef2, Some(overrideRule.tyype))) {
 //            List((interfaceRef2, subTemplar))
 //          } else {
 //            List()

--- a/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarMutateTests.scala
+++ b/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarMutateTests.scala
@@ -24,7 +24,7 @@ class TemplarMutateTests extends FunSuite with Matchers {
   }
 
   test("Test mutating a local var") {
-    val compile = TemplarTestCompilation.test("fn main() {a! = 3; set a = 4; }")
+    val compile = TemplarTestCompilation.test("fn main() export {a! = 3; set a = 4; }")
     val temputs = compile.expectTemputs();
     val main = temputs.lookupFunction("main")
     main.only({ case Mutate2(LocalLookup2(_,ReferenceLocalVariable2(FullName2(_,_, CodeVarName2("a")), Varying, _), _, Varying), IntLiteral2(4)) => })
@@ -40,7 +40,7 @@ class TemplarMutateTests extends FunSuite with Matchers {
         """
           |struct Engine { fuel int; }
           |struct Spaceship { engine! Engine; }
-          |fn main() {
+          |fn main() export {
           |  ship = Spaceship(Engine(10));
           |  set ship.engine = Engine(15);
           |}
@@ -66,7 +66,7 @@ class TemplarMutateTests extends FunSuite with Matchers {
         |struct XNone<T> rules(T Ref) { }
         |impl<T> IXOption<T> for XNone<T>;
         |
-        |fn main() {
+        |fn main() export {
         |  m! IXOption<int> = XNone<int>();
         |  set m = XSome(6);
         |}
@@ -91,7 +91,7 @@ class TemplarMutateTests extends FunSuite with Matchers {
         |struct Marine {
         |  weapon! IXOption<int>;
         |}
-        |fn main() {
+        |fn main() export {
         |  m = Marine(XNone<int>());
         |  set m.weapon = XSome(6);
         |}
@@ -185,7 +185,7 @@ class TemplarMutateTests extends FunSuite with Matchers {
   test("Reports when we try to mutate a local variable with wrong type") {
     val compile = TemplarTestCompilation.test(
       """
-        |fn main() {
+        |fn main() export {
         |  a! = 5;
         |  set a = "blah";
         |}

--- a/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarTests.scala
+++ b/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarTests.scala
@@ -114,7 +114,7 @@ class TemplarTests extends FunSuite with Matchers {
 //        """
 //          |struct Ship { }
 //          |fn moo<T>(a &!T) &!T { a }
-//          |fn main() {
+//          |fn main() export {
 //          |  s = Ship();
 //          |  t = moo(&s);
 //          |}
@@ -326,7 +326,7 @@ class TemplarTests extends FunSuite with Matchers {
         |  Muta() = m;
         |}
         |
-        |fn main() {
+        |fn main() export {
         |  a = Muta();
         |}
       """.stripMargin)
@@ -348,7 +348,7 @@ class TemplarTests extends FunSuite with Matchers {
         |  SomeStruct<T>(t)
         |}
         |
-        |fn main() {
+        |fn main() export {
         |  doAThing(4);
         |}
         |""".stripMargin
@@ -500,7 +500,7 @@ class TemplarTests extends FunSuite with Matchers {
       """
         |struct MyThing { value int; }
         |fn moo() MyThing { MyThing(4) }
-        |fn main() { moo(); }
+        |fn main() export { moo(); }
       """.stripMargin)
 
     val temputs = compile.expectTemputs()
@@ -590,7 +590,7 @@ class TemplarTests extends FunSuite with Matchers {
       """
         |fn moo<T> () rules(T Ref) { }
         |
-        |fn main() {
+        |fn main() export {
         |	moo<int>();
         |}
       """.stripMargin)
@@ -824,7 +824,7 @@ class TemplarTests extends FunSuite with Matchers {
         |fn helperFunc<T>(x T) {
         |  { print(x); }();
         |}
-        |fn main() {
+        |fn main() export {
         |  helperFunc(4);
         |  helperFunc("bork");
         |}
@@ -848,7 +848,7 @@ class TemplarTests extends FunSuite with Matchers {
         |fn helperFunc(x str) {
         |  { print(x); }();
         |}
-        |fn main() {
+        |fn main() export {
         |  helperFunc(4);
         |  helperFunc("bork");
         |}
@@ -998,7 +998,7 @@ class TemplarTests extends FunSuite with Matchers {
           |interface AFunction1<P> rules(P Ref) {
           |  fn __call(virtual this &AFunction1<P>, a P) int;
           |}
-          |fn main() {
+          |fn main() export {
           |  arr = &AFunction1<int>((_){ true });
           |}
           |""".stripMargin)

--- a/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarTests.scala
+++ b/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarTests.scala
@@ -567,7 +567,7 @@ class TemplarTests extends FunSuite with Matchers {
         innerExpr.resultRegister.only({
           case StructRef2(simpleName("Toyota")) =>
         })
-        vassert(up.resultRegister.reference.referend == InterfaceRef2(FullName2(PackageCoordinate.TEST_TLD, List(), CitizenName2("Car", List()))))
+        vassert(up.resultRegister.reference.kind == InterfaceRef2(FullName2(PackageCoordinate.TEST_TLD, List(), CitizenName2("Car", List()))))
       }
     })
   }

--- a/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarVirtualTests.scala
+++ b/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarVirtualTests.scala
@@ -57,7 +57,7 @@ class TemplarVirtualTests extends FunSuite with Matchers {
               Constraint,Readonly,
               InterfaceRef2(FullName2(_, List(),CitizenName2("IShip",List()))))) =>
         }
-        vassert(okConstructor.paramTypes.head.referend == targetSubtype)
+        vassert(okConstructor.paramTypes.head.kind == targetSubtype)
         vassert(errConstructor.paramTypes.head == sourceExpr.resultRegister.reference)
         as
       }

--- a/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarVirtualTests.scala
+++ b/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarVirtualTests.scala
@@ -72,7 +72,7 @@ class TemplarVirtualTests extends FunSuite with Matchers {
         |impl IBork for Bork;
         |
         |fn rebork(virtual result &IBork) bool { true }
-        |fn main() {
+        |fn main() export {
         |  rebork(&Bork());
         |}
         |""".stripMargin)

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/TemplataNamer.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/TemplataNamer.scala
@@ -10,7 +10,7 @@ object TemplataNamer {
   // with the same signature because of this.
 
   def getReferenceIdentifierName(reference: Coord): String = {
-    val Coord(ownership, permission, referend) = reference;
+    val Coord(ownership, permission, kind) = reference;
     val ownershipString =
       ownership match {
         case Share => ""//"*"
@@ -24,7 +24,7 @@ object TemplataNamer {
         case Readwrite => "!"
 //        case ExclusiveReadwrite => "!!"
       }
-    ownershipString + permissionString + getReferendIdentifierName(referend)
+    ownershipString + permissionString + getKindIdentifierName(kind)
   }
 
   def stringifyTemplateArgs(templateArgs: List[ITemplata]): String = {
@@ -59,12 +59,12 @@ object TemplataNamer {
       case LambdaCitizenName2(codeLocation) => "ᛊ" + codeLocation
       case AnonymousSubstructName2(thing) =>
       case TupleName2(members) => "tup#"
-      case ImmDropName2(kind) => "drop*" + getReferendIdentifierName(kind)
+      case ImmDropName2(kind) => "drop*" + getKindIdentifierName(kind)
       case x => vimpl(x.toString)
     }).mkString(".")
   }
 
-  def getReferendIdentifierName(tyype: Kind): String = {
+  def getKindIdentifierName(tyype: Kind): String = {
     tyype match {
       case Int2() => "int"//"𝒾"
       case Float2() => "float"//"𝒻"
@@ -76,7 +76,7 @@ object TemplataNamer {
       case RuntimeSizedArrayT2(array) => "𝔸" + getReferenceIdentifierName(array.memberType)
       case StaticSizedArrayT2(size, arrayT2) => "𝔸" + size + getReferenceIdentifierName(arrayT2.memberType)
       case PackT2(_, underlyingStruct) => {
-        getReferendIdentifierName(underlyingStruct)
+        getKindIdentifierName(underlyingStruct)
       }
       case StructRef2(fullName) => "𝕊" + getFullNameIdentifierName(fullName)
       case InterfaceRef2(fullName) => "𝕋" + getFullNameIdentifierName(fullName)
@@ -88,7 +88,7 @@ object TemplataNamer {
 
   private def getIdentifierName(tyype: ITemplata): String = {
     tyype match {
-      case KindTemplata(referend) => "ㄊ" + getReferendIdentifierName(referend)
+      case KindTemplata(kind) => "ㄊ" + getKindIdentifierName(kind)
       case CoordTemplata(reference) => "ㄊ" + getReferenceIdentifierName(reference)
       case MutabilityTemplata(Mutable) => "ㄊmut"
       case MutabilityTemplata(Immutable) => "ㄊimm"
@@ -110,7 +110,7 @@ object TemplataNamer {
       (virtuality match {
         case None => ""
         case Some(Abstract2) => " abstract"
-        case Some(Override2(kind)) => " impl " + getReferendIdentifierName(kind)
+        case Some(Override2(kind)) => " impl " + getKindIdentifierName(kind)
       })
   }
 }

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/ast.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/ast.scala
@@ -28,15 +28,43 @@ case class Impl2(
   }
 }
 
-case class ExportAs2(
+case class KindExport2(
   tyype: Kind,
   packageCoordinate: PackageCoordinate,
   exportedName: String
 ) extends Queriable2 {
-  vpass()
-
   def all[T](func: PartialFunction[Queriable2, T]): List[T] = {
     tyype.all(func)
+  }
+}
+
+case class FunctionExport2(
+  prototype: Prototype2,
+  packageCoordinate: PackageCoordinate,
+  exportedName: String
+) extends Queriable2 {
+  def all[T](func: PartialFunction[Queriable2, T]): List[T] = {
+    prototype.all(func)
+  }
+}
+
+case class KindExtern2(
+  tyype: Kind,
+  packageCoordinate: PackageCoordinate,
+  externName: String
+) extends Queriable2 {
+  def all[T](func: PartialFunction[Queriable2, T]): List[T] = {
+    tyype.all(func)
+  }
+}
+
+case class FunctionExtern2(
+  prototype: Prototype2,
+  packageCoordinate: PackageCoordinate,
+  externName: String
+) extends Queriable2 {
+  def all[T](func: PartialFunction[Queriable2, T]): List[T] = {
+    prototype.all(func)
   }
 }
 
@@ -88,8 +116,8 @@ case class Function2(
   body: ReferenceExpression2) extends Queriable2 {
 
   vassert(
-    body.resultRegister.referend == Never2() ||
-    header.returnType.referend == Never2() ||
+    body.resultRegister.kind == Never2() ||
+    header.returnType.kind == Never2() ||
     body.resultRegister.reference == header.returnType)
 
   def all[T](func: PartialFunction[Queriable2, T]): List[T] = {

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/ast.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/ast.scala
@@ -4,7 +4,7 @@ import net.verdagon.vale.astronomer.FunctionA
 import net.verdagon.vale.templar.env._
 import net.verdagon.vale.templar.templata._
 import net.verdagon.vale.templar.types._
-import net.verdagon.vale.{PackageCoordinate, vassert, vassertSome, vfail, vwat}
+import net.verdagon.vale.{PackageCoordinate, vassert, vassertSome, vfail, vpass, vwat}
 
 import scala.collection.immutable._
 import scala.collection.mutable
@@ -33,6 +33,8 @@ case class ExportAs2(
   packageCoordinate: PackageCoordinate,
   exportedName: String
 ) extends Queriable2 {
+  vpass()
+
   def all[T](func: PartialFunction[Queriable2, T]): List[T] = {
     tyype.all(func)
   }

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/templata/TemplataTemplarInner.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/templata/TemplataTemplarInner.scala
@@ -101,16 +101,16 @@ class TemplataTemplarInner[Env, State](delegate: ITemplataTemplarInnerDelegate[E
 //  (Coord) = {
 //    templata match {
 //      case CoordTemplata(reference) => (reference)
-//      case KindTemplata(referend) => {
-//        (pointifyReferend(state, referend, ownershipIfMutable))
+//      case KindTemplata(kind) => {
+//        (pointifyKind(state, kind, ownershipIfMutable))
 //      }
 //      case st @ StructTemplata(_, _) => {
 //        val kind = delegate.evaluateStructTemplata(state, st, List())
-//        (pointifyReferend(state, kind, ownershipIfMutable))
+//        (pointifyKind(state, kind, ownershipIfMutable))
 //      }
 //      case it @ InterfaceTemplata(_, _) => {
 //        val kind = delegate.evaluateInterfaceTemplata(state, it, List())
-//        (pointifyReferend(state, kind, ownershipIfMutable))
+//        (pointifyKind(state, kind, ownershipIfMutable))
 //      }
 //      case _ => vfail("not yet")
 //    }
@@ -365,11 +365,11 @@ class TemplataTemplarInner[Env, State](delegate: ITemplataTemplarInnerDelegate[E
     true
   }
 
-  def pointifyReferend(state: State, referend: Kind, ownershipIfMutable: Ownership): Coord = {
-    val mutability = delegate.getMutability(state, referend)
+  def pointifyKind(state: State, kind: Kind, ownershipIfMutable: Ownership): Coord = {
+    val mutability = delegate.getMutability(state, kind)
     val ownership = if (mutability == Mutable) ownershipIfMutable else Share
     val permission = if (mutability == Mutable) Readwrite else Readonly
-    referend match {
+    kind match {
       case a @ RuntimeSizedArrayT2(array) => {
         Coord(ownership, permission, a)
       }
@@ -403,8 +403,8 @@ class TemplataTemplarInner[Env, State](delegate: ITemplataTemplarInnerDelegate[E
     }
   }
 
-//  def pointifyReferends(state: State, valueTypes: List[Kind], ownershipIfMutable: Ownership): List[Coord] = {
-//    valueTypes.map(valueType => pointifyReferend(state, valueType, ownershipIfMutable))
+//  def pointifyKinds(state: State, valueTypes: List[Kind], ownershipIfMutable: Ownership): List[Coord] = {
+//    valueTypes.map(valueType => pointifyKind(state, valueType, ownershipIfMutable))
 //  }
 
 

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/templata/templata.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/templata/templata.scala
@@ -22,12 +22,12 @@ case class CoordTemplata(reference: Coord) extends ITemplata {
     List(this).collect(func) ++ reference.all(func)
   }
 }
-case class KindTemplata(referend: Kind) extends ITemplata {
+case class KindTemplata(kind: Kind) extends ITemplata {
   override def order: Int = 2;
   override def tyype: ITemplataType = KindTemplataType
 
   def all[T](func: PartialFunction[Queriable2, T]): List[T] = {
-    List(this).collect(func) ++ referend.all(func)
+    List(this).collect(func) ++ kind.all(func)
   }
 }
 case class ArrayTemplateTemplata() extends ITemplata {

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/types/types.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/types/types.scala
@@ -122,8 +122,8 @@ case object Yonder extends Location {
 }
 
 
-case class Coord(ownership: Ownership, permission: Permission, referend: Kind) extends Queriable2 {
-  referend match {
+case class Coord(ownership: Ownership, permission: Permission, kind: Kind) extends Queriable2 {
+  kind match {
     case Int2() | Bool2() | Str2() | Float2() | Void2() | Never2() => {
       vassert(ownership == Share)
     }
@@ -138,7 +138,7 @@ case class Coord(ownership: Ownership, permission: Permission, referend: Kind) e
   }
 
   def all[T](func: PartialFunction[Queriable2, T]): List[T] = {
-    List(this).collect(func) ++ ownership.all(func) ++ referend.all(func)
+    List(this).collect(func) ++ ownership.all(func) ++ kind.all(func)
   }
 }
 sealed trait Kind extends Queriable2 {
@@ -429,12 +429,12 @@ object ReferenceComparator extends Ordering[Coord] {
     if (orderDiff != 0) {
       orderDiff
     } else {
-      ReferendComparator.compare(a.referend, b.referend)
+      KindComparator.compare(a.kind, b.kind)
     }
   }
 }
 
-object ReferendComparator extends Ordering[Kind] {
+object KindComparator extends Ordering[Kind] {
   override def compare(a: Kind, b: Kind): Int = {
     val orderDiff = a.order compare b.order;
     if (orderDiff != 0) {

--- a/Valestrom/Tests/test/main/resources/programs/externs/exportimminterfaceparam/native/exportimminterfaceparam.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/exportimminterfaceparam/native/exportimminterfaceparam.c
@@ -7,8 +7,8 @@
 #include "IShip.h"
 #include "expGetShipFuel.h"
 
-extern int64_t expGetShipFuel(IShip s);
+extern int64_t tmod_expGetShipFuel(tmod_IShip s);
 
-int64_t extGetShipFuel(IShip s) {
-  return expGetShipFuel(s);
+extern int64_t tmod_extGetShipFuel(tmod_IShip s) {
+  return tmod_expGetShipFuel(s);
 }

--- a/Valestrom/Tests/test/main/resources/programs/externs/exportimmrsaparam/native/exportimmrsaparam.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/exportimmrsaparam/native/exportimmrsaparam.c
@@ -2,8 +2,8 @@
 #include <stdio.h>
 #include "ImmIntArray.h"
 
-extern int64_t expSumBytes(ImmIntArray* arr);
+extern int64_t tmod_expSumBytes(tmod_ImmIntArray* arr);
 
-int64_t extSumBytes(ImmIntArray* arr) {
-  return expSumBytes(arr);
+int64_t tmod_extSumBytes(tmod_ImmIntArray* arr) {
+  return tmod_expSumBytes(arr);
 }

--- a/Valestrom/Tests/test/main/resources/programs/externs/exportimmstructparam/native/exportimmstructparam.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/exportimmstructparam/native/exportimmstructparam.c
@@ -6,7 +6,7 @@
 #include "Flamscrankle.h"
 #include "expFunc.h"
 
-int64_t extFunc(Flamscrankle* flam) {
-  int64_t result = expFunc(flam);
+int64_t tmod_extFunc(tmod_Flamscrankle* flam) {
+  int64_t result = tmod_expFunc(flam);
   return result;
 }

--- a/Valestrom/Tests/test/main/resources/programs/externs/exportimmstructparamdeep/native/exportimmstructparamdeep.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/exportimmstructparamdeep/native/exportimmstructparamdeep.c
@@ -7,8 +7,8 @@
 #include "Bogglewoggle.h"
 #include "Flamscrankle.h"
 
-extern int64_t expFunc(Flamscrankle* flam);
+extern int64_t tmod_expFunc(tmod_Flamscrankle* flam);
 
-int64_t extFunc(Flamscrankle* flam) {
-  return expFunc(flam);
+int64_t tmod_extFunc(tmod_Flamscrankle* flam) {
+  return tmod_expFunc(flam);
 }

--- a/Valestrom/Tests/test/main/resources/programs/externs/exportmutrsaparam/native/exportmutrsaparam.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/exportmutrsaparam/native/exportmutrsaparam.c
@@ -4,11 +4,11 @@
 #include "getMutIntArrayLen.h"
 #include "getMutIntArrayElem.h"
 
-int64_t sumBytes(MutIntArrayRef arr) {
+int64_t tmod_sumBytes(tmod_MutIntArrayRef arr) {
   int64_t total = 0;
-  int64_t len = getMutIntArrayLen(arr);
+  int64_t len = tmod_getMutIntArrayLen(arr);
   for (int i = 0; i < len; i++) {
-    int64_t elem = getMutIntArrayElem(arr, i);
+    int64_t elem = tmod_getMutIntArrayElem(arr, i);
     total += elem;
   }
   return total;

--- a/Valestrom/Tests/test/main/resources/programs/externs/exportmutssaparam/native/exportmutssaparam.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/exportmutssaparam/native/exportmutssaparam.c
@@ -4,11 +4,11 @@
 #include "getMutIntArrayLen.h"
 #include "getMutIntArrayElem.h"
 
-int64_t sumBytes(MutIntArrayRef arr) {
+int64_t tmod_sumBytes(tmod_MutIntArrayRef arr) {
   int64_t total = 0;
-  int64_t len = getMutIntArrayLen(arr);
+  int64_t len = tmod_getMutIntArrayLen(arr);
   for (int i = 0; i < len; i++) {
-    int64_t elem = getMutIntArrayElem(arr, i);
+    int64_t elem = tmod_getMutIntArrayElem(arr, i);
     total += elem;
   }
   return total;

--- a/Valestrom/Tests/test/main/resources/programs/externs/exportretvoid/native/exportretvoid.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/exportretvoid/native/exportretvoid.c
@@ -1,6 +1,6 @@
 #include <stdint.h>
 #include "donothing.h"
 
-void runExtCommand() {
-  donothing();
+void tmod_runExtCommand() {
+  tmod_donothing();
 }

--- a/Valestrom/Tests/test/main/resources/programs/externs/externimminterfaceparam/native/externimminterfaceparam.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externimminterfaceparam/native/externimminterfaceparam.c
@@ -9,12 +9,12 @@
 int64_t getShipFuel(IShip s) {
   int64_t result = 0;
   switch (s.type) {
-    case IShip_Seaship: {
+    case IShip_Type_Seaship: {
       Seaship* ship = (Seaship*)s.obj;
       result = ship->leftFuel + ship->rightFuel;
       break;
     }
-    case IShip_Spaceship: {
+    case IShip_Type_Spaceship: {
       Spaceship* ship = (Spaceship*)s.obj;
       result = ship->fuel;
       break;

--- a/Valestrom/Tests/test/main/resources/programs/externs/externimminterfaceparam/native/externimminterfaceparam.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externimminterfaceparam/native/externimminterfaceparam.c
@@ -6,16 +6,16 @@
 #include "Seaship.h"
 #include "IShip.h"
 
-int64_t getShipFuel(IShip s) {
+int64_t tmod_getShipFuel(tmod_IShip s) {
   int64_t result = 0;
   switch (s.type) {
-    case IShip_Type_Seaship: {
-      Seaship* ship = (Seaship*)s.obj;
+    case tmod_IShip_Type_Seaship: {
+      tmod_Seaship* ship = (tmod_Seaship*)s.obj;
       result = ship->leftFuel + ship->rightFuel;
       break;
     }
-    case IShip_Type_Spaceship: {
-      Spaceship* ship = (Spaceship*)s.obj;
+    case tmod_IShip_Type_Spaceship: {
+      tmod_Spaceship* ship = (tmod_Spaceship*)s.obj;
       result = ship->fuel;
       break;
     }

--- a/Valestrom/Tests/test/main/resources/programs/externs/externimmrsaparam/native/externimmrsaparam.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externimmrsaparam/native/externimmrsaparam.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include "ImmIntArray.h"
 
-int64_t sumBytes(ImmIntArray* arr) {
+int64_t tmod_sumBytes(tmod_ImmIntArray* arr) {
   int64_t total = 0;
   for (int i = 0; i < arr->length; i++) {
     total += arr->elements[i];

--- a/Valestrom/Tests/test/main/resources/programs/externs/externimmrsaparamdeep/native/externimmrsaparamdeep.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externimmrsaparamdeep/native/externimmrsaparamdeep.c
@@ -12,10 +12,10 @@ size_t floorMultipleOf16(size_t x) {
   return x & ~0xF;
 }
 
-int64_t sumWings(ImmSpaceshipArray* arr) {
+extern int64_t tmod_sumWings(tmod_ImmSpaceshipArray* arr) {
 
   size_t arrayHeaderAddr = (size_t)(void*)arr;
-  size_t arrayShallowSize = sizeof(ImmSpaceshipArray) + sizeof(Spaceship*) * arr->length;
+  size_t arrayShallowSize = sizeof(tmod_ImmSpaceshipArray) + sizeof(tmod_Spaceship*) * arr->length;
   // AP = And Padding; to get the next multiple of 16 from the end of the array's header struct.
   size_t arrayHeaderAPEndAddr = nextMultipleOf16(arrayHeaderAddr + arrayShallowSize);
 
@@ -25,7 +25,7 @@ int64_t sumWings(ImmSpaceshipArray* arr) {
   size_t rootMetadataAddr = floorMultipleOf16(rootMetadataAPEndAddr - 16);
 
   size_t lastElementAPEndAddr = rootMetadataAddr;
-  size_t lastElementAddr = floorMultipleOf16(lastElementAPEndAddr - sizeof(Spaceship));
+  size_t lastElementAddr = floorMultipleOf16(lastElementAPEndAddr - sizeof(tmod_Spaceship));
 
   size_t elementStride = lastElementAPEndAddr - lastElementAddr;
 

--- a/Valestrom/Tests/test/main/resources/programs/externs/externimmssaparam/native/externimmssaparam.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externimmssaparam/native/externimmssaparam.c
@@ -2,9 +2,9 @@
 #include <stdio.h>
 #include "ImmIntArray.h"
 
-int64_t sumBytes(ImmIntArray* arr) {
+int64_t sumBytes(tmod_ImmIntArray* arr) {
   int64_t total = 0;
-  for (int i = 0; i < ImmIntArray_LENGTH; i++) {
+  for (int i = 0; i < tmod_ImmIntArray_LENGTH; i++) {
     total += arr->elements[i];
   }
   return total;

--- a/Valestrom/Tests/test/main/resources/programs/externs/externimmstructparam/native/externimmstructparam.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externimmstructparam/native/externimmstructparam.c
@@ -5,7 +5,7 @@
 
 #include "Flamscrankle.h"
 
-int64_t extFunc(Flamscrankle* flam) {
+int64_t tmod_extFunc(tmod_Flamscrankle* flam) {
   int64_t result = flam->a + flam->c;
   ValeReleaseMessage(flam);
   return result;

--- a/Valestrom/Tests/test/main/resources/programs/externs/externimmstructparamdeep/native/externimmstructparamdeep.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externimmstructparamdeep/native/externimmstructparamdeep.c
@@ -15,7 +15,7 @@ size_t floorMultipleOf16(size_t x) {
   return x & ~0xF;
 }
 
-int64_t extFunc(Flamscrankle* flam) {
+int64_t tmod_extFunc(tmod_Flamscrankle* flam) {
   // Make sure the root pointer is at a multiple of 16.
   // If this fails, that means we have a bug, or malloc is breaking our assumptions
   // about alignment.
@@ -26,7 +26,7 @@ int64_t extFunc(Flamscrankle* flam) {
 
   size_t flamAddr = (size_t)(void*)flam;
   // AP = And Padding; to get the next multiple of 16 from the end of the Flamscrankle.
-  size_t flamAPEndAddr = nextMultipleOf16(flamAddr + sizeof(Flamscrankle));
+  size_t flamAPEndAddr = nextMultipleOf16(flamAddr + sizeof(tmod_Flamscrankle));
 
   // The root object (Flamscrankle here) always has a 16B "metadata block" before it, which contains
   // the start address and the size of the message.
@@ -35,11 +35,11 @@ int64_t extFunc(Flamscrankle* flam) {
 
   // Bogglewoggle is before the Flamscrankle, but at a multiple of 16.
   size_t bogAPEndAddr = rootMetadataAddr;
-  size_t bogAddr = floorMultipleOf16(bogAPEndAddr - sizeof(Bogglewoggle));
+  size_t bogAddr = floorMultipleOf16(bogAPEndAddr - sizeof(tmod_Bogglewoggle));
 
   // Spigglewigget is before the Bogglewoggle, but at a multiple of 16.
   size_t spigAPEndAddr = bogAddr;
-  size_t spigAddr = floorMultipleOf16(spigAPEndAddr - sizeof(Spigglewigget));
+  size_t spigAddr = floorMultipleOf16(spigAPEndAddr - sizeof(tmod_Spigglewigget));
 
   // Start metadata is before the Spigglewigget, but at a multiple of 16.
   size_t startMetadataAPEndAddr = spigAddr;

--- a/Valestrom/Tests/test/main/resources/programs/externs/externmain/externmain.vale
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externmain/externmain.vale
@@ -1,2 +1,0 @@
-
-fn main() int extern;

--- a/Valestrom/Tests/test/main/resources/programs/externs/externmain/native/externmain.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externmain/native/externmain.c
@@ -1,3 +1,0 @@
-int main() {
-  return 42;
-}

--- a/Valestrom/Tests/test/main/resources/programs/externs/externretmutstruct/native/externretmutstruct.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externretmutstruct/native/externretmutstruct.c
@@ -3,8 +3,8 @@
 
 #include "Thing.h"
 
-extern ThingRef makeThing(ValeStr* a, ValeInt b);
+extern tmod_ThingRef tmod_makeThing(ValeStr* a, ValeInt b);
 
-ThingRef runExtCommand() {
-  return makeThing(ValeStrFrom("hello"), 37);
+tmod_ThingRef tmod_runExtCommand() {
+  return tmod_makeThing(ValeStrFrom("hello"), 37);
 }

--- a/Valestrom/Tests/test/main/resources/programs/externs/externretvoid/native/externretvoid.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externretvoid/native/externretvoid.c
@@ -3,6 +3,6 @@
 #include "MyBox.h"
 #include "changeInBox.h"
 
-void runExtCommand(MyBoxRef b) {
-  changeInBox(b);
+void tmod_runExtCommand(tmod_MyBoxRef b) {
+  tmod_changeInBox(b);
 }

--- a/Valestrom/Tests/test/main/resources/programs/externs/externstrlen/native/externstrlen.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externstrlen/native/externstrlen.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 
-ValeInt extStrLen(ValeStr* haystackContainerStr) {
+ValeInt tmod_extStrLen(ValeStr* haystackContainerStr) {
   char* haystackContainerChars = haystackContainerStr->chars;
   ValeInt result = strlen(haystackContainerChars);
   return result;

--- a/Valestrom/Tests/test/main/resources/programs/externs/externstructparam/native/externstructparam.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externstructparam/native/externstructparam.c
@@ -6,9 +6,9 @@
 //  uint64_t ignore_1; // generation. if 0xFF, this is the owning reference.
 //  void* ignore_2; // ptr to obj.
 //} SpaceshipRef;
-extern int64_t spaceshipGetA(SpaceshipRef s);
-extern int64_t spaceshipGetB(SpaceshipRef s);
+extern int64_t tmod_spaceshipGetA(tmod_SpaceshipRef s);
+extern int64_t tmod_spaceshipGetB(tmod_SpaceshipRef s);
 
-int64_t sumSpaceshipFields(SpaceshipRef s) {
-  return spaceshipGetA(s) + spaceshipGetB(s);
+extern int64_t tmod_sumSpaceshipFields(tmod_SpaceshipRef s) {
+  return tmod_spaceshipGetA(s) + tmod_spaceshipGetB(s);
 }

--- a/Valestrom/Tests/test/main/resources/programs/externs/externtupleparam/native/externtupleparam.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externtupleparam/native/externtupleparam.c
@@ -1,10 +1,10 @@
 #include <stdint.h>
 
-typedef struct TwoInts {
+typedef struct tmod_TwoInts {
   int64_t a;
   int64_t b;
-} TwoInts;
+} tmod_TwoInts;
 
-int extGetFromTuple(TwoInts ints) {
+int tmod_extGetFromTuple(tmod_TwoInts ints) {
   return ints.b;
 }

--- a/Valestrom/Tests/test/main/resources/programs/externs/externtupleret/native/externtupleret.c
+++ b/Valestrom/Tests/test/main/resources/programs/externs/externtupleret/native/externtupleret.c
@@ -1,11 +1,11 @@
 #include <stdint.h>
 
-typedef struct TwoInts {
+typedef struct tmod_TwoInts {
   int64_t a;
   int64_t b;
-} TwoInts;
+} tmod_TwoInts;
 
-TwoInts extMakeTuple(int i) {
-  TwoInts result = { i * 2, i * 3 };
+TwoInts tmod_extMakeTuple(int i) {
+  tmod_TwoInts result = { i * 2, i * 3 };
   return result;
 }

--- a/Valestrom/Tests/test/main/resources/programs/functions/overloads.vale
+++ b/Valestrom/Tests/test/main/resources/programs/functions/overloads.vale
@@ -3,4 +3,4 @@ import v.builtins.str.*;
 
 fn ~(a int, b int) infer-ret {+(a, b)}
 fn ~(a str, b str) infer-ret {+(a, b)}
-fn main() infer-ret {3 ~ 3}
+fn main() infer-ret export {3 ~ 3}

--- a/Valestrom/Tests/test/main/resources/programs/genericvirtuals/templatedinterface.vale
+++ b/Valestrom/Tests/test/main/resources/programs/genericvirtuals/templatedinterface.vale
@@ -12,7 +12,7 @@ fn go(this &MyFunc impl MyIFunction1<int, int>, param int) int {
   param * 2
 }
 
-fn main() {
+fn main() export {
   m = MyFunc();
   i &MyIFunction1<int, int> = &m;
   println(i.go(4));

--- a/Valestrom/Tests/test/main/resources/programs/scratch.vale
+++ b/Valestrom/Tests/test/main/resources/programs/scratch.vale
@@ -464,29 +464,29 @@ struct FunctionHeaderP {
 
 
 // A reference contains these things:
-// - The referend; the thing that this reference points at.
-// - The ownership; this reference's relationship to the referend. This can be:
-//   - Share, which means the references all share ownership of the referend. This
-//     means that the referend will only be deallocated once all references to it are
-//     gone. Share references can only point at immutable referends, and immutable
-//     referends can *only* be pointed at by share references.
+// - The kind; the thing that this reference points at.
+// - The ownership; this reference's relationship to the kind. This can be:
+//   - Share, which means the references all share ownership of the kind. This
+//     means that the kind will only be deallocated once all references to it are
+//     gone. Share references can only point at immutable kinds, and immutable
+//     kinds can *only* be pointed at by share references.
 //   - Owning, which means this reference owns the object, and when this reference
 //     disappears (without being moved), the object should disappear (this is taken
-//     care of by the typing stage). Owning refs can only point at mutable referends.
-//   - Constraint, which means this reference doesn't own the referend. The referend
+//     care of by the typing stage). Owning refs can only point at mutable kinds.
+//   - Constraint, which means this reference doesn't own the kind. The kind
 //     is guaranteed not to die while this constraint ref is active (indeed if it did
-//     the program would panic). Constraint refs can only point at mutable referends.
+//     the program would panic). Constraint refs can only point at mutable kinds.
 //   - Raw, which is a weird ownership and should go away. We point at Void with this.
 //     TODO: Get rid of raw.
 //   - (in the future) Weak, which is a reference that will null itself out when the
-//     referend is destroyed. Weak refs can only point at mutable referends.
+//     kind is destroyed. Weak refs can only point at mutable kinds.
 // - (in the future) Permission, either readonly or readwrite.
 // - (in the future) Location, either inline or yonder. Inline means that this reference
 //   isn't actually a pointer, it's just the value itself, like C's Car vs Car*.
 // In previous stages, this is referred to as a "coord", because these four things can be
 // thought of as dimensions of a coordinate.
 
-// // Ownership is the way a reference relates to the referend's lifetime, see the
+// // Ownership is the way a reference relates to the kind's lifetime, see the
 // // above reference explanation.
 interface OwnershipP {}
 struct OwnP {}
@@ -498,7 +498,7 @@ impl OwnershipP for BorrowP;
 struct ShareP {}
 impl OwnershipP for ShareP;
 
-// Permission says whether a reference can modify the referend it's pointing at.
+// Permission says whether a reference can modify the kind it's pointing at.
 // See above reference explanation.
 interface PermissionP {}
 struct NormalP {}
@@ -508,9 +508,9 @@ impl PermissionP for NormalP;
 struct ExclusiveReadwriteP {}
 impl PermissionP for ExclusiveReadwriteP;
 
-// Location says whether a reference contains the referend's location (yonder) or
-// contains the referend itself (inline).
-// Yes, it's weird to consider a reference containing a referend, but it makes a
+// Location says whether a reference contains the kind's location (yonder) or
+// contains the kind itself (inline).
+// Yes, it's weird to consider a reference containing a kind, but it makes a
 // lot of things simpler for the language.
 // Examples (with C++ translations):
 //   This will create a variable `car` that lives on the stack ("inline"):
@@ -531,11 +531,11 @@ impl PermissionP for ExclusiveReadwriteP;
 // local variables it can, to speed up the program.
 interface LocationP {}
 
-// Means that the referend will be in the containing stack frame or struct.
+// Means that the kind will be in the containing stack frame or struct.
 struct InlineP {}
 impl LocationP for InlineP;
 
-// Means that the referend will be allocated separately, in the heap.
+// Means that the kind will be allocated separately, in the heap.
 struct YonderP {}
 impl LocationP for YonderP;
 
@@ -583,8 +583,8 @@ impl MutabilityP for ImmutableP;
 //       x->numWheels = 6;
 // In other words, variability affects whether the variable (or member) can be
 // changed to point at something different, but it doesn't affect whether we can
-// change anything inside the referend (this reference's permission and the
-// referend struct's member's variability affect that).
+// change anything inside the kind (this reference's permission and the
+// kind struct's member's variability affect that).
 interface VariabilityP {}
 struct FinalP {}
 impl VariabilityP for FinalP;

--- a/Valestrom/Tests/test/main/resources/programs/virtuals/upcasting.vale
+++ b/Valestrom/Tests/test/main/resources/programs/virtuals/upcasting.vale
@@ -1,6 +1,6 @@
 interface MyInterface { }
 struct MyStruct { value int; }
 impl MyInterface for MyStruct;
-fn main() {
+fn main() export {
   x MyInterface = MyStruct(9);
 }

--- a/Valestrom/Vivem/src/net/verdagon/vale/vivem/Call.scala
+++ b/Valestrom/Vivem/src/net/verdagon/vale/vivem/Call.scala
@@ -1,6 +1,6 @@
 package net.verdagon.vale.vivem
 
-import net.verdagon.vale.metal.{ReferenceH, ReferendH}
+import net.verdagon.vale.metal.{ReferenceH, KindH}
 import net.verdagon.vale.{vassert, vassertSome, vfail}
 
 import scala.collection.mutable
@@ -10,7 +10,7 @@ class Call(callId: CallId, in_args: Vector[ReferenceV]) {
 
   private val locals = mutable.HashMap[VariableAddressV, VariableV]()
 
-  def addLocal(varAddr: VariableAddressV, reference: ReferenceV, tyype: ReferenceH[ReferendH]): Unit = {
+  def addLocal(varAddr: VariableAddressV, reference: ReferenceV, tyype: ReferenceH[KindH]): Unit = {
     vassert(varAddr.callId == callId)
     vassert(!locals.contains(varAddr))
     vassert(!locals.exists(_._1.local.id.number == varAddr.local.id.number))
@@ -27,7 +27,7 @@ class Call(callId: CallId, in_args: Vector[ReferenceV]) {
     vassertSome(locals.get(addr))
   }
 
-  def mutateLocal(varAddr: VariableAddressV, reference: ReferenceV, expectedType: ReferenceH[ReferendH]): Unit = {
+  def mutateLocal(varAddr: VariableAddressV, reference: ReferenceV, expectedType: ReferenceH[KindH]): Unit = {
     locals(varAddr).reference = reference
   }
 

--- a/Valestrom/Vivem/src/net/verdagon/vale/vivem/FunctionVivem.scala
+++ b/Valestrom/Vivem/src/net/verdagon/vale/vivem/FunctionVivem.scala
@@ -50,42 +50,42 @@ object FunctionVivem {
 
   def getExternFunction(programH: ProgramH, ref: PrototypeH): (AdapterForExterns, Vector[ReferenceV]) => ReferenceV = {
     ref.fullName.toFullString() match {
-      case """"":F("__addIntInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.addIntInt
-      case """"":F("__addFloatFloat",[],[R(*,<,#,f),R(*,<,#,f)])""" => VivemExterns.addFloatFloat
-      case """"":F("__panic")""" => VivemExterns.panic
-      case """"":F("__multiplyIntInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.multiplyIntInt
-      case """"":F("__subtractFloatFloat",[],[R(*,<,#,f),R(*,<,#,f)])""" => VivemExterns.subtractFloatFloat
-      case """"":F("__divideIntInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.divideIntInt
-      case """"":F("__multiplyFloatFloat",[],[R(*,<,#,f),R(*,<,#,f)])""" => VivemExterns.multiplyFloatFloat
-      case """"":F("__divideFloatFloat",[],[R(*,<,#,f),R(*,<,#,f)])""" => VivemExterns.divideFloatFloat
-      case """"":F("__subtractIntInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.subtractIntInt
-      case """"":F("__vaddStr",[],[R(*,>,#,s),R(*,<,#,i),R(*,<,#,i),R(*,>,#,s),R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.addStrStr
-      case """"ioutils":F("__getch")""" => VivemExterns.getch
-      case """"":F("__eqFloatFloat",[],[R(*,<,#,f),R(*,<,#,f)])""" => VivemExterns.eqFloatFloat
-      case """"math":F("sqrt",[],[R(*,<,#,f)])""" => VivemExterns.sqrt
-      case """"":F("__lessThanInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.lessThanInt
-      case """"":F("__lessThanFloat",[],[R(*,<,#,f),R(*,<,#,f)])""" => VivemExterns.lessThanFloat
+      case """::F("__addIntInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.addIntInt
+      case """::F("__addFloatFloat",[],[R(*,<,#,f),R(*,<,#,f)])""" => VivemExterns.addFloatFloat
+      case """::F("__panic")""" => VivemExterns.panic
+      case """::F("__multiplyIntInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.multiplyIntInt
+      case """::F("__subtractFloatFloat",[],[R(*,<,#,f),R(*,<,#,f)])""" => VivemExterns.subtractFloatFloat
+      case """::F("__divideIntInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.divideIntInt
+      case """::F("__multiplyFloatFloat",[],[R(*,<,#,f),R(*,<,#,f)])""" => VivemExterns.multiplyFloatFloat
+      case """::F("__divideFloatFloat",[],[R(*,<,#,f),R(*,<,#,f)])""" => VivemExterns.divideFloatFloat
+      case """::F("__subtractIntInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.subtractIntInt
+      case """::F("__vaddStr",[],[R(*,>,#,s),R(*,<,#,i),R(*,<,#,i),R(*,>,#,s),R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.addStrStr
+      case """ioutils::F("__getch")""" => VivemExterns.getch
+      case """::F("__eqFloatFloat",[],[R(*,<,#,f),R(*,<,#,f)])""" => VivemExterns.eqFloatFloat
+      case """math::F("sqrt",[],[R(*,<,#,f)])""" => VivemExterns.sqrt
+      case """::F("__lessThanInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.lessThanInt
+      case """::F("__lessThanFloat",[],[R(*,<,#,f),R(*,<,#,f)])""" => VivemExterns.lessThanFloat
 //      case PrototypeH(FullNameH(List(NamePartH("__greaterThanFloat", Some(List()), Some(List(ReferenceH(m.Share,FloatH()), ReferenceH(m.Share,FloatH()))), None))), List(ReferenceH(m.Share,FloatH()), ReferenceH(m.Share,FloatH())), ReferenceH(m.Share,BoolH())) =>
 //        VivemExterns.greaterThanFloat
 //      case PrototypeH(FullNameH(List(NamePartH("__greaterThanInt", Some(List()), Some(List(ReferenceH(m.Share,IntH()), ReferenceH(m.Share,IntH()))), None))), List(ReferenceH(m.Share,IntH()), ReferenceH(m.Share,IntH())), ReferenceH(m.Share,BoolH())) =>
 //        VivemExterns.greaterThanInt
 //      case """F("__eqStrStr",[],[R(*,>,#,s),R(*,>,#,s)])""" => VivemExterns.eqStrStr
-      case """"":F("__greaterThanOrEqInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.greaterThanOrEqInt
-      case """"":F("__eqIntInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.eqIntInt
-      case """"":F("__eqBoolBool",[],[R(*,<,#,b),R(*,<,#,b)])""" => VivemExterns.eqBoolBool
-      case """"":F("__vprintStr",[],[R(*,>,#,s),R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.print
-      case """"":F("__not",[],[R(*,<,#,b)])""" => VivemExterns.not
-      case """"":F("__castIntStr",[],[R(*,<,#,i)])""" => VivemExterns.castIntStr
-      case """"":F("__castIntFloat",[],[R(*,<,#,i)])""" => VivemExterns.castIntFloat
-      case """"":F("__castFloatInt",[],[R(*,<,#,f)])""" => VivemExterns.castFloatInt
-      case """"":F("__lessThanOrEqInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.lessThanOrEqInt
-      case """"":F("__and",[],[R(*,<,#,b),R(*,<,#,b)])""" => VivemExterns.and
-      case """"":F("__or",[],[R(*,<,#,b),R(*,<,#,b)])""" => VivemExterns.or
-      case """"":F("__mod",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.mod
-      case """"":F("__strLength",[],[R(*,>,#,s)])""" => VivemExterns.strLength
-      case """"":F("__castFloatStr",[],[R(*,<,#,f)])""" => VivemExterns.castFloatStr
-      case """"":F("vstr_eq",[],[R(*,>,#,s),R(*,<,#,i),R(*,<,#,i),R(*,>,#,s),R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.eqStrStr
-      case """"":F("__negateFloat",[],[R(*,<,#,f)])""" => VivemExterns.negateFloat
+      case """::F("__greaterThanOrEqInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.greaterThanOrEqInt
+      case """::F("__eqIntInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.eqIntInt
+      case """::F("__eqBoolBool",[],[R(*,<,#,b),R(*,<,#,b)])""" => VivemExterns.eqBoolBool
+      case """::F("__vprintStr",[],[R(*,>,#,s),R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.print
+      case """::F("__not",[],[R(*,<,#,b)])""" => VivemExterns.not
+      case """::F("__castIntStr",[],[R(*,<,#,i)])""" => VivemExterns.castIntStr
+      case """::F("__castIntFloat",[],[R(*,<,#,i)])""" => VivemExterns.castIntFloat
+      case """::F("__castFloatInt",[],[R(*,<,#,f)])""" => VivemExterns.castFloatInt
+      case """::F("__lessThanOrEqInt",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.lessThanOrEqInt
+      case """::F("__and",[],[R(*,<,#,b),R(*,<,#,b)])""" => VivemExterns.and
+      case """::F("__or",[],[R(*,<,#,b),R(*,<,#,b)])""" => VivemExterns.or
+      case """::F("__mod",[],[R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.mod
+      case """::F("__strLength",[],[R(*,>,#,s)])""" => VivemExterns.strLength
+      case """::F("__castFloatStr",[],[R(*,<,#,f)])""" => VivemExterns.castFloatStr
+      case """::F("vstr_eq",[],[R(*,>,#,s),R(*,<,#,i),R(*,<,#,i),R(*,>,#,s),R(*,<,#,i),R(*,<,#,i)])""" => VivemExterns.eqStrStr
+      case """::F("__negateFloat",[],[R(*,<,#,f)])""" => VivemExterns.negateFloat
       case _ => vimpl(ref.fullName.toFullString())
     }
   }

--- a/Valestrom/Vivem/src/net/verdagon/vale/vivem/Heap.scala
+++ b/Valestrom/Vivem/src/net/verdagon/vale/vivem/Heap.scala
@@ -34,7 +34,7 @@ class AdapterForExterns(
 
   def makeVoid(): ReferenceV = {
     val emptyPackStructRefH = ProgramH.emptyTupleStructRef
-    val emptyPackStructDefH = vassertSome(programH.structs.find(_.getRef == emptyPackStructRefH))
+    val emptyPackStructDefH = programH.lookupStruct(emptyPackStructRefH)
     heap.newStruct(emptyPackStructDefH, ReferenceH(ShareH, InlineH, ReadonlyH, emptyPackStructRefH), List())
   }
 }

--- a/Valestrom/Vivem/src/net/verdagon/vale/vivem/Values.scala
+++ b/Valestrom/Vivem/src/net/verdagon/vale/vivem/Values.scala
@@ -8,12 +8,12 @@ import net.verdagon.vale.{vassert, vcheck, vfail}
 
 // RR = Runtime Result. Don't use these to determine behavior, just use
 // these to check that things are as we expect.
-case class RRReference(hamut: ReferenceH[ReferendH])
-case class RRReferend(hamut: ReferendH)
+case class RRReference(hamut: ReferenceH[KindH])
+case class RRKind(hamut: KindH)
 
 class Allocation(
     val reference: ReferenceV, // note that this cannot change
-    val referend: ReferendV // note that this cannot change
+    val kind: KindV // note that this cannot change
 ) {
   private var referrers = Map[IObjectReferrer, Int]()
 
@@ -89,7 +89,7 @@ class Allocation(
 //    if (referrers.size != expectedNum) {
 //      vfail(
 //        "o" + reference.allocId.num + " expected " + expectedNum + " but was " + referrers.size + ":\n" +
-//            referrers.mkString("\n") + "\nReferend:\n" + referend)
+//            referrers.mkString("\n") + "\nKind:\n" + kind)
 //    }
 //  }
 
@@ -111,39 +111,39 @@ class Allocation(
 //    vassert(referrers.isEmpty)
   }
 
-  def unapply(arg: Allocation): Option[ReferendV] = Some(referend)
+  def unapply(arg: Allocation): Option[KindV] = Some(kind)
 }
 
 object Allocation {
-  def unapply(arg: Allocation): Option[ReferendV] = {
-    Some(arg.referend)
+  def unapply(arg: Allocation): Option[KindV] = {
+    Some(arg.kind)
   }
 }
 
-sealed trait ReferendV {
-  def tyype: RRReferend
+sealed trait KindV {
+  def tyype: RRKind
 }
-sealed trait PrimitiveReferendV extends ReferendV
-case class IntV(value: Int) extends PrimitiveReferendV {
-  override def tyype = RRReferend(IntH())
+sealed trait PrimitiveKindV extends KindV
+case class IntV(value: Int) extends PrimitiveKindV {
+  override def tyype = RRKind(IntH())
 }
-case class BoolV(value: Boolean) extends PrimitiveReferendV {
-  override def tyype = RRReferend(BoolH())
+case class BoolV(value: Boolean) extends PrimitiveKindV {
+  override def tyype = RRKind(BoolH())
 }
-case class FloatV(value: Double) extends PrimitiveReferendV {
-  override def tyype = RRReferend(FloatH())
+case class FloatV(value: Double) extends PrimitiveKindV {
+  override def tyype = RRKind(FloatH())
 }
-case class StrV(value: String) extends PrimitiveReferendV {
-  override def tyype = RRReferend(StrH())
+case class StrV(value: String) extends PrimitiveKindV {
+  override def tyype = RRKind(StrH())
 }
 
 case class StructInstanceV(
     structH: StructDefinitionH,
     private var members: Option[Vector[ReferenceV]]
-) extends ReferendV {
+) extends KindV {
   vassert(members.get.size == structH.members.size)
 
-  override def tyype = RRReferend(structH.getRef)
+  override def tyype = RRKind(structH.getRef)
 
   def getReferenceMember(index: Int) = {
     (structH.members(index).tyype, members.get(index)) match {
@@ -164,12 +164,12 @@ case class StructInstanceV(
 }
 
 case class ArrayInstanceV(
-    typeH: ReferenceH[ReferendH],
-    elementTypeH: ReferenceH[ReferendH],
+    typeH: ReferenceH[KindH],
+    elementTypeH: ReferenceH[KindH],
     private val size: Int,
     private var elements: Vector[ReferenceV]
-) extends ReferendV {
-  override def tyype = RRReferend(typeH.kind)
+) extends KindV {
+  override def tyype = RRKind(typeH.kind)
 
   def getElement(index: Int): ReferenceV = {
     // Make sure we're initialized
@@ -214,7 +214,7 @@ case class ArrayInstanceV(
   }
 }
 
-case class AllocationId(tyype: RRReferend, num: Int) {
+case class AllocationId(tyype: RRKind, num: Int) {
   override def hashCode(): Int = num
 }
 
@@ -224,9 +224,9 @@ case class ReferenceV(
 
   // What is the actual type of what we're pointing to (as opposed to an interface).
   // If we have a Car reference to a Civic, then this will be Civic.
-  actualKind: RRReferend,
+  actualKind: RRKind,
   // What do we see the type as. If we have a Car reference to a Civic, then this will be Car.
-  seenAsKind: RRReferend,
+  seenAsKind: RRKind,
 
   ownership: OwnershipH,
 
@@ -236,7 +236,7 @@ case class ReferenceV(
   // Negative number means it's an empty struct (like void).
   num: Int
 ) {
-  def allocId = AllocationId(RRReferend(actualKind.hamut), num)
+  def allocId = AllocationId(RRKind(actualKind.hamut), num)
   val actualCoord: RRReference = RRReference(ReferenceH(ownership, location, permission, actualKind.hamut))
   val seenAsCoord: RRReference = RRReference(ReferenceH(ownership, location, permission, seenAsKind.hamut))
 }
@@ -265,7 +265,7 @@ case class ElementAddressV(arrayId: AllocationId, elementIndex: Int) {
 
 // Used in tracking reference counts/maps.
 case class CallId(callDepth: Int, function: PrototypeH) {
-  override def toString: String = "ƒ" + callDepth + "/" + function.fullName.toReadableString()
+  override def toString: String = "ƒ" + callDepth + "/" + (function.fullName.readableName + "_" + function.fullName.id)
   override def hashCode(): Int = callDepth + function.fullName.id
 }
 //case class RegisterId(blockId: BlockId, lineInBlock: Int)
@@ -273,7 +273,7 @@ case class ArgumentId(callId: CallId, index: Int)
 case class VariableV(
     id: VariableAddressV,
     var reference: ReferenceV,
-    expectedType: ReferenceH[ReferendH]) {
+    expectedType: ReferenceH[KindH]) {
   vassert(reference != None)
 }
 

--- a/Valestrom/Vivem/src/net/verdagon/vale/vivem/Vivem.scala
+++ b/Valestrom/Vivem/src/net/verdagon/vale/vivem/Vivem.scala
@@ -13,14 +13,14 @@ case class ConstraintViolatedException(msg: String) extends Throwable
 object Vivem {
   def executeWithPrimitiveArgs(
       programH: ProgramH,
-      externalArgumentReferends: Vector[PrimitiveReferendV],
+      externalArgumentKinds: Vector[PrimitiveKindV],
       vivemDout: PrintStream,
       stdin: () => String,
       stdout: String => Unit): IVonData = {
     val heap = new Heap(vivemDout)
     val argReferences =
-      externalArgumentReferends.map(argReferend => {
-        heap.add(ShareH, InlineH, ReadonlyH, argReferend);
+      externalArgumentKinds.map(argKind => {
+        heap.add(ShareH, InlineH, ReadonlyH, argKind);
       });
     innerExecute(programH, argReferences, heap, vivemDout, stdin, stdout)
   }
@@ -73,7 +73,7 @@ object Vivem {
       stdout: String => Unit): IVonData = {
     val main =
       programH.packages.flatMap({ case (packageCoord, paackage) =>
-        paackage.exportNameToFullName.get("main").map(fullName => paackage.functions.find(_.fullName == fullName).get).toList
+        paackage.exportNameToFunction.get("main").map(prototype => paackage.functions.find(_.prototype == prototype).get).toList
       }).flatten match {
         case List() => vfail()
         case List(m) => m

--- a/Valestrom/Vivem/src/net/verdagon/vale/vivem/Vivem.scala
+++ b/Valestrom/Vivem/src/net/verdagon/vale/vivem/Vivem.scala
@@ -71,7 +71,14 @@ object Vivem {
       vivemDout: PrintStream,
       stdin: () => String,
       stdout: String => Unit): IVonData = {
-    val main = programH.lookupFunction("main")
+    val main =
+      programH.packages.flatMap({ case (packageCoord, paackage) =>
+        paackage.exportNameToFullName.get("main").map(fullName => paackage.functions.find(_.fullName == fullName).get).toList
+      }).flatten match {
+        case List() => vfail()
+        case List(m) => m
+        case _ => vfail()
+      }
 
     val callId = CallId(0, main.prototype)
 

--- a/Valestrom/Vivem/src/net/verdagon/vale/vivem/VivemExterns.scala
+++ b/Valestrom/Vivem/src/net/verdagon/vale/vivem/VivemExterns.scala
@@ -12,9 +12,9 @@ object VivemExterns {
 
   def addIntInt(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (IntV(aValue), IntV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, IntV(aValue + bValue))
       }
@@ -23,9 +23,9 @@ object VivemExterns {
 
   def addFloatFloat(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (FloatV(aValue), FloatV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, FloatV(aValue + bValue))
       }
@@ -34,9 +34,9 @@ object VivemExterns {
 
   def multiplyIntInt(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (IntV(aValue), IntV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, IntV(aValue * bValue))
       }
@@ -45,9 +45,9 @@ object VivemExterns {
 
   def divideIntInt(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (IntV(aValue), IntV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, IntV(aValue / bValue))
       }
@@ -56,9 +56,9 @@ object VivemExterns {
 
   def multiplyFloatFloat(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (FloatV(aValue), FloatV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, FloatV(aValue * bValue))
       }
@@ -67,9 +67,9 @@ object VivemExterns {
 
   def divideFloatFloat(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (FloatV(aValue), FloatV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, FloatV(aValue / bValue))
       }
@@ -78,9 +78,9 @@ object VivemExterns {
 
   def mod(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (IntV(aValue), IntV(bValue)) => {
         try {
           memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, IntV(aValue % bValue))
@@ -93,9 +93,9 @@ object VivemExterns {
 
   def subtractIntInt(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (IntV(aValue), IntV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, IntV(aValue - bValue))
       }
@@ -104,9 +104,9 @@ object VivemExterns {
 
   def subtractFloatFloat(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (FloatV(aValue), FloatV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, FloatV(aValue - bValue))
       }
@@ -133,9 +133,9 @@ object VivemExterns {
 
   def lessThanInt(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (IntV(aValue), IntV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, BoolV(aValue < bValue))
       }
@@ -144,9 +144,9 @@ object VivemExterns {
 
   def lessThanFloat(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (FloatV(aValue), FloatV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, BoolV(aValue < bValue))
       }
@@ -155,9 +155,9 @@ object VivemExterns {
 
   def greaterThanFloat(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (FloatV(aValue), FloatV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, BoolV(aValue > bValue))
       }
@@ -166,9 +166,9 @@ object VivemExterns {
 
   def lessThanOrEqInt(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (IntV(aValue), IntV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, BoolV(aValue <= bValue))
       }
@@ -177,9 +177,9 @@ object VivemExterns {
 
   def greaterThanInt(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (IntV(aValue), IntV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, BoolV(aValue > bValue))
       }
@@ -188,9 +188,9 @@ object VivemExterns {
 
   def greaterThanOrEqInt(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (IntV(aValue), IntV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, BoolV(aValue >= bValue))
       }
@@ -199,9 +199,9 @@ object VivemExterns {
 
   def eqIntInt(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (IntV(aValue), IntV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, BoolV(aValue == bValue))
       }
@@ -210,9 +210,9 @@ object VivemExterns {
 
   def eqFloatFloat(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (FloatV(aValue), FloatV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, BoolV(aValue == bValue))
       }
@@ -233,9 +233,9 @@ object VivemExterns {
 
   def eqBoolBool(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (BoolV(aValue), BoolV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, BoolV(aValue == bValue))
       }
@@ -244,9 +244,9 @@ object VivemExterns {
 
   def and(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (BoolV(aValue), BoolV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, BoolV(aValue && bValue))
       }
@@ -255,9 +255,9 @@ object VivemExterns {
 
   def or(memory: AdapterForExterns, args: Vector[ReferenceV]): ReferenceV = {
     vassert(args.size == 2)
-    val aReferend = memory.dereference(args(0))
-    val bReferend = memory.dereference(args(1))
-    (aReferend, bReferend) match {
+    val aKind = memory.dereference(args(0))
+    val bKind = memory.dereference(args(1))
+    (aKind, bKind) match {
       case (BoolV(aValue), BoolV(bValue)) => {
         memory.addAllocationForReturn(ShareH, InlineH, ReadonlyH, BoolV(aValue || bValue))
       }

--- a/Valestrom/Vivem/test/net/verdagon/vale/vivem/VivemTests.scala
+++ b/Valestrom/Vivem/test/net/verdagon/vale/vivem/VivemTests.scala
@@ -23,7 +23,7 @@ class VivemTests extends FunSuite with Matchers {
     val programH =
       ProgramH(
         PackageCoordinateMap(Map())
-          .add(PackageCoordinate.TEST_TLD, PackageH(List(), List(), List(), List(main), List(), List(), Map(), Map("main" -> main.fullName), Map())))
+          .add(PackageCoordinate.TEST_TLD, PackageH(List(), List(), List(main), List(), List(), Map(), Map("main" -> main.prototype), Map(), Map(), Map())))
     val result =
       Vivem.executeWithPrimitiveArgs(programH, Vector(), System.out, Vivem.emptyStdin, Vivem.nullStdout)
     result shouldEqual VonInt(7)
@@ -75,8 +75,8 @@ class VivemTests extends FunSuite with Matchers {
     val programH =
       ProgramH(
         PackageCoordinateMap(Map())
-          .add(PackageCoordinate.BUILTIN, PackageH(List(), List(), List(), List(addExtern), List(), List(), Map(), Map(), Map()))
-          .add(PackageCoordinate.TEST_TLD, PackageH(List(), List(), List(), List(main), List(), List(), Map(), Map("main" -> main.fullName), Map())))
+          .add(PackageCoordinate.BUILTIN, PackageH(List(), List(), List(addExtern), List(), List(), Map(), Map(), Map(), Map("__addIntInt" -> addPrototype), Map()))
+          .add(PackageCoordinate.TEST_TLD, PackageH(List(), List(), List(main), List(), List(), Map(), Map("main" -> main.prototype), Map(), Map(), Map())))
     val result =
       Vivem.executeWithPrimitiveArgs(programH, Vector(), System.out, Vivem.emptyStdin, Vivem.nullStdout)
     result shouldEqual VonInt(159)

--- a/Valestrom/Vivem/test/net/verdagon/vale/vivem/VivemTests.scala
+++ b/Valestrom/Vivem/test/net/verdagon/vale/vivem/VivemTests.scala
@@ -1,7 +1,7 @@
 package net.verdagon.vale.vivem
 
 import net.verdagon.vale.metal._
-import net.verdagon.vale.{metal => m}
+import net.verdagon.vale.{PackageCoordinate, PackageCoordinateMap, metal => m}
 import net.verdagon.von.{VonArray, VonInt, VonMember, VonObject, VonStr}
 import org.scalatest.{FunSuite, Matchers}
 
@@ -13,13 +13,17 @@ class VivemTests extends FunSuite with Matchers {
           FullNameH(
             "main",
             0,
+            PackageCoordinate.TEST_TLD,
             List(VonObject("F",None,Vector(VonMember("humanName",VonStr("main")), VonMember("templateArgs",VonArray(None,Vector())), VonMember("parameters",VonArray(None,Vector())))))),List(),ReferenceH(m.ShareH,InlineH,ReadonlyH,IntH())),
         true,
         false,
         false,
         List(UserFunctionH),
         BlockH(ConstantI64H(7)))
-    val programH = ProgramH(List(), List(), List(), List(main), List(), List(), Map(), Map(), Map(), List())
+    val programH =
+      ProgramH(
+        PackageCoordinateMap(Map())
+          .add(PackageCoordinate.TEST_TLD, PackageH(List(), List(), List(), List(main), List(), List(), Map(), Map("main" -> main.fullName), Map())))
     val result =
       Vivem.executeWithPrimitiveArgs(programH, Vector(), System.out, Vivem.emptyStdin, Vivem.nullStdout)
     result shouldEqual VonInt(7)
@@ -34,7 +38,8 @@ class VivemTests extends FunSuite with Matchers {
         FullNameH(
           "__addIntInt",
           0,
-          List(VonStr(""),VonObject("F",None,Vector(VonMember("humanName",VonStr("__addIntInt")), VonMember("templateArgs",VonArray(None,Vector())), VonMember("parameters",VonArray(None,Vector(intRef, intRef))))))),
+          PackageCoordinate.BUILTIN,
+          List(VonObject("F",None,Vector(VonMember("humanName",VonStr("__addIntInt")), VonMember("templateArgs",VonArray(None,Vector())), VonMember("parameters",VonArray(None,Vector(intRef, intRef))))))),
         List(ReferenceH(ShareH,InlineH,ReadonlyH,IntH()), ReferenceH(ShareH,InlineH,ReadonlyH,IntH())),
         ReferenceH(ShareH,InlineH,ReadonlyH,IntH()))
     val main =
@@ -43,6 +48,7 @@ class VivemTests extends FunSuite with Matchers {
           FullNameH(
             "main",
             0,
+            PackageCoordinate.TEST_TLD,
             List(VonObject("F",None,Vector(VonMember("humanName",VonStr("main")), VonMember("templateArgs",VonArray(None,Vector())), VonMember("parameters",VonArray(None,Vector())))))),List(),ReferenceH(m.ShareH,InlineH,ReadonlyH,IntH())),
         true,
         false,
@@ -66,7 +72,11 @@ class VivemTests extends FunSuite with Matchers {
         true,
         List(),
         BlockH(ConstantI64H(133337)))
-    val programH = ProgramH(List(), List(), List(), List(main, addExtern), List(), List(), Map(), Map(), Map(), List())
+    val programH =
+      ProgramH(
+        PackageCoordinateMap(Map())
+          .add(PackageCoordinate.BUILTIN, PackageH(List(), List(), List(), List(addExtern), List(), List(), Map(), Map(), Map()))
+          .add(PackageCoordinate.TEST_TLD, PackageH(List(), List(), List(), List(main), List(), List(), Map(), Map("main" -> main.fullName), Map())))
     val result =
       Vivem.executeWithPrimitiveArgs(programH, Vector(), System.out, Vivem.emptyStdin, Vivem.nullStdout)
     result shouldEqual VonInt(159)


### PR DESCRIPTION
Separated the .vast by package
Starting to add package coords to midas
Fixed MMEDT, exports now can only use exports from their own package
Prefix externs and exports with their project name
Made it so builtin package doesnt prefix for externs and exports