### PR TITLE
[mike] Replaced List() with List.empty or Nil(in match clauses)

### DIFF
--- a/Valestrom/.idea/codeStyles/Project.xml
+++ b/Valestrom/.idea/codeStyles/Project.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="FORMATTER_TAGS_ENABLED" value="true" />
     <ScalaCodeStyleSettings>
       <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
     </ScalaCodeStyleSettings>

--- a/Valestrom/.idea/google-java-format.xml
+++ b/Valestrom/.idea/google-java-format.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoogleJavaFormatSettings">
+    <option name="enabled" value="false" />
+  </component>
+</project>

--- a/Valestrom/.idea/scala_settings.xml
+++ b/Valestrom/.idea/scala_settings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ScalaProjectSettings">
-    <option name="ignorePerformance" value="true" />
-  </component>
-</project>

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/Astronomer.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/Astronomer.scala
@@ -46,7 +46,7 @@ case class Environment(
       case _ => vimpl()
     }
 
-//    val envNameSteps = maybeName.map(_.steps).getOrElse(List())
+//    val envNameSteps = maybeName.map(_.steps).getOrElse(List.empty)
 //
 //    // See MINAAN for what we're doing here.
 //    absoluteNameEndsWithImpreciseName(absoluteName, needleImpreciseNameS) match {
@@ -86,7 +86,7 @@ case class Environment(
       return (nearPrimitives, nearStructs.toList, nearInterfaces.toList)
     }
     maybeParentEnv match {
-      case None => (None, List(), List())
+      case None => (None, List.empty, List.empty)
       case Some(parentEnv) => parentEnv.lookupType(needleImpreciseNameS)
     }
   }
@@ -100,7 +100,7 @@ case class Environment(
       return (nearStructs.toList, nearInterfaces.toList)
     }
     maybeParentEnv match {
-      case None => (List(), List())
+      case None => (List.empty, List.empty)
       case Some(parentEnv) => parentEnv.lookupType(name)
     }
   }
@@ -304,7 +304,7 @@ object Astronomer {
     }
 
     val (conclusions, rulesA) =
-      makeRuleTyper().solve(astrouts, env, rules, rangeS, List(), Some(localRunesA ++ knowableRunesA)) match {
+      makeRuleTyper().solve(astrouts, env, rules, rangeS, List.empty, Some(localRunesA ++ knowableRunesA)) match {
         case (_, rtsf @ RuleTyperSolveFailure(_, _, _, _)) => throw CompileErrorExceptionA(CouldntSolveRulesA(rangeS, rtsf))
         case (c, RuleTyperSolveSuccess(r)) => (c, r)
       }
@@ -349,7 +349,7 @@ object Astronomer {
       case ExportS(packageCoordinate) => List(ExportA(packageCoordinate))
       case ExternS(packageCoordinate) => List(ExternA(packageCoordinate))
       case PureS => List(PureA)
-      case BuiltinS(_) => List()
+      case BuiltinS(_) => List.empty
       case x => vimpl(x.toString)
     })
   }
@@ -372,7 +372,7 @@ object Astronomer {
     }
 
     val (conclusions, rulesA) =
-      makeRuleTyper().solve(astrouts, env, rules, range, List(), Some(knowableRunesA ++ localRunesA)) match {
+      makeRuleTyper().solve(astrouts, env, rules, range, List.empty, Some(knowableRunesA ++ localRunesA)) match {
         case (_, rtsf @ RuleTyperSolveFailure(_, _, _, _)) => throw CompileErrorExceptionA(CouldntSolveRulesA(range, rtsf))
         case (c, RuleTyperSolveSuccess(r)) => (c, r)
       }
@@ -416,12 +416,12 @@ object Astronomer {
     }
 
     val (conclusionsForRulesFromStructDirection, rulesFromStructDirectionA) =
-      makeRuleTyper().solve(astrouts, env, rulesFromStructDirection, range, List(), Some(knowableRunesA ++ localRunesA)) match {
+      makeRuleTyper().solve(astrouts, env, rulesFromStructDirection, range, List.empty, Some(knowableRunesA ++ localRunesA)) match {
         case (_, rtsf @ RuleTyperSolveFailure(_, _, _, _)) => throw CompileErrorExceptionA(CouldntSolveRulesA(range, rtsf))
         case (c, RuleTyperSolveSuccess(r)) => (c, r)
       }
     val (conclusionsForRulesFromInterfaceDirection, rulesFromInterfaceDirectionA) =
-      makeRuleTyper().solve(astrouts, env, rulesFromInterfaceDirection, range, List(), Some(knowableRunesA ++ localRunesA)) match {
+      makeRuleTyper().solve(astrouts, env, rulesFromInterfaceDirection, range, List.empty, Some(knowableRunesA ++ localRunesA)) match {
         case (_, rtsf @ RuleTyperSolveFailure(_, _, _, _)) => throw CompileErrorExceptionA(CouldntSolveRulesA(range, rtsf))
         case (c, RuleTyperSolveSuccess(r)) => (c, r)
       }
@@ -447,7 +447,7 @@ object Astronomer {
     val rulesS = List(EqualsSR(range, TypedSR(range, runeS, KindTypeSR), TemplexSR(templexS)))
 
     val (conclusions, rulesA) =
-      makeRuleTyper().solve(astrouts, env, rulesS, range, List(), Some(Set(runeA))) match {
+      makeRuleTyper().solve(astrouts, env, rulesS, range, List.empty, Some(Set(runeA))) match {
         case (_, rtsf @ RuleTyperSolveFailure(_, _, _, _)) => throw CompileErrorExceptionA(CouldntSolveRulesA(range, rtsf))
         case (c, RuleTyperSolveSuccess(r)) => (c, r)
       }
@@ -506,7 +506,7 @@ object Astronomer {
     val paramsA = paramsS.map(translateParameter(env, _))
 
     val (conclusions, rulesA) =
-      makeRuleTyper().solve(astrouts, env, templateRules, rangeS, List(), Some(localRunesA)) match {
+      makeRuleTyper().solve(astrouts, env, templateRules, rangeS, List.empty, Some(localRunesA)) match {
         case (_, rtsf @ RuleTyperSolveFailure(_, _, _, _)) => {
           ErrorReporter.report(CouldntSolveRulesA(rangeS, rtsf))
         }
@@ -684,7 +684,7 @@ object Astronomer {
   ProgramA = {
     val astrouts = AstroutsBox(Astrouts(Map()))
 
-    val env = Environment(None, None, primitives, codeMap, Map(), List())
+    val env = Environment(None, None, primitives, codeMap, Map(), List.empty)
 
     val structsA = env.structsS.map(translateStruct(astrouts, env, _))
 
@@ -759,11 +759,11 @@ object Astronomer {
         allPackages.map(paackage => {
           val contents =
             ProgramA(
-              packageToStructsA.getOrElse(paackage, List()),
-              packageToInterfacesA.getOrElse(paackage, List()),
-              packageToImplsA.getOrElse(paackage, List()),
-              packageToFunctionsA.getOrElse(paackage, List()),
-              packageToExportsA.getOrElse(paackage, List()))
+              packageToStructsA.getOrElse(paackage, List.empty),
+              packageToInterfacesA.getOrElse(paackage, List.empty),
+              packageToImplsA.getOrElse(paackage, List.empty),
+              packageToFunctionsA.getOrElse(paackage, List.empty),
+              packageToExportsA.getOrElse(paackage, List.empty))
           (paackage -> contents)
         }).toMap
       val moduleToPackageToContents =

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/ExpressionAstronomer.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/ExpressionAstronomer.scala
@@ -116,7 +116,7 @@ object ExpressionAstronomer {
         val runesA = maybeMutabilityRuneA.toList ++ maybeVariabilityRuneA.toList ++ maybeSizeRuneA.toList
 
         val (conclusions, rulesA) =
-          makeRuleTyper().solve(astrouts, env, rules, range, List(), Some(runesA.toSet)) match {
+          makeRuleTyper().solve(astrouts, env, rules, range, List.empty, Some(runesA.toSet)) match {
             case (_, rtsf @ RuleTyperSolveFailure(_, _, _, _)) => vfail(rtsf.toString)
             case (c, RuleTyperSolveSuccess(r)) => (c, r)
           }
@@ -141,7 +141,7 @@ object ExpressionAstronomer {
         val runesA = maybeMutabilityRuneA.toList ++ maybeVariabilityRuneA.toList ++ List(sizeRuneA)
 
         val (conclusions, rulesA) =
-          makeRuleTyper().solve(astrouts, env, rules, range, List(), Some(runesA.toSet)) match {
+          makeRuleTyper().solve(astrouts, env, rules, range, List.empty, Some(runesA.toSet)) match {
             case (_, rtsf @ RuleTyperSolveFailure(_, _, _, _)) => vfail(rtsf.toString)
             case (c, RuleTyperSolveSuccess(r)) => (c, r)
           }
@@ -164,7 +164,7 @@ object ExpressionAstronomer {
         val runesA = maybeMutabilityRuneA.toList ++ maybeVariabilityRuneA.toList
 
         val (conclusions, rulesA) =
-          makeRuleTyper().solve(astrouts, env, rules, range, List(), Some(runesA.toSet)) match {
+          makeRuleTyper().solve(astrouts, env, rules, range, List.empty, Some(runesA.toSet)) match {
             case (_, rtsf @ RuleTyperSolveFailure(_, _, _, _)) => vfail(rtsf.toString)
             case (c, RuleTyperSolveSuccess(r)) => (c, r)
           }

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/builtins/IFunction1.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/builtins/IFunction1.scala
@@ -12,7 +12,7 @@ object IFunction1 {
     InterfaceA(
       RangeS.internal(-69),
       TopLevelCitizenDeclarationNameA("IFunction1", CodeLocationS.internal(-7)),
-      List(),
+      List.empty,
       false,
       CodeRuneA("M"),
       None,
@@ -32,10 +32,10 @@ object IFunction1 {
         FunctionA(
           RangeS.internal(-5633),
           FunctionNameA("__call", CodeLocationS.internal(-8)),
-          List(),
+          List.empty,
           FunctionTemplataType,
           Set(),
-          List(),
+          List.empty,
           Set(CodeRuneA("BorrowThis"), CodeRuneA("ThisK")),
           Map(
             CodeRuneA("BorrowThis") -> CoordTemplataType,

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/builtins/arrays.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/builtins/arrays.scala
@@ -10,7 +10,7 @@ object Arrays {
 //    FunctionA(
 //      RangeS.internal(-57),
 //      FunctionNameA("__Array", CodeLocationS.internal(-4)),
-//      List(),
+//      List.empty,
 //      TemplateTemplataType(List(MutabilityTemplataType, CoordTemplataType, CoordTemplataType, PrototypeTemplataType), FunctionTemplataType),
 //      Set(CodeRuneA("IntType")),
 //      List(CodeRuneA("ArrayMutability"), CodeRuneA("ArrayMutability"), CodeRuneA("ElementType"), CodeRuneA("GeneratorType"), CodeRuneA("GeneratorPrototype")),
@@ -56,7 +56,7 @@ object Arrays {
 //      CodeBodyA(
 //        BodyAE(
 //          RangeS.internal(-5621),
-//          List(),
+//          List.empty,
 //          BlockAE(
 //            RangeS.internal(-5622),
 //            List(

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/builtins/refcounting.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/builtins/refcounting.scala
@@ -10,7 +10,7 @@ object RefCounting {
     FunctionA(
       RangeS.internal(-60),
       FunctionNameA("__checkvarrc", CodeLocationS.internal(-11)),
-      List(),
+      List.empty,
       TemplateTemplataType(List(CoordTemplataType), FunctionTemplataType),
       Set(CodeRuneA("V"), CodeRuneA("I")),
       List(CodeRuneA("T")),
@@ -41,7 +41,7 @@ object RefCounting {
       CodeBodyA(
         BodyAE(
           RangeS.internal(-35),
-          List(),
+          List.empty,
           BlockAE(
             RangeS.internal(-35),
             List(
@@ -63,7 +63,7 @@ object RefCounting {
     FunctionA(
       RangeS.internal(-59),
       checkMemberRcName,
-      List(),
+      List.empty,
       TemplateTemplataType(List(CoordTemplataType), FunctionTemplataType),
       Set(CodeRuneA("V"), CodeRuneA("I")),
       List(CodeRuneA("T")),
@@ -84,7 +84,7 @@ object RefCounting {
       CodeBodyA(
         BodyAE(
           RangeS.internal(-35),
-          List(),
+          List.empty,
           BlockAE(
             RangeS.internal(-35),
             List(

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/makeSimpleFunction.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/makeSimpleFunction.scala
@@ -32,10 +32,10 @@ object makeSimpleFunction {
     FunctionA(
       RangeS.internal(-53),
       name,
-      List(),
+      List.empty,
       FunctionTemplataType,
       knowableRunes,
-      List(),
+      List.empty,
       localRunes,
       runeByType
         .map({ case (_, rune) => (rune, CoordTemplataType) })

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/patterns.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/patterns.scala
@@ -20,8 +20,8 @@ object PatternSUtils {
   def getDistinctOrderedRunesForPattern(pattern: AtomAP): List[IRuneA] = {
     val runesFromVirtuality =
       pattern.virtuality match {
-        case None => List()
-        case Some(AbstractAP) => List()
+        case None => List.empty
+        case Some(AbstractAP) => List.empty
         case Some(OverrideAP(range, kindRune)) => List(kindRune)
       }
     val runesFromDestructures =

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/ruletyper/RuleTyperEvaluator.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/ruletyper/RuleTyperEvaluator.scala
@@ -72,7 +72,7 @@ class RuleTyperEvaluator[Env, State](
           conclusions,
           invocationRange,
           "Couldn't figure out types of all rules! Couldn't figure out rules at indices: " + unknownIndices,
-          List()))
+          List.empty))
     }
 
     val unfiguredOutRunes = maybeNeededRunes.getOrElse(Set()) -- conclusions.typeByRune.keySet
@@ -83,7 +83,7 @@ class RuleTyperEvaluator[Env, State](
           conclusions,
           invocationRange,
           "Couldn't figure out types of all runes! Couldn't figure out: " + unfiguredOutRunes,
-          List()))
+          List.empty))
     }
 
     (conclusions.conclusions, RuleTyperSolveSuccess(knowns))
@@ -148,7 +148,7 @@ class RuleTyperEvaluator[Env, State](
     rules: List[IRulexSR],
   ): (IRuleTyperEvaluateResult[List[IRulexAR]]) = {
     val initialResult: IRuleTyperEvaluateResult[List[IRulexAR]] =
-      RuleTyperEvaluateSuccess(List())
+      RuleTyperEvaluateSuccess(List.empty)
     rules.zipWithIndex.foldLeft((initialResult))({
       case (RuleTyperEvaluateUnknown(), (rule, index)) => {
         evaluateRule(state, env, conclusions, rule) match {

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/ruletyper/RuleTyperMatcher.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/ruletyper/RuleTyperMatcher.scala
@@ -31,7 +31,7 @@ class RuleTyperMatcher[Env, State](
         if (existing == tyype) {
           RuleTyperMatchSuccess(())
         } else {
-          RuleTyperMatchConflict(conclusions.conclusions, range, "Disagreement about rune " + rune + "! " + existing + " and " + tyype, List())
+          RuleTyperMatchConflict(conclusions.conclusions, range, "Disagreement about rune " + rune + "! " + existing + " and " + tyype, List.empty)
         }
       }
     }
@@ -100,7 +100,7 @@ class RuleTyperMatcher[Env, State](
 //  IRuleTyperMatchResult = {
 //    val actualTemplate =
 //      delegate.lookupTemplata(env, actualTemplateName) match {
-//        case None => return (RuleTyperMatchConflict(conclusions.conclusions, s"Couldn't find template '${actualTemplateName}'", List()))
+//        case None => return (RuleTyperMatchConflict(conclusions.conclusions, s"Couldn't find template '${actualTemplateName}'", List.empty))
 //        case Some(x) => x
 //      }
 //    // Check to see that the actual template matches the expected template
@@ -233,14 +233,14 @@ class RuleTyperMatcher[Env, State](
             val templexTemplateType =
               templateTemplexT.resultType match {
                 case ttt @ TemplateTemplataType(_, _) => ttt
-                case _ => return (RuleTyperMatchConflict(conclusions.conclusions, range, "Expected template call callee's to be a template but was " + templateTemplexT.resultType, List()))
+                case _ => return (RuleTyperMatchConflict(conclusions.conclusions, range, "Expected template call callee's to be a template but was " + templateTemplexT.resultType, List.empty))
               }
 
             (templexTemplateType.returnType, expectedType) match {
               case (a, b) if a == b =>
               // We can coerce kinds to coords, that's fine
               case (KindTemplataType, CoordTemplataType) =>
-              case _ => return (RuleTyperMatchConflict(conclusions.conclusions, range, "Expected template call callee's return type to be " + expectedType + " but was " + templexTemplateType.returnType, List()))
+              case _ => return (RuleTyperMatchConflict(conclusions.conclusions, range, "Expected template call callee's return type to be " + expectedType + " but was " + templexTemplateType.returnType, List.empty))
             }
             matchTypeAgainstTemplexesS(state, env, conclusions, range, templexTemplateType.paramTypes, templateArgs) match {
               case (rtec @ RuleTyperMatchConflict(_, _, _, _)) => return (RuleTyperMatchConflict(conclusions.conclusions, range, "Couldn't evaluate template call args!", List(rtec)))
@@ -288,7 +288,7 @@ class RuleTyperMatcher[Env, State](
 //      }
 //      case (OwnershipST(ownershipP), OwnershipTemplata(ownershipT)) => {
 //        if (ownershipT != Conversions.evaluateOwnership(ownershipP)) {
-//          (RuleTyperMatchConflict(conclusions.conclusions, s"Ownerships don't match: ${ownershipP} and ${ownershipT}", List()))
+//          (RuleTyperMatchConflict(conclusions.conclusions, s"Ownerships don't match: ${ownershipP} and ${ownershipT}", List.empty))
 //        } else {
 //          (RuleTyperMatchContinue(conclusions))
 //        }
@@ -393,7 +393,7 @@ class RuleTyperMatcher[Env, State](
         (RuleTyperMatchSuccess(()))
       }
       case (nonIntType, IntegerTemplataType) => {
-        (RuleTyperMatchConflict(conclusions.conclusions, range, "Expected an int, but was " + nonIntType, List()))
+        (RuleTyperMatchConflict(conclusions.conclusions, range, "Expected an int, but was " + nonIntType, List.empty))
       }
       case (MutabilityTemplataType, MutabilityTemplataType) => {
         (RuleTyperMatchSuccess(()))
@@ -409,20 +409,20 @@ class RuleTyperMatcher[Env, State](
       }
       case (TemplateTemplataType(paramTypes, returnType), TemplateTemplataType(expectedParamTypes, expectedReturnType)) => {
         if (paramTypes.size != expectedParamTypes.size) {
-          return (RuleTyperMatchConflict(conclusions.conclusions, range, "Received " + paramTypes.size + " template params but expected " + expectedParamTypes.size, List()))
+          return (RuleTyperMatchConflict(conclusions.conclusions, range, "Received " + paramTypes.size + " template params but expected " + expectedParamTypes.size, List.empty))
         }
         if (paramTypes != expectedParamTypes) {
-          return (RuleTyperMatchConflict(conclusions.conclusions, range, "Received " + paramTypes + " template params but expected " + expectedParamTypes, List()))
+          return (RuleTyperMatchConflict(conclusions.conclusions, range, "Received " + paramTypes + " template params but expected " + expectedParamTypes, List.empty))
         }
         if (returnType != expectedReturnType) {
-          return (RuleTyperMatchConflict(conclusions.conclusions, range, "Received " + returnType + " return type but expected " + expectedReturnType, List()))
+          return (RuleTyperMatchConflict(conclusions.conclusions, range, "Received " + returnType + " return type but expected " + expectedReturnType, List.empty))
         }
         (RuleTyperMatchSuccess(()))
       }
       //          // Is this right? Can't we look it up as a coord, like we did with KindTemplata/CoordTemplataType?
       //          case (InterfaceTemplata(_, interfaceS), KindTemplataType | CoordTemplataType) => {
       //            if (Inferer.interfaceIsTemplate(interfaceS)) {
-      //              RuleTyperMatchConflict(conclusions.conclusions, range, "Tried making a '" + name + "' but it's a template and no arguments were supplied!", List())
+      //              RuleTyperMatchConflict(conclusions.conclusions, range, "Tried making a '" + name + "' but it's a template and no arguments were supplied!", List.empty)
       //            } else {
       //              RuleTyperMatchSuccess(NameAT(name, expectedType))
       //            }
@@ -430,7 +430,7 @@ class RuleTyperMatcher[Env, State](
       //          // Is this right? Can't we look it up as a coord, like we did with KindTemplata/CoordTemplataType?
       //          case (StructTemplata(_, structS), KindTemplataType | CoordTemplataType) => {
       //            if (Inferer.structIsTemplate(structS)) {
-      //              RuleTyperMatchConflict(conclusions.conclusions, range, "Tried making a '" + name + "' but it's a template and no arguments were supplied!", List())
+      //              RuleTyperMatchConflict(conclusions.conclusions, range, "Tried making a '" + name + "' but it's a template and no arguments were supplied!", List.empty)
       //            } else {
       //              RuleTyperMatchSuccess(NameAT(name, expectedType))
       //            }
@@ -443,7 +443,7 @@ class RuleTyperMatcher[Env, State](
       //            val TemplateTemplataType(paramTypes, resultType) = delegate.getStructTemplataType(st)
       //            vimpl()
       //          }
-      case _ => (RuleTyperMatchConflict(conclusions.conclusions, range, "Given name doesn't match needed " + expectedType, List()))
+      case _ => (RuleTyperMatchConflict(conclusions.conclusions, range, "Given name doesn't match needed " + expectedType, List.empty))
     }
   }
 
@@ -528,7 +528,7 @@ class RuleTyperMatcher[Env, State](
       case (PrototypeTemplataType, PrototypeTypeSR) =>
       // When you add a case here, make sure you consider all combinations, and
       // add it to the above matches to note that you did.
-      case _ => return (RuleTyperMatchConflict(conclusions.conclusions, range, "Type from above (" + expectedType + ") didn't match type from rule (" + zrule.tyype + ")", List()))
+      case _ => return (RuleTyperMatchConflict(conclusions.conclusions, range, "Type from above (" + expectedType + ") didn't match type from rule (" + zrule.tyype + ")", List.empty))
     }
 
     val runeA = Astronomer.translateRune(rune)
@@ -560,7 +560,7 @@ class RuleTyperMatcher[Env, State](
     name match {
       case "passThroughIfConcrete" => {
         if (expectedType != KindTemplataType) {
-          return (RuleTyperMatchConflict(conclusions.conclusions, range, "passThroughIfConcrete returns a kind, but tried to match " + expectedType, List()))
+          return (RuleTyperMatchConflict(conclusions.conclusions, range, "passThroughIfConcrete returns a kind, but tried to match " + expectedType, List.empty))
         }
         val List(argRule) = argRules
         matchTypeAgainstRulexSR(state, env, conclusions, KindTemplataType, argRule) match {
@@ -570,7 +570,7 @@ class RuleTyperMatcher[Env, State](
       }
       case "passThroughIfInterface" => {
         if (expectedType != KindTemplataType) {
-          return (RuleTyperMatchConflict(conclusions.conclusions, range, "passThroughIfInterface returns a kind, but tried to match " + expectedType, List()))
+          return (RuleTyperMatchConflict(conclusions.conclusions, range, "passThroughIfInterface returns a kind, but tried to match " + expectedType, List.empty))
         }
         val List(argRule) = argRules
         matchTypeAgainstRulexSR(state, env, conclusions, KindTemplataType, argRule) match {
@@ -580,7 +580,7 @@ class RuleTyperMatcher[Env, State](
       }
       case "passThroughIfStruct" => {
         if (expectedType != KindTemplataType) {
-          return (RuleTyperMatchConflict(conclusions.conclusions, range, "passThroughIfStruct returns a kind, but tried to match " + expectedType, List()))
+          return (RuleTyperMatchConflict(conclusions.conclusions, range, "passThroughIfStruct returns a kind, but tried to match " + expectedType, List.empty))
         }
         val List(argRule) = argRules
         matchTypeAgainstRulexSR(state, env, conclusions, KindTemplataType, argRule) match {

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/templex.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/templex.scala
@@ -42,16 +42,16 @@ import scala.collection.immutable.List
 //object TemplexSUtils {
 //  def getDistinctOrderedRunesForTemplex(templex: ITemplexA): List[String] = {
 //    templex match {
-//      case IntAT(value) => List()
-//      case MutabilityAT(mutability) => List()
-//      case PermissionAT(permission) => List()
-//      case LocationAT(location) => List()
-//      case OwnershipAT(ownership) => List()
-//      case VariabilityAT(variability) => List()
-//      case BoolAT(value) => List()
-//      case NameAT(name) => List()
+//      case IntAT(value) => List.empty
+//      case MutabilityAT(mutability) => List.empty
+//      case PermissionAT(permission) => List.empty
+//      case LocationAT(location) => List.empty
+//      case OwnershipAT(ownership) => List.empty
+//      case VariabilityAT(variability) => List.empty
+//      case BoolAT(value) => List.empty
+//      case NameAT(name) => List.empty
 //      case RuneAT(rune) => List(rune)
-//      case AnonymousRuneAT() => List()
+//      case AnonymousRuneAT() => List.empty
 //      case InterpretedAT(_, inner) => getDistinctOrderedRunesForTemplex(inner)
 //      case CallAT(template, args) => {
 //        (template :: args).flatMap(getDistinctOrderedRunesForTemplex).distinct

--- a/Valestrom/Astronomer/test/net/verdagon/vale/astronomer/RuleTyperTests.scala
+++ b/Valestrom/Astronomer/test/net/verdagon/vale/astronomer/RuleTyperTests.scala
@@ -91,7 +91,7 @@ class RuleTyperTests extends FunSuite with Matchers {
               TemplexSR(
                 InterpretedST(RangeS.testZero,ConstraintP,ReadonlyP,NameST(RangeS.testZero, CodeTypeNameS("ImmInterface")))))),
           RangeS.testZero,
-          List(),
+          List.empty,
           None)
 
     vassert(conclusions.typeByRune(CodeRuneA("__C")) == CoordTemplataType)
@@ -112,7 +112,7 @@ class RuleTyperTests extends FunSuite with Matchers {
                 InterpretedST(
                   RangeS.testZero,WeakP,ReadonlyP,NameST(RangeS.testZero, CodeTypeNameS("ImmInterface")))))),
           RangeS.testZero,
-          List(),
+          List.empty,
           None)
 
     vassert(conclusions.typeByRune(CodeRuneA("__C")) == CoordTemplataType)
@@ -126,7 +126,7 @@ class RuleTyperTests extends FunSuite with Matchers {
           makeCannedEnvironment(),
           List(TypedSR(RangeS.testZero,CodeRuneS("C"), CoordTypeSR)),
           RangeS.testZero,
-          List(),
+          List.empty,
           None)
 
     vassert(conclusions.typeByRune(CodeRuneA("C")) == CoordTemplataType)
@@ -140,7 +140,7 @@ class RuleTyperTests extends FunSuite with Matchers {
           makeCannedEnvironment(),
           List(EqualsSR(RangeS.testZero,TypedSR(RangeS.testZero,CodeRuneS("C"), CoordTypeSR), TypedSR(RangeS.testZero,CodeRuneS("C"), KindTypeSR))),
           RangeS.testZero,
-          List(),
+          List.empty,
           None)
 
     vassert(isf.toString.contains("but previously concluded"))
@@ -154,7 +154,7 @@ class RuleTyperTests extends FunSuite with Matchers {
           makeCannedEnvironment(),
           List(EqualsSR(RangeS.testZero,TypedSR(RangeS.testZero,CodeRuneS("C"), CoordTypeSR), CallSR(RangeS.testZero,"toRef", List(TypedSR(RangeS.testZero,CodeRuneS("A"), KindTypeSR))))),
           RangeS.testZero,
-          List(),
+          List.empty,
           None)
 
     conclusions.typeByRune(CodeRuneA("C")) shouldEqual CoordTemplataType
@@ -170,7 +170,7 @@ class RuleTyperTests extends FunSuite with Matchers {
             TypedSR(RangeS.testZero,CodeRuneS("Z"),CoordTypeSR),
             EqualsSR(RangeS.testZero,TemplexSR(RuneST(RangeS.testZero,CodeRuneS("Z"))),TemplexSR(NameST(RangeS.testZero, CodeTypeNameS("int"))))),
           RangeS.testZero,
-          List(),
+          List.empty,
           None)
 
     conclusions.typeByRune(CodeRuneA("Z")) shouldEqual CoordTemplataType
@@ -185,7 +185,7 @@ class RuleTyperTests extends FunSuite with Matchers {
           List(
             EqualsSR(RangeS.testZero,TemplexSR(RuneST(RangeS.testZero,CodeRuneS("__RetRune"))),CallSR(RangeS.testZero,"toRef",List(TemplexSR(NameST(RangeS.testZero, CodeTypeNameS("MutStruct"))))))),
           RangeS.testZero,
-          List(),
+          List.empty,
           None)
 
     conclusions.typeByRune(CodeRuneA("__RetRune")) shouldEqual CoordTemplataType
@@ -201,7 +201,7 @@ class RuleTyperTests extends FunSuite with Matchers {
             TypedSR(RangeS.testZero,CodeRuneS("Z"),CoordTypeSR),
             EqualsSR(RangeS.testZero,TemplexSR(RuneST(RangeS.testZero,CodeRuneS("Z"))),CallSR(RangeS.testZero,"toRef", List(TemplexSR(NameST(RangeS.testZero, CodeTypeNameS("int"))))))),
           RangeS.testZero,
-          List(),
+          List.empty,
           None)
 
     vassert(conclusions.typeByRune(CodeRuneA("Z")) == CoordTemplataType)
@@ -218,7 +218,7 @@ class RuleTyperTests extends FunSuite with Matchers {
               TypedSR(RangeS.testZero,CodeRuneS("K"), KindTypeSR),
               TemplexSR(CallST(RangeS.testZero,NameST(RangeS.testZero, CodeTypeNameS("MutTInterface")),List(RuneST(RangeS.testZero,CodeRuneS("T"))))))),
           RangeS.testZero,
-          List(),
+          List.empty,
           None)
 
     vassert(conclusions.typeByRune(CodeRuneA("T")) == CoordTemplataType)
@@ -236,7 +236,7 @@ class RuleTyperTests extends FunSuite with Matchers {
               TypedSR(RangeS.testZero,CodeRuneS("X"),KindTypeSR),
               TemplexSR(CallST(RangeS.testZero,NameST(RangeS.testZero, CodeTypeNameS("MutTInterface")),List(RuneST(RangeS.testZero,CodeRuneS("T"))))))),
           RangeS.testZero,
-          List(),
+          List.empty,
           None)
 
     vassert(conclusions.typeByRune(CodeRuneA("T")) == CoordTemplataType)
@@ -491,7 +491,7 @@ class RuleTyperTests extends FunSuite with Matchers {
                 VariabilityST(RangeS.testZero,VaryingP),
                 IntST(RangeS.testZero,5),InterpretedST(RangeS.testZero,ShareP,ReadonlyP,NameST(RangeS.testZero, CodeTypeNameS("int"))))))),
         RangeS.testZero,
-        List(),
+        List.empty,
         None)
     conclusions.typeByRune(CodeRuneA("Z")) shouldEqual CoordTemplataType
   }
@@ -511,7 +511,7 @@ class RuleTyperTests extends FunSuite with Matchers {
                   InterpretedST(RangeS.testZero,ShareP,ReadonlyP, NameST(RangeS.testZero, CodeTypeNameS("int"))),
                   InterpretedST(RangeS.testZero,ShareP,ReadonlyP, NameST(RangeS.testZero, CodeTypeNameS("int")))))))),
         RangeS.testZero,
-        List(),
+        List.empty,
         None)
     conclusions.typeByRune(CodeRuneA("Z")) shouldEqual CoordTemplataType
   }
@@ -530,7 +530,7 @@ class RuleTyperTests extends FunSuite with Matchers {
             TypedSR(RangeS.testZero,CodeRuneS("K"), KindTypeSR),
             TemplexSR(CallST(RangeS.testZero,NameST(RangeS.testZero, CodeTypeNameS("Array")),List(RuneST(RangeS.testZero,CodeRuneS("M")), RuneST(RangeS.testZero,CodeRuneS("V")), RuneST(RangeS.testZero,CodeRuneS("T"))))))),
         RangeS.testZero,
-        List(),
+        List.empty,
         None)
     conclusions.typeByRune(CodeRuneA("M")) shouldEqual MutabilityTemplataType
     conclusions.typeByRune(CodeRuneA("V")) shouldEqual VariabilityTemplataType
@@ -548,7 +548,7 @@ class RuleTyperTests extends FunSuite with Matchers {
               TemplexSR(RuneST(RangeS.testZero,CodeRuneS("K"))),
               TemplexSR(NameST(RangeS.testZero, CodeTypeNameS("MutInterface"))))),
           RangeS.testZero,
-          List(),
+          List.empty,
           None)
     conclusions.typeByRune(CodeRuneA("K")) shouldEqual KindTemplataType
   }
@@ -568,7 +568,7 @@ class RuleTyperTests extends FunSuite with Matchers {
                 TemplexSR(PackST(RangeS.testZero,List(RuneST(RangeS.testZero,CodeRuneS("B"))))),
                 TemplexSR(RuneST(RangeS.testZero,CodeRuneS("C")))))),
           RangeS.testZero,
-          List(),
+          List.empty,
           None)
     conclusions.typeByRune(CodeRuneA("X")) shouldEqual PrototypeTemplataType
     conclusions.typeByRune(CodeRuneA("A")) shouldEqual StringTemplataType

--- a/Valestrom/Builtins/src/net/verdagon/vale/Builtins.scala
+++ b/Valestrom/Builtins/src/net/verdagon/vale/Builtins.scala
@@ -3,7 +3,7 @@ package net.verdagon.vale
 import scala.io.Source
 
 object Builtins {
-  val NAMESPACE_COORD = PackageCoordinate("", List())
+  val NAMESPACE_COORD = PackageCoordinate("", List.empty)
 
   val moduleToFilename =
     Map(

--- a/Valestrom/Driver/src/net/verdagon/vale/driver/Driver.scala
+++ b/Valestrom/Driver/src/net/verdagon/vale/driver/Driver.scala
@@ -18,13 +18,13 @@ import scala.io.Source
 import scala.util.matching.Regex
 
 object Driver {
-  val DEFAULT_PACKAGE_COORD = PackageCoordinate("my_module", List())
+  val DEFAULT_PACKAGE_COORD = PackageCoordinate("my_module", List.empty)
 
   sealed trait IValestromInput {
     def packageCoord: PackageCoordinate
   }
   case class ModulePathInput(moduleName: String, path: String) extends IValestromInput {
-    override def packageCoord: PackageCoordinate = PackageCoordinate(moduleName, List())
+    override def packageCoord: PackageCoordinate = PackageCoordinate(moduleName, List.empty)
   }
   case class DirectFilePathInput(packageCoord: PackageCoordinate, path: String) extends IValestromInput
   case class SourceInput(
@@ -93,7 +93,7 @@ object Driver {
                 val packageCoordinateParts = packageCoordStr.split("\\.")
                 PackageCoordinate(packageCoordinateParts.head, packageCoordinateParts.tail.toList)
               } else {
-                PackageCoordinate(packageCoordStr, List())
+                PackageCoordinate(packageCoordStr, List.empty)
               }
             val input =
               if (path.endsWith(".vale") || path.endsWith(".vpst")) {
@@ -133,7 +133,7 @@ object Driver {
 
     val sourceInputs =
       inputs.zipWithIndex.filter(_._1.packageCoord.module == module).flatMap({
-        case (SourceInput(_, name, code), index) if (packages == List()) => {
+        case (SourceInput(_, name, code), index) if (packages == List.empty) => {
           // All .vpst and .vale direct inputs are considered part of the root paackage.
           List((index + "(" + name + ")" -> code))
         }
@@ -238,7 +238,7 @@ object Driver {
 //        val paackage = List[String]()
 //        val filepathToCode =
 //          loadedInputsInModule.groupBy(_.path).map({
-//            case (path, List()) => vfail("No files with path: " + path)
+//            case (path, List.empty) => vfail("No files with path: " + path)
 //            case (path, List(onlyCodeWithThisFilename)) => (path -> onlyCodeWithThisFilename.code)
 //            case (path, multipleCodeWithThisFilename) => vfail("Multiple files with path " + path + ": " + multipleCodeWithThisFilename.mkString(", "))
 //          })
@@ -265,7 +265,7 @@ object Driver {
 //            }
 //          }
 //        } else if (filepath.endsWith(".vpst")) {
-//          (contents, List())
+//          (contents, List.empty)
 //        } else {
 //          throw new InputException("Unknown input type: " + filepath)
 //        }
@@ -429,7 +429,7 @@ object Driver {
 
   def main(args: Array[String]): Unit = {
     try {
-      val opts = parseOpts(Options(List(), List(), None, false, true, true, false, true, None, false), args.toList)
+      val opts = parseOpts(Options(List.empty, List.empty, None, false, true, true, false, true, None, false), args.toList)
       vcheck(opts.mode.nonEmpty, "No mode!", InputException)
       vcheck(opts.inputs.nonEmpty, "No input files!", InputException)
 
@@ -466,7 +466,7 @@ object Driver {
 
           val code =
             valeCodeMap.moduleToPackagesToFilenameToContents.values.flatMap(_.values.flatMap(_.values)).toList match {
-              case List() => throw InputException("No vale code given to highlight!")
+              case Nil => throw InputException("No vale code given to highlight!")
               case List(x) => x
               case _ => throw InputException("No vale code given to highlight!")
             }

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/CallHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/CallHammer.scala
@@ -247,18 +247,18 @@ object CallHammer {
   ExpressionH[KindH] = {
     val IfTE(condition2, thenBlock2, elseBlock2) = if2
 
-    val (conditionBlockH, List()) =
+    val (conditionBlockH, Nil) =
       ExpressionHammer.translate(hinputs, hamuts, currentFunctionHeader, parentLocals, condition2);
     vassert(conditionBlockH.resultType == ReferenceH(m.ShareH, InlineH, ReadonlyH, BoolH()))
 
     val thenLocals = LocalsBox(parentLocals.snapshot)
-    val (thenBlockH, List()) =
+    val (thenBlockH, Nil) =
       ExpressionHammer.translate(hinputs, hamuts, currentFunctionHeader, thenLocals, thenBlock2);
     val thenResultCoord = thenBlockH.resultType
     parentLocals.setNextLocalIdNumber(thenLocals.nextLocalIdNumber)
 
     val elseLocals = LocalsBox(parentLocals.snapshot)
-    val (elseBlockH, List()) =
+    val (elseBlockH, Nil) =
       ExpressionHammer.translate(hinputs, hamuts, currentFunctionHeader, elseLocals, elseBlock2);
     val elseResultCoord = elseBlockH.resultType
     parentLocals.setNextLocalIdNumber(elseLocals.nextLocalIdNumber)

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/ExpressionHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/ExpressionHammer.scala
@@ -26,30 +26,30 @@ object ExpressionHammer {
   ): (ExpressionH[KindH], List[ExpressionT]) = {
     expr2 match {
       case ConstantIntTE(value, bits) => {
-        (ConstantIntH(value, bits), List())
+        (ConstantIntH(value, bits), List.empty)
       }
       case VoidLiteralTE() => {
-        val constructH = NewStructH(List(), List(), ProgramH.emptyTupleStructType)
-        (constructH, List())
+        val constructH = NewStructH(List.empty, List.empty, ProgramH.emptyTupleStructType)
+        (constructH, List.empty)
       }
       case ConstantStrTE(value) => {
-        (ConstantStrH(value), List())
+        (ConstantStrH(value), List.empty)
       }
       case ConstantFloatTE(value) => {
-        (ConstantF64H(value), List())
+        (ConstantF64H(value), List.empty)
       }
       case ConstantBoolTE(value) => {
-        (ConstantBoolH(value), List())
+        (ConstantBoolH(value), List.empty)
       }
       case let2 @ LetNormalTE(_, _) => {
         val letH =
           LetHammer.translateLet(hinputs, hamuts, currentFunctionHeader, locals, let2)
-        (letH, List())
+        (letH, List.empty)
       }
       case let2 @ LetAndLendTE(_, _) => {
         val borrowAccess =
           LetHammer.translateLetAndLend(hinputs, hamuts, currentFunctionHeader, locals, let2)
-        (borrowAccess, List())
+        (borrowAccess, List.empty)
       }
       case des2 @ DestroyTE(_, _, _) => {
         val destroyH =
@@ -58,7 +58,7 @@ object ExpressionHammer {
         // uses registers internally to make that happen).
         // Since all the members landed in locals, we still need something to return, so we
         // return a void.
-        (destroyH, List())
+        (destroyH, List.empty)
       }
       case des2 @ DestroyStaticSizedArrayIntoLocalsTE(_, _, _) => {
         val destructureH =
@@ -67,36 +67,36 @@ object ExpressionHammer {
         // uses registers internally to make that happen).
         // Since all the members landed in locals, we still need something to return, so we
         // return a void.
-        (destructureH, List())
+        (destructureH, List.empty)
       }
       case unlet2 @ UnletTE(_) => {
         val valueAccess =
           LetHammer.translateUnlet(
             hinputs, hamuts, currentFunctionHeader, locals, unlet2)
-        (valueAccess, List())
+        (valueAccess, List.empty)
       }
       case mutate2 @ MutateTE(_, _) => {
         val newEmptyPackStructNodeLine =
           MutateHammer.translateMutate(hinputs, hamuts, currentFunctionHeader, locals, mutate2)
-        (newEmptyPackStructNodeLine, List())
+        (newEmptyPackStructNodeLine, List.empty)
       }
       case b @ BlockTE(_) => {
         val blockH =
           BlockHammer.translateBlock(hinputs, hamuts, currentFunctionHeader, locals, b)
-        (blockH, List())
+        (blockH, List.empty)
       }
       case call2 @ FunctionCallTE(callableExpr, args) => {
         val access =
           CallHammer.translateFunctionPointerCall(
             hinputs, hamuts, currentFunctionHeader, locals, callableExpr, args, call2.resultRegister.reference)
-        (access, List())
+        (access, List.empty)
       }
 
       case InterfaceFunctionCallTE(superFunctionHeader, resultType2, argsExprs2) => {
         val access =
           CallHammer.translateInterfaceFunctionCall(
             hinputs, hamuts, currentFunctionHeader, locals, superFunctionHeader, resultType2, argsExprs2)
-        (access, List())
+        (access, List.empty)
       }
 
       case ConsecutorTE(exprs) => {
@@ -106,7 +106,7 @@ object ExpressionHammer {
           vassert(nonLastResultLine.resultType == ProgramH.emptyTupleStructType)
         })
         vassert(deferreds.isEmpty) // curiosity, would we have any here?
-        (ConsecutorH(resultLines), List())
+        (ConsecutorH(resultLines), List.empty)
       }
 
       case PackTE(exprs, resultType, resultPackType) => {
@@ -130,7 +130,7 @@ object ExpressionHammer {
             translateDeferreds(hinputs, hamuts, currentFunctionHeader, locals, newStructNode, deferreds)
 
         // Export locals from inside the pack
-        (newStructNodeAndDeferredsExprH, List())
+        (newStructNodeAndDeferredsExprH, List.empty)
       }
 
       case ArrayLengthTE(arrayExpr2) => {
@@ -142,7 +142,7 @@ object ExpressionHammer {
         val arrayLengthAndDeferredsExprH =
           translateDeferreds(hinputs, hamuts, currentFunctionHeader, locals, lengthResultNode, deferreds)
 
-        (arrayLengthAndDeferredsExprH, List())
+        (arrayLengthAndDeferredsExprH, List.empty)
       }
 
       case LockWeakTE(innerExpr2, resultOptBorrowType2, someConstructor, noneConstructor) => {
@@ -186,7 +186,7 @@ object ExpressionHammer {
         val newStructAndDeferredsExprH =
             translateDeferreds(hinputs, hamuts, currentFunctionHeader, locals, newStructNode, deferreds)
 
-        (newStructAndDeferredsExprH, List())
+        (newStructAndDeferredsExprH, List.empty)
       }
 
       case StaticArrayFromValuesTE(exprs, arrayReference2, arrayType2) => {
@@ -207,7 +207,7 @@ object ExpressionHammer {
         val newStructAndDeferredsExprH =
         translateDeferreds(hinputs, hamuts, currentFunctionHeader, locals, newStructNode, deferreds)
 
-        (newStructAndDeferredsExprH, List())
+        (newStructAndDeferredsExprH, List.empty)
       }
 
       case ConstructTE(structRef2, resultType2, memberExprs) => {
@@ -232,7 +232,7 @@ object ExpressionHammer {
         val newStructAndDeferredsExprH =
             translateDeferreds(hinputs, hamuts, currentFunctionHeader, locals, newStructNode, deferreds)
 
-        (newStructAndDeferredsExprH, List())
+        (newStructAndDeferredsExprH, List.empty)
       }
 
       case load2 @ SoftLoadTE(_, _, _) => {
@@ -244,7 +244,7 @@ object ExpressionHammer {
       case lookup2 @ LocalLookupT(_,AddressibleLocalVariableT(_, _, _), _, _) => {
         val loadBoxAccess =
           LoadHammer.translateLocalAddress(hinputs, hamuts, currentFunctionHeader, locals, lookup2)
-        (loadBoxAccess, List())
+        (loadBoxAccess, List.empty)
       }
 
       case lookup2 @ AddressMemberLookupT(_,_, _, _, _) => {
@@ -256,21 +256,21 @@ object ExpressionHammer {
       case if2 @ IfTE(_, _, _) => {
         val maybeAccess =
           CallHammer.translateIf(hinputs, hamuts, currentFunctionHeader, locals, if2)
-        (maybeAccess, List())
+        (maybeAccess, List.empty)
       }
 
       case ca2 @ ConstructArrayTE(_, _, _, _) => {
         val access =
           CallHammer.translateConstructArray(
             hinputs, hamuts, currentFunctionHeader, locals, ca2)
-        (access, List())
+        (access, List.empty)
       }
 
       case ca2 @ StaticArrayFromCallableTE(_, _, _) => {
         val access =
           CallHammer.translateStaticArrayFromCallable(
             hinputs, hamuts, currentFunctionHeader, locals, ca2)
-        (access, List())
+        (access, List.empty)
       }
 
       case TemplarReinterpretTE(innerExpr, resultType2) => {
@@ -328,7 +328,7 @@ object ExpressionHammer {
             translateDeferreds(
               hinputs, hamuts, currentFunctionHeader, locals, checkRefCountH, numExprDeferreds ++ refExprDeferreds)
 
-        (checkRefCountAndDeferredsH, List())
+        (checkRefCountAndDeferredsH, List.empty)
       }
 
       case up @ InterfaceToInterfaceUpcastTE(innerExpr, targetInterfaceRef2) => {
@@ -381,13 +381,13 @@ object ExpressionHammer {
       case ExternFunctionCallTE(prototype2, argsExprs2) => {
         val access =
           CallHammer.translateExternFunctionCall(hinputs, hamuts, currentFunctionHeader, locals, prototype2, argsExprs2)
-        (access, List())
+        (access, List.empty)
       }
 
       case while2 @ WhileTE(_) => {
         val whileH =
             CallHammer.translateWhile(hinputs, hamuts, currentFunctionHeader, locals, while2)
-        (whileH, List())
+        (whileH, List.empty)
       }
 
       case DeferTE(innerExpr, deferredExpr) => {
@@ -403,7 +403,7 @@ object ExpressionHammer {
         val innerExprH = DiscardH(undiscardedInnerExprH)
         val innerWithDeferredsExprH =
           translateDeferreds(hinputs, hamuts, currentFunctionHeader, locals, innerExprH, innerDeferreds)
-        (innerWithDeferredsExprH, List())
+        (innerWithDeferredsExprH, List.empty)
       }
       case ReturnTE(innerExpr) => {
         val (innerExprResultLine, innerDeferreds) =
@@ -417,28 +417,28 @@ object ExpressionHammer {
         vassert(
           innerExpr.resultRegister.kind == NeverT() ||
           innerExpr.resultRegister.reference == currentFunctionHeader.returnType)
-        (ReturnH(innerWithDeferreds), List())
+        (ReturnH(innerWithDeferreds), List.empty)
       }
       case ArgLookupTE(paramIndex, type2) => {
         val typeH = TypeHammer.translateReference(hinputs, hamuts, type2)
         vassert(currentFunctionHeader.paramTypes(paramIndex) == type2)
         vassert(TypeHammer.translateReference(hinputs, hamuts, currentFunctionHeader.paramTypes(paramIndex)) == typeH)
         val argNode = ArgumentH(typeH, paramIndex)
-        (argNode, List())
+        (argNode, List.empty)
       }
 
       case das2 @ DestroyStaticSizedArrayIntoFunctionTE(_, _, _, _) => {
         val dasH =
             CallHammer.translateDestroyStaticSizedArray(
               hinputs, hamuts, currentFunctionHeader, locals, das2)
-        (dasH, List())
+        (dasH, List.empty)
       }
 
       case das2 @ DestroyRuntimeSizedArrayTE(_, _, _, _) => {
         val drsaH =
             CallHammer.translateDestroyRuntimeSizedArray(
               hinputs, hamuts, currentFunctionHeader, locals, das2)
-        (drsaH, List())
+        (drsaH, List.empty)
       }
 
       case UnreachableMootTE(innerExpr) => {
@@ -451,7 +451,7 @@ object ExpressionHammer {
         // theyll never get run anyway.
         // We only translated them above to mark unstackified things unstackified.
 
-        (innerWithDeferredsH, List())
+        (innerWithDeferredsH, List.empty)
       }
 
       case WeakAliasTE(innerExpr) => {
@@ -474,7 +474,7 @@ object ExpressionHammer {
         val resultLine = IsSameInstanceH(leftExprResultLine, rightExprResultLine)
 
         val expr = translateDeferreds(hinputs, hamuts, currentFunctionHeader, locals, resultLine, leftDeferreds ++ rightDeferreds)
-        (expr, List())
+        (expr, List.empty)
       }
 
       case AsSubtypeTE(leftExprT, targetSubtype, resultOptType, someConstructor, noneConstructor) => {
@@ -535,7 +535,7 @@ object ExpressionHammer {
 
     val newExprs =
       if (originalExpr.resultType == ProgramH.emptyTupleStructType) {
-        val void = NewStructH(List(), List(), ProgramH.emptyTupleStructType)
+        val void = NewStructH(List.empty, List.empty, ProgramH.emptyTupleStructType)
         originalExpr :: (deferredExprs :+ void)
       } else {
         val temporaryResultLocal = locals.addHammerLocal(originalExpr.resultType, m.Final)
@@ -557,7 +557,7 @@ object ExpressionHammer {
       exprs2: List[ExpressionT]):
   (List[ExpressionH[KindH]], List[ExpressionT]) = {
     exprs2 match {
-      case Nil => (List(), List())
+      case Nil => (List.empty, List.empty)
       case firstExpr :: restExprs => {
         val (firstResultLine, firstDeferreds) =
           translate(hinputs, hamuts, currentFunctionHeader, locals, firstExpr);
@@ -578,7 +578,7 @@ object ExpressionHammer {
     exprs2: List[ExpressionT]):
   List[ExpressionH[KindH]] = {
     exprs2 match {
-      case Nil => List()
+      case Nil => List.empty
       case firstExpr :: restExprs => {
         val (firstResultLine, firstDeferreds) =
           translate(hinputs, hamuts, currentFunctionHeader, locals, firstExpr);

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/FunctionHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/FunctionHammer.scala
@@ -46,7 +46,7 @@ object FunctionHammer {
               Set[VariableIdH](),
               Map[VariableIdH,Local](),
               1));
-        val (bodyH, List()) =
+        val (bodyH, Nil) =
           ExpressionHammer.translate(hinputs, hamuts, header, locals, body)
         vassert(locals.unstackifiedVars.size == locals.locals.size)
         val resultCoord = bodyH.resultType

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/Hammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/Hammer.scala
@@ -159,7 +159,7 @@ object Hammer {
       functionExterns) = hinputs
 
 
-    val hamuts = HamutsBox(Hamuts(Map(), Map(), Map(), List(), List(), List(), Map(), Map(), Map(), Map(), Map(), Map(), Map(), Map()))
+    val hamuts = HamutsBox(Hamuts(Map(), Map(), Map(), List.empty, List.empty, List.empty, Map(), Map(), Map(), Map(), Map(), Map(), Map(), Map()))
     val emptyPackStructRefH = StructHammer.translateStructRef(hinputs, hamuts, emptyPackStructRef)
     vassert(emptyPackStructRefH == ProgramH.emptyTupleStructRef)
 
@@ -264,10 +264,10 @@ object Hammer {
         packageCoord ->
           PackageH(
             packageToInterfaceDefs.getOrElse(packageCoord, Map()).values.toList,
-            packageToStructDefs.getOrElse(packageCoord, List()),
-            packageToFunctionDefs.getOrElse(packageCoord, List()),
-            packageToStaticSizedArrays.getOrElse(packageCoord, List()),
-            packageToRuntimeSizedArrays.getOrElse(packageCoord, List()),
+            packageToStructDefs.getOrElse(packageCoord, List.empty),
+            packageToFunctionDefs.getOrElse(packageCoord, List.empty),
+            packageToStaticSizedArrays.getOrElse(packageCoord, List.empty),
+            packageToRuntimeSizedArrays.getOrElse(packageCoord, List.empty),
             packageToImmDestructorPrototypes.getOrElse(packageCoord, Map()),
             packageToExportNameToFunction.getOrElse(packageCoord, Map()),
             packageToExportNameToKind.getOrElse(packageCoord, Map()),

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/LetHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/LetHammer.scala
@@ -115,7 +115,7 @@ object LetHammer {
     val stackifyH =
       translateAddressibleLet(
         hinputs, hamuts, currentFunctionHeader, locals, sourceExprResultLine, sourceResultPointerTypeH, varId, variability, reference)
-    val (borrowAccess, List()) =
+    val (borrowAccess, Nil) =
       LoadHammer.translateAddressibleLocalLoad(
         hinputs,
         hamuts,
@@ -173,7 +173,7 @@ object LetHammer {
           varId,
           variability)
 
-    val (borrowAccess, List()) =
+    val (borrowAccess, Nil) =
       LoadHammer.translateMundaneLocalLoad(
         hinputs,
         hamuts,
@@ -301,9 +301,9 @@ object LetHammer {
     // However, the templar only supplied variables for the reference members,
     // so we need to introduce our own local variables here.
 
-    // We put List() here to make sure that we've consumed all the destination
+    // We put List.empty here to make sure that we've consumed all the destination
     // reference local variables.
-    val (List(), localTypes, localIndices) =
+    val (Nil, localTypes, localIndices) =
       structDef2.members.foldLeft((destinationReferenceLocalVariables, List[ReferenceH[KindH]](), List[Local]()))({
         case ((remainingDestinationReferenceLocalVariables, previousLocalTypes, previousLocalIndices), member2) => {
           member2.tyype match {
@@ -348,7 +348,7 @@ object LetHammer {
       structDef2.members.zip(localTypes.zip(localIndices)).flatMap({
         case (structMember2, (localType, local)) => {
           structMember2.tyype match {
-            case ReferenceMemberTypeT(_) => List()
+            case ReferenceMemberTypeT(_) => List.empty
             case AddressMemberTypeT(_) => {
               // localType is the box type.
               // First, unlet it, then discard the contents.

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/LoadHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/LoadHammer.scala
@@ -301,7 +301,7 @@ object LoadHammer {
           localTypeH,
           loadResultType,
           NameHammer.addStep(hamuts, boxStructRefH.fullName, StructHammer.BOX_MEMBER_NAME))
-    (loadedNode, List())
+    (loadedNode, List.empty)
   }
 
   def translateMundaneLocalLoad(
@@ -336,7 +336,7 @@ object LoadHammer {
           targetOwnership,
           targetPermission,
           NameHammer.translateFullName(hinputs, hamuts, varId))
-    (loadedNode, List())
+    (loadedNode, List.empty)
   }
 
   def translateLocalAddress(

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/MutateHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/MutateHammer.scala
@@ -240,7 +240,7 @@ object MutateHammer {
           StructHammer.BOX_MEMBER_INDEX,
           sourceExprResultLine,
           NameHammer.addStep(hamuts, boxStructRefH.fullName, StructHammer.BOX_MEMBER_NAME))
-    (storeNode, List())
+    (storeNode, List.empty)
   }
 
   private def translateMundaneLocalMutate(
@@ -258,6 +258,6 @@ object MutateHammer {
           local,
           sourceExprResultLine,
           NameHammer.translateFullName(hinputs, hamuts, varId))
-    (newStoreNode, List())
+    (newStoreNode, List.empty)
   }
 }

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/StructHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/StructHammer.scala
@@ -76,7 +76,7 @@ object StructHammer {
             maybeExport.nonEmpty,
             interfaceDef2.weakable,
             Conversions.evaluateMutability(interfaceDef2.mutability),
-            List() /* super interfaces */,
+            List.empty /* super interfaces */,
             methodsH)
         hamuts.addInterface(interfaceRef2, interfaceDefH)
         vassert(interfaceDefH.getRef == temporaryInterfaceRefH)
@@ -127,7 +127,7 @@ object StructHammer {
             if (structRef2 != Program2.emptyTupleStructRef) {
               vassertSome(
                 hinputs.functions.find(function => {
-                  function.header.fullName == FullNameT(PackageCoordinate.BUILTIN, List(), ImmConcreteDestructorNameT(structRef2))
+                  function.header.fullName == FullNameT(PackageCoordinate.BUILTIN, List.empty, ImmConcreteDestructorNameT(structRef2))
                 }))
             }
           }
@@ -170,7 +170,7 @@ object StructHammer {
     type2: CoordT,
     typeH: ReferenceH[KindH]):
   (StructRefH) = {
-    val boxFullName2 = FullNameT(PackageCoordinate.BUILTIN, List(), CitizenNameT(BOX_HUMAN_NAME, List(CoordTemplata(type2))))
+    val boxFullName2 = FullNameT(PackageCoordinate.BUILTIN, List.empty, CitizenNameT(BOX_HUMAN_NAME, List(CoordTemplata(type2))))
     val boxFullNameH = NameHammer.translateFullName(hinputs, hamuts, boxFullName2)
     hamuts.structDefsByRef2.find(_._2.fullName == boxFullNameH) match {
       case Some((_, structDefH)) => (structDefH.getRef)
@@ -193,7 +193,7 @@ object StructHammer {
             false,
             false,
             m.Mutable,
-            List(),
+            List.empty,
             List(memberH));
         hamuts.addStructOriginatingFromHammer(structDefH)
         vassert(structDefH.getRef == temporaryStructRefH)

--- a/Valestrom/Hammer/test/net/verdagon/vale/hammer/HammerTest.scala
+++ b/Valestrom/Hammer/test/net/verdagon/vale/hammer/HammerTest.scala
@@ -20,7 +20,7 @@ class HammerTest extends FunSuite with Matchers {
     }
     a match {
       case p : Product => p.productIterator.flatMap(x => recursiveCollect(x, partialFunction)).toList
-      case _ => List()
+      case _ => List.empty
     }
   }
 

--- a/Valestrom/Highlighter/src/net/verdagon/vale/highlighter/Highlighter.scala
+++ b/Valestrom/Highlighter/src/net/verdagon/vale/highlighter/Highlighter.scala
@@ -6,7 +6,7 @@ import net.verdagon.vale.{vassert, vfail}
 object Highlighter {
   def min(positions: List[Int]): Int = {
     positions match {
-      case List() => vfail()
+      case Nil => vfail()
       case List(p) => p
       case head :: tail => {
         val minOfTail = min(tail)

--- a/Valestrom/Highlighter/src/net/verdagon/vale/highlighter/Spanner.scala
+++ b/Valestrom/Highlighter/src/net/verdagon/vale/highlighter/Spanner.scala
@@ -75,7 +75,7 @@ object Spanner {
     makeSpan(
       Interface,
       range,
-      makeSpan(StructName, name.range, List()) ::
+      makeSpan(StructName, name.range, List.empty) ::
       members.map(forFunction))
   }
 
@@ -94,7 +94,7 @@ object Spanner {
     makeSpan(
       Struct,
       range,
-      makeSpan(StructName, nameRange, List()) ::
+      makeSpan(StructName, nameRange, List.empty) ::
       maybeIdentifyingRunesP.toList.map(forIdentifyingRunes) ++
       maybeTemplateRulesP.toList.map(forTemplateRules) ++
       List(
@@ -117,7 +117,7 @@ object Spanner {
       Memb,
       range,
       List(
-        makeSpan(MembName, nameRange, List()),
+        makeSpan(MembName, nameRange, List.empty),
         forTemplex(tyype)))
   }
 
@@ -135,7 +135,7 @@ object Spanner {
     makeSpan(
       Ret,
       range,
-      maybeInferRet.toList.map({ case UnitP(range) => makeSpan(Ret, range, List()) }) ++
+      maybeInferRet.toList.map({ case UnitP(range) => makeSpan(Ret, range, List.empty) }) ++
       maybeRetType.toList.map(forTemplex))
   }
 
@@ -161,15 +161,15 @@ object Spanner {
 
   def forExpression(e: IExpressionPE): Span = {
     e match {
-      case ConstantIntPE(range, _, _) => makeSpan(Num, range, List())
-      case ConstantStrPE(range, _) => makeSpan(Str, range, List())
-      case ConstantBoolPE(range, _) => makeSpan(Bool, range, List())
-      case VoidPE(range) => makeSpan(W, range, List())
+      case ConstantIntPE(range, _, _) => makeSpan(Num, range, List.empty)
+      case ConstantStrPE(range, _) => makeSpan(Str, range, List.empty)
+      case ConstantBoolPE(range, _) => makeSpan(Bool, range, List.empty)
+      case VoidPE(range) => makeSpan(W, range, List.empty)
       case MagicParamLookupPE(range) => {
         makeSpan(
           MagicParam,
           range,
-          List())
+          List.empty)
       }
       case LambdaPE(captures, FunctionP(range, FunctionHeaderP(_, None, _, _, _, params, _), body)) => {
         makeSpan(
@@ -184,7 +184,7 @@ object Spanner {
           List(forPattern(pattern), forExpression(expr)))
       }
       case LookupPE(NameP(range, _), templateArgs) => {
-        makeSpan(Lookup, range, List())
+        makeSpan(Lookup, range, List.empty)
       }
       case TuplePE(range, elements) => {
         makeSpan(Seq, range, elements.map(forExpression))
@@ -199,7 +199,7 @@ object Spanner {
           mutability.map(forTemplex).toList ++
           variability.map(forTemplex).toList ++
           (size match {
-            case RuntimeSizedP => List()
+            case RuntimeSizedP => List.empty
             case StaticSizedP(sizePT) => {
               sizePT.map(forTemplex).toList
             }
@@ -216,7 +216,7 @@ object Spanner {
         makeSpan(
           MemberAccess,
           range,
-          List(forExpression(left), makeSpan(MemberAccess, operatorRange)) :+ makeSpan(Lookup, member.range, List()))
+          List(forExpression(left), makeSpan(MemberAccess, operatorRange)) :+ makeSpan(Lookup, member.range, List.empty))
       }
       case LendPE(range, expr, targetOwnership) => {
         makeSpan(
@@ -232,16 +232,16 @@ object Spanner {
       }
       case MethodCallPE(range, inline, callableExpr, operatorRange, _, _, LookupPE(NameP(methodNameRange, _), maybeTemplateArgs), argExprs) => {
         val callableSpan = forExpression(callableExpr)
-        val methodSpan = makeSpan(CallLookup, methodNameRange, List())
+        val methodSpan = makeSpan(CallLookup, methodNameRange, List.empty)
         val maybeTemplateArgsSpan = maybeTemplateArgs.toList.map(forTemplateArgs)
         val argSpans = argExprs.map(forExpression)
         val allSpans = (callableSpan :: makeSpan(MemberAccess, operatorRange) :: methodSpan :: (maybeTemplateArgsSpan ++ argSpans))
         makeSpan(Call, range, allSpans)
       }
       case FunctionCallPE(range, inlRange, operatorRange, _, LookupPE(NameP(nameRange, _), maybeTemplateArgs), argExprs, _) => {
-        val inlSpan = inlRange.toList.map(x => makeSpan(Inl, x.range, List()))
+        val inlSpan = inlRange.toList.map(x => makeSpan(Inl, x.range, List.empty))
         val opSpan = makeSpan(MemberAccess, operatorRange)
-        val callableSpan = makeSpan(CallLookup, nameRange, List())
+        val callableSpan = makeSpan(CallLookup, nameRange, List.empty)
         val maybeTemplateArgsSpan = maybeTemplateArgs.toList.map(forTemplateArgs)
         val argSpans = argExprs.map(forExpression)
         val allSpans =
@@ -301,7 +301,7 @@ object Spanner {
     makeSpan(
       Pat,
       range,
-      maybePreBorrow.toList.map(b => makeSpan(Lend, b.range, List())) ++
+      maybePreBorrow.toList.map(b => makeSpan(Lend, b.range, List.empty)) ++
       capture.toList.map(forCapture) ++
       templex.toList.map(forTemplex) ++
       maybeDestructure.toList.map(forDestructure))
@@ -320,10 +320,10 @@ object Spanner {
     val nameSpan =
       name match {
         case LocalNameP(NameP(nameRange, _)) => {
-          makeSpan(CaptureName, nameRange, List())
+          makeSpan(CaptureName, nameRange, List.empty)
         }
         case ConstructingMemberNameP(NameP(nameRange, _)) => {
-          makeSpan(CaptureName, nameRange, List())
+          makeSpan(CaptureName, nameRange, List.empty)
         }
       }
     makeSpan(
@@ -335,7 +335,7 @@ object Spanner {
   def forTemplex(t: ITemplexPT): Span = {
     t match {
       case NameOrRunePT(NameP(range, _)) => {
-        makeSpan(Typ, range, List())
+        makeSpan(Typ, range, List.empty)
       }
       case InlinePT(range, inner) => {
         makeSpan(Inl, range, List(forTemplex(inner)))
@@ -353,7 +353,7 @@ object Spanner {
         makeSpan(
           Num,
           range,
-          List())
+          List.empty)
       }
       case CallPT(range, template, args) => {
         makeSpan(
@@ -386,7 +386,7 @@ object Spanner {
     makeSpan(
       Rules,
       rulex.range,
-      List())
+      List.empty)
   }
 
   def forIdentifyingRunes(r: IdentifyingRunesP): Span = {
@@ -397,7 +397,7 @@ object Spanner {
       runes.map(rune => makeSpan(IdentRune, rune.range)))
   }
 
-  def makeSpan(classs: IClass, range: Range, children: List[Span] = List()) = {
+  def makeSpan(classs: IClass, range: Range, children: List[Span] = List.empty) = {
     val filteredAndSortedChildren =
       children
         .filter(s => s.range.begin != s.range.end)

--- a/Valestrom/Highlighter/test/net/verdagon/vale/highlighter/SpannerTests.scala
+++ b/Valestrom/Highlighter/test/net/verdagon/vale/highlighter/SpannerTests.scala
@@ -17,11 +17,11 @@ class SpannerTests extends FunSuite with Matchers {
     val main = program1.lookupFunction("main")
     Spanner.forFunction(main) shouldEqual
       Span(Fn,Range(0,25),List(
-        Span(FnName,Range(3,7),List()),
-        Span(Params,Range(7,9),List()),
-        Span(Ret,Range(10,20),List(Span(Ret,Range(10,19),List()))),
+        Span(FnName,Range(3,7),List.empty),
+        Span(Params,Range(7,9),List.empty),
+        Span(Ret,Range(10,20),List(Span(Ret,Range(10,19),List.empty))),
         Span(Block,Range(20,25),List(
-          Span(Num,Range(22,23),List())))))
+          Span(Num,Range(22,23),List.empty)))))
   }
 
 
@@ -36,20 +36,20 @@ class SpannerTests extends FunSuite with Matchers {
       case Span(
         Fn,_,
         List(
-          Span(FnName,_,List()),
-          Span(Params,_,List()),
-          Span(Ret,_,List(Span(Ret,_,List()))),
+          Span(FnName,_,Nil),
+          Span(Params,_,Nil),
+          Span(Ret,_,List(Span(Ret,_,Nil))),
           Span(Block,_,
             List(
               Span(Call,_,
                 List(
                   Span(MemberAccess,_,
                     List(
-                      Span(Lookup,_,List()),
-                      Span(MemberAccess,_,List()),
-                      Span(Lookup,_,List()))),
-                  Span(MemberAccess,_,List()),
-                  Span(CallLookup,_,List()))))))) =>
+                      Span(Lookup,_,Nil),
+                      Span(MemberAccess,_,Nil),
+                      Span(Lookup,_,Nil))),
+                  Span(MemberAccess,_,Nil),
+                  Span(CallLookup,_,Nil))))))) =>
     }
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/BlockTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/BlockTests.scala
@@ -17,7 +17,7 @@ class BlockTests extends FunSuite with Matchers {
         |  = 3;
         |}
       """.stripMargin)
-    val scoutput = compile.getScoutput().getOrDie().moduleToPackagesToFilenameToContents("test")(List())("0.vale")
+    val scoutput = compile.getScoutput().getOrDie().moduleToPackagesToFilenameToContents("test")(List.empty)("0.vale")
     val main = scoutput.lookupFunction("main")
     main.body match { case CodeBody1(BodySE(_, _,BlockSE(_, _,List(BlockSE(_, _,_), _)))) => }
 
@@ -33,7 +33,7 @@ class BlockTests extends FunSuite with Matchers {
         |  = 3;
         |}
       """.stripMargin)
-    val scoutput = compile.getScoutput().getOrDie().moduleToPackagesToFilenameToContents("test")(List())("0.vale")
+    val scoutput = compile.getScoutput().getOrDie().moduleToPackagesToFilenameToContents("test")(List.empty)("0.vale")
     val main = scoutput.lookupFunction("main")
     val block = main.body match { case CodeBody1(BodySE(_, _,BlockSE(_, _,List(b @ BlockSE(_, _,_), _)))) => b }
     vassert(block.locals.size == 1)

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ClosureTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ClosureTests.scala
@@ -115,7 +115,7 @@ class ClosureTests extends FunSuite with Matchers {
         ReferenceLocalVariableT(
           FullNameT(_, List(FunctionNameT("main",_,_), LambdaCitizenNameT(_), FunctionNameT("__call",_,_)), ClosureParamNameT()),
           FinalT,
-          CoordT(ShareT,ReadonlyT,StructRefT(FullNameT(_, List(FunctionNameT("main",List(),List())),LambdaCitizenNameT(_))))),
+          CoordT(ShareT,ReadonlyT,StructRefT(FullNameT(_, List(FunctionNameT("main",Nil, Nil)),LambdaCitizenNameT(_))))),
         ReferenceLocalVariableT(
           FullNameT(_, List(FunctionNameT("main",_,_), LambdaCitizenNameT(_), FunctionNameT("__call",_,_)),TemplarBlockResultVarNameT(0)),
           FinalT,
@@ -154,14 +154,14 @@ class ClosureTests extends FunSuite with Matchers {
           }
         }))
     lambdaCall.header.paramTypes.head match {
-      case CoordT(ShareT, ReadonlyT, StructRefT(FullNameT(_, List(FunctionNameT("main",List(),List())),LambdaCitizenNameT(_)))) =>
+      case CoordT(ShareT, ReadonlyT, StructRefT(FullNameT(_, List(FunctionNameT("main",Nil,Nil)),LambdaCitizenNameT(_)))) =>
     }
     lambdaCall.header.returnType shouldEqual CoordT(ShareT, ReadonlyT, IntT.i32)
 
     // Make sure we make it with a function pointer and a constructed vars struct
     val main = temputs.lookupFunction("main")
     main.only({
-      case ConstructTE(StructRefT(FullNameT(_, List(FunctionNameT("main",List(),List())),LambdaCitizenNameT(_))), _, _) =>
+      case ConstructTE(StructRefT(FullNameT(_, List(FunctionNameT("main",Nil,Nil)),LambdaCitizenNameT(_))), _, _) =>
     })
 
     // Make sure we call the function somewhere
@@ -193,7 +193,7 @@ class ClosureTests extends FunSuite with Matchers {
     val lambda = temputs.lookupLambdaIn("main")
     lambda.only({
       case MutateTE(
-        AddressMemberLookupT(_,_,FullNameT(_, List(FunctionNameT("main",List(),List()), LambdaCitizenNameT(_)),CodeVarNameT("x")),CoordT(ShareT,ReadonlyT, IntT.i32), _),
+        AddressMemberLookupT(_,_,FullNameT(_, List(FunctionNameT("main",Nil,Nil), LambdaCitizenNameT(_)),CodeVarNameT("x")),CoordT(ShareT,ReadonlyT, IntT.i32), _),
         _) =>
     })
 

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/HammerTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/HammerTests.scala
@@ -91,7 +91,7 @@ class HammerTests extends FunSuite with Matchers {
     val packageH = compile.getHamuts().lookupPackage(PackageCoordinate.TEST_TLD)
     val main = packageH.lookupFunction("main")
     main.body match {
-      case BlockH(CallH(PrototypeH(fullNameH, List(), ReferenceH(_, _, ReadonlyH, NeverH())), List())) => {
+      case BlockH(CallH(PrototypeH(fullNameH, Nil, ReferenceH(_, _, ReadonlyH, NeverH())), Nil)) => {
         vassert(fullNameH.toFullString().contains("__panic"))
       }
     }
@@ -142,20 +142,20 @@ class HammerTests extends FunSuite with Matchers {
   test("Tests exports from two modules, different names") {
     val compile =
       new RunCompilation(
-        List(PackageCoordinate.BUILTIN, PackageCoordinate("moduleA", List()), PackageCoordinate("moduleB", List())),
+        List(PackageCoordinate.BUILTIN, PackageCoordinate("moduleA", List.empty), PackageCoordinate("moduleB", List.empty)),
         Builtins.getCodeMap()
           .or(
             FileCoordinateMap(Map())
-              .add("moduleA", List(), "StructA.vale", "struct StructA export { a int; }")
-              .add("moduleB", List(), "StructB.vale", "struct StructB export { a int; }"))
+              .add("moduleA", List.empty, "StructA.vale", "struct StructA export { a int; }")
+              .add("moduleB", List.empty, "StructB.vale", "struct StructB export { a int; }"))
           .or(Tests.getPackageToResourceResolver),
         FullCompilationOptions())
     val hamuts = compile.getHamuts()
 
-    val packageA = hamuts.lookupPackage(PackageCoordinate("moduleA", List()))
+    val packageA = hamuts.lookupPackage(PackageCoordinate("moduleA", List.empty))
     val fullNameA = vassertSome(packageA.exportNameToKind.get("StructA"))
 
-    val packageB = hamuts.lookupPackage(PackageCoordinate("moduleB", List()))
+    val packageB = hamuts.lookupPackage(PackageCoordinate("moduleB", List.empty))
     val fullNameB = vassertSome(packageB.exportNameToKind.get("StructB"))
 
     vassert(fullNameA != fullNameB)
@@ -165,20 +165,20 @@ class HammerTests extends FunSuite with Matchers {
 //  test("Tests exports from two modules, same name") {
 //    val compile =
 //      new RunCompilation(
-//        List(PackageCoordinate.BUILTIN, PackageCoordinate("moduleA", List()), PackageCoordinate("moduleB", List())),
+//        List(PackageCoordinate.BUILTIN, PackageCoordinate("moduleA", List.empty), PackageCoordinate("moduleB", List.empty)),
 //        Builtins.getCodeMap()
 //          .or(
 //            FileCoordinateMap(Map())
-//              .add("moduleA", List(), "MyStruct.vale", "struct MyStruct export { a int; }")
-//              .add("moduleB", List(), "MyStruct.vale", "struct MyStruct export { a int; }"))
+//              .add("moduleA", List.empty, "MyStruct.vale", "struct MyStruct export { a int; }")
+//              .add("moduleB", List.empty, "MyStruct.vale", "struct MyStruct export { a int; }"))
 //          .or(Tests.getPackageToResourceResolver),
 //        FullCompilationOptions())
 //    val hamuts = compile.getHamuts()
 //
-//    val packageA = hamuts.lookupPackage(PackageCoordinate("moduleA", List()))
+//    val packageA = hamuts.lookupPackage(PackageCoordinate("moduleA", List.empty))
 //    val fullNameA = vassertSome(packageA.exportNameToKind.get("StructA"))
 //
-//    val packageB = hamuts.lookupPackage(PackageCoordinate("moduleB", List()))
+//    val packageB = hamuts.lookupPackage(PackageCoordinate("moduleB", List.empty))
 //    val fullNameB = vassertSome(packageB.exportNameToKind.get("StructA"))
 //
 //    vassert(fullNameA != fullNameB)

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/IfTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/IfTests.scala
@@ -15,7 +15,7 @@ class IfTests extends FunSuite with Matchers {
         |  = if (true) { 3 } else { 5 }
         |}
       """.stripMargin)
-    val programS = compile.getScoutput().getOrDie().moduleToPackagesToFilenameToContents("test")(List())("0.vale")
+    val programS = compile.getScoutput().getOrDie().moduleToPackagesToFilenameToContents("test")(List.empty)("0.vale")
     val main = programS.lookupFunction("main")
     val CodeBody1(BodySE(_, _, BlockSE(_, _, List(IfSE(_, _, _, _))))) = main.body
 

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ImportTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ImportTests.scala
@@ -27,12 +27,12 @@ class ImportTests extends FunSuite with Matchers {
 
     val compile =
       new RunCompilation(
-        List(PackageCoordinate.BUILTIN, PackageCoordinate("moduleA", List())),
+        List(PackageCoordinate.BUILTIN, PackageCoordinate("moduleA", List.empty)),
         Builtins.getCodeMap()
           .or(
             FileCoordinateMap(Map())
-              .add("moduleA", List(), "moduleA.vale", moduleACode)
-              .add("moduleB", List(), "moduleB.vale", moduleBCode))
+              .add("moduleA", List.empty, "moduleA.vale", moduleACode)
+              .add("moduleB", List.empty, "moduleB.vale", moduleBCode))
           .or(Tests.getPackageToResourceResolver),
         FullCompilationOptions())
 
@@ -55,12 +55,12 @@ class ImportTests extends FunSuite with Matchers {
 
     val compile =
       new RunCompilation(
-        List(PackageCoordinate.BUILTIN, PackageCoordinate("moduleA", List())),
+        List(PackageCoordinate.BUILTIN, PackageCoordinate("moduleA", List.empty)),
         Builtins.getCodeMap()
           .or(
             FileCoordinateMap(Map())
-              .add("moduleA", List(), "moduleA.vale", moduleACode)
-              .add("moduleB", List(), "moduleB.vale", moduleBCode))
+              .add("moduleA", List.empty, "moduleA.vale", moduleACode)
+              .add("moduleB", List.empty, "moduleB.vale", moduleBCode))
           .or(Tests.getPackageToResourceResolver),
         FullCompilationOptions())
 
@@ -87,11 +87,11 @@ class ImportTests extends FunSuite with Matchers {
 
     val compile =
       new RunCompilation(
-        List(PackageCoordinate.BUILTIN, PackageCoordinate("moduleA", List())),
+        List(PackageCoordinate.BUILTIN, PackageCoordinate("moduleA", List.empty)),
         Builtins.getCodeMap()
           .or(
             FileCoordinateMap(Map())
-              .add("moduleA", List(), "moduleA.vale", moduleACode)
+              .add("moduleA", List.empty, "moduleA.vale", moduleACode)
               .add("moduleB", List("bork"), "moduleB.vale", moduleBCode))
           .or(Tests.getPackageToResourceResolver),
         FullCompilationOptions())
@@ -112,12 +112,12 @@ class ImportTests extends FunSuite with Matchers {
 
     val compile =
       new RunCompilation(
-        List(PackageCoordinate.BUILTIN, PackageCoordinate("moduleA", List())),
+        List(PackageCoordinate.BUILTIN, PackageCoordinate("moduleA", List.empty)),
         Builtins.getCodeMap()
           .or(Tests.getPackageToResourceResolver)
           .or(
             FileCoordinateMap(Map())
-              .add("moduleA", List(), "moduleA.vale", moduleACode))
+              .add("moduleA", List.empty, "moduleA.vale", moduleACode))
           .or({ case PackageCoordinate("moduleB", List("bork")) => Some(Map()) }),
     FullCompilationOptions())
 

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/InferTemplateTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/InferTemplateTests.scala
@@ -23,7 +23,7 @@ class InferTemplateTests extends FunSuite with Matchers {
       case List(ParameterT(CodeVarNameT("m"), _, CoordT(ConstraintT,ReadonlyT, _))) =>
     }
     moo.header.fullName.last.templateArgs shouldEqual
-      List(CoordTemplata(CoordT(OwnT,ReadwriteT,StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(),CitizenNameT("Muta",List()))))), CoordTemplata(CoordT(ConstraintT,ReadonlyT,StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(),CitizenNameT("Muta",List()))))))
+      List(CoordTemplata(CoordT(OwnT,ReadwriteT,StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List.empty,CitizenNameT("Muta",List.empty))))), CoordTemplata(CoordT(ConstraintT,ReadonlyT,StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List.empty,CitizenNameT("Muta",List.empty))))))
 
     compile.evalForKind(Vector()) shouldEqual VonInt(10)
   }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/IntegrationTestsA.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/IntegrationTestsA.scala
@@ -509,11 +509,11 @@ class IntegrationTestsA extends FunSuite with Matchers {
         |""".stripMargin)
     val hinputs = compile.expectTemputs()
 
-    vassertSome(hinputs.lookupFunction(SignatureT(FullNameT(PackageCoordinate.TEST_TLD, List(), FunctionNameT("helperFunc", List(), List(CoordT(ShareT, ReadonlyT, IntT.i32)))))))
+    vassertSome(hinputs.lookupFunction(SignatureT(FullNameT(PackageCoordinate.TEST_TLD, List.empty, FunctionNameT("helperFunc", List.empty, List(CoordT(ShareT, ReadonlyT, IntT.i32)))))))
 
-    vassert(None == hinputs.lookupFunction(SignatureT(FullNameT(PackageCoordinate.TEST_TLD, List(), FunctionNameT("bork", List(), List(CoordT(ShareT, ReadonlyT, StrT())))))))
+    vassert(None == hinputs.lookupFunction(SignatureT(FullNameT(PackageCoordinate.TEST_TLD, List.empty, FunctionNameT("bork", List.empty, List(CoordT(ShareT, ReadonlyT, StrT())))))))
 
-    vassert(None == hinputs.lookupFunction(SignatureT(FullNameT(PackageCoordinate.TEST_TLD, List(), FunctionNameT("helperFunc", List(), List(CoordT(ShareT, ReadonlyT, StrT())))))))
+    vassert(None == hinputs.lookupFunction(SignatureT(FullNameT(PackageCoordinate.TEST_TLD, List.empty, FunctionNameT("helperFunc", List.empty, List(CoordT(ShareT, ReadonlyT, StrT())))))))
   }
 
 //  test("Test overloading between borrow and own") {
@@ -562,11 +562,11 @@ class IntegrationTestsA extends FunSuite with Matchers {
   test("Test extern functions") {
     val compile = RunCompilation.test(Tests.loadExpected("programs/externs/extern.vale"))
 
-    val packageH = compile.getHamuts().lookupPackage(PackageCoordinate("math", List()))
+    val packageH = compile.getHamuts().lookupPackage(PackageCoordinate("math", List.empty))
 
     // The extern we make should have the name we expect
     vassertSome(packageH.externNameToFunction.get("sqrt")) match {
-      case PrototypeH(FullNameH("sqrt",_,PackageCoordinate("math",List()),_),_,_) =>
+      case PrototypeH(FullNameH("sqrt",_,PackageCoordinate("math",Nil),_),_,_) =>
     }
 
     // We also made an internal function that contains an extern call

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/OwnershipTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/OwnershipTests.scala
@@ -24,7 +24,7 @@ class OwnershipTests extends FunSuite with Matchers {
 
     val main = compile.expectTemputs().lookupFunction("main")
     main.only({
-      case LetAndLendTE(ReferenceLocalVariableT(FullNameT(_, List(FunctionNameT("main",List(),List())),TemplarTemporaryVarNameT(0)),FinalT,_),refExpr) => {
+      case LetAndLendTE(ReferenceLocalVariableT(FullNameT(_, List(FunctionNameT("main",Nil,Nil)),TemplarTemporaryVarNameT(0)),FinalT,_),refExpr) => {
         refExpr.resultRegister.reference match {
           case CoordT(OwnT, ReadwriteT, StructRefT(simpleName("Muta"))) =>
         }
@@ -243,7 +243,7 @@ class OwnershipTests extends FunSuite with Matchers {
     val main = compile.expectTemputs().lookupFunction("main")
     // Only one variable containing a Muta
     main.only({
-      case LetNormalTE(ReferenceLocalVariableT(_,FinalT,CoordT(OwnT,ReadwriteT,StructRefT(FullNameT(_, List(),CitizenNameT("Muta",List()))))),_) =>
+      case LetNormalTE(ReferenceLocalVariableT(_,FinalT,CoordT(OwnT,ReadwriteT,StructRefT(FullNameT(_, Nil,CitizenNameT("Muta",Nil))))),_) =>
     })
 
     compile.run(Vector())

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/VirtualTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/VirtualTests.scala
@@ -29,16 +29,16 @@ class VirtualTests extends FunSuite with Matchers {
             SignatureT(
               FullNameT(
                 PackageCoordinate.TEST_TLD,
-                List(),
+                List.empty,
                 FunctionNameT(
                   "doThing",
-                  List(),
+                  List.empty,
                   List(
                     CoordT(
                       OwnT,
                       ReadwriteT,
                       InterfaceRefT(
-                        FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("I", List()))))))))))
+                        FullNameT(PackageCoordinate.TEST_TLD, List.empty, CitizenNameT("I", List.empty))))))))))
       vassert(doThing.header.params(0).virtuality.get == AbstractT$)
     }
 
@@ -63,16 +63,16 @@ class VirtualTests extends FunSuite with Matchers {
           SignatureT(
             FullNameT(
               PackageCoordinate.TEST_TLD,
-              List(),
+              List.empty,
               FunctionNameT(
                 "doThing",
-                List(),
+                List.empty,
                 List(
                   CoordT(
                     OwnT,
                     ReadwriteT,
                     InterfaceRefT(
-                      FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("I", List()))))))))))
+                      FullNameT(PackageCoordinate.TEST_TLD, List.empty, CitizenNameT("I", List.empty))))))))))
     vassert(doThing.header.params(0).virtuality.get == AbstractT$)
   }
 
@@ -96,7 +96,7 @@ class VirtualTests extends FunSuite with Matchers {
       vassertSome(
         temputs.lookupFunction(
           SignatureT(
-            FullNameT(PackageCoordinate.TEST_TLD, List(CitizenNameT("I",List())),FunctionNameT("doThing",List(),List(CoordT(OwnT,ReadwriteT,InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(),CitizenNameT("I",List()))))))))))
+            FullNameT(PackageCoordinate.TEST_TLD, List(CitizenNameT("I",List.empty)),FunctionNameT("doThing",List.empty,List(CoordT(OwnT,ReadwriteT,InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List.empty,CitizenNameT("I",List.empty))))))))))
     vassert(doThing.header.params(0).virtuality.get == AbstractT$)
   }
 

--- a/Valestrom/Metal/src/net/verdagon/vale/metal/ast.scala
+++ b/Valestrom/Metal/src/net/verdagon/vale/metal/ast.scala
@@ -63,7 +63,7 @@ case class PackageH(
   // Function must be at the top level of the program.
   def lookupFunction(readableName: String) = {
     val matches =
-      (List() ++
+      (List.empty ++
         exportNameToFunction.get(readableName).toList ++
         functions.filter(_.prototype.fullName.readableName == readableName).map(_.prototype))
         .distinct

--- a/Valestrom/Parser/src/net/verdagon/vale/parser/CombinatorParsers.scala
+++ b/Valestrom/Parser/src/net/verdagon/vale/parser/CombinatorParsers.scala
@@ -143,7 +143,7 @@ object CombinatorParsers
         // A hack to do region highlighting
         opt("'" ~> optWhite ~> exprIdentifier <~ optWhite) ~
         (pos <~ "{" <~ optWhite) ~
-        ("..." <~ optWhite ^^^ List() | repsep(structContent, optWhite)) ~
+        ("..." <~ optWhite ^^^ List.empty | repsep(structContent, optWhite)) ~
         (optWhite ~> "}" ~> pos) ^^ {
       case begin ~ name ~ identifyingRunes ~ attributes ~ imm ~ maybeTemplateRules ~ defaultRegion ~ membersBegin ~ members ~ end => {
         val mutability = if (imm == Some("imm")) ImmutableP else MutableP

--- a/Valestrom/Parser/src/net/verdagon/vale/parser/ExpressionParser.scala
+++ b/Valestrom/Parser/src/net/verdagon/vale/parser/ExpressionParser.scala
@@ -20,7 +20,7 @@ trait ExpressionParser extends RegexParsers with ParserUtils with TemplexParser 
   }
 
   private[parser] def lookup: Parser[LookupPE] = {
-//    ("`" ~> "[^`]+".r <~ "`" ^^ (i => LookupPE(i, List()))) |
+//    ("`" ~> "[^`]+".r <~ "`" ^^ (i => LookupPE(i, List.empty))) |
     (exprIdentifier ^^ (i => LookupPE(i, None)))
   }
 
@@ -61,7 +61,7 @@ trait ExpressionParser extends RegexParsers with ParserUtils with TemplexParser 
         pos ^^ {
       case LetBegin(begin, pattern) ~ expr ~ end => {
         // We just threw away the topLevelRunes because let statements cant have them.
-        LetPE(Range(begin, end), /*maybeTemplateRules.getOrElse(List())*/None, pattern, expr)
+        LetPE(Range(begin, end), /*maybeTemplateRules.getOrElse(List.empty)*/None, pattern, expr)
       }
     }
   }
@@ -302,8 +302,8 @@ trait ExpressionParser extends RegexParsers with ParserUtils with TemplexParser 
 
     val StrInterpolatePE(range, parts) = stringExpr
 
-    combine(List(), parts).reverse match {
-      case List() => ConstantStrPE(range, "")
+    combine(List.empty, parts).reverse match {
+      case Nil => ConstantStrPE(range, "")
       case List(s @ ConstantStrPE(_, _)) => s
       case multiple => StrInterpolatePE(range, multiple)
     }
@@ -359,7 +359,7 @@ trait ExpressionParser extends RegexParsers with ParserUtils with TemplexParser 
             Range(begin, begin),
             false,
             LookupPE(NameP(Range(begin, begin), ""), None),
-            List(),
+            List.empty,
             LendConstraintP((None)))
         }
       }) |
@@ -631,7 +631,7 @@ trait ExpressionParser extends RegexParsers with ParserUtils with TemplexParser 
     rep1sep(statementOrResult, optWhite) ~ pos ^^ {
       case statements ~ end => {
         statements match {
-          case List() => List(VoidPE(Range(end, end)))
+          case Nil => List(VoidPE(Range(end, end)))
           case resultsOrStatements => {
             if (resultsOrStatements.init.exists(_._2)) {
               vfail("wot")
@@ -714,7 +714,7 @@ trait ExpressionParser extends RegexParsers with ParserUtils with TemplexParser 
   }
 
   private[parser] def packExpr: Parser[PackPE] = {
-    pos ~ ("(" ~> optWhite ~> ("..." ^^^ List() | repsep(expression, optWhite ~> "," <~ optWhite)) <~ optWhite <~ ")") ~ pos ^^ {
+    pos ~ ("(" ~> optWhite ~> ("..." ^^^ List.empty | repsep(expression, optWhite ~> "," <~ optWhite)) <~ optWhite <~ ")") ~ pos ^^ {
       case begin ~ inners ~ end => PackPE(Range(begin, end), inners)
     }
   }
@@ -755,7 +755,7 @@ trait ExpressionParser extends RegexParsers with ParserUtils with TemplexParser 
             Range(begin, end),
             FunctionHeaderP(
               Range(begin, headerEnd),
-              None, List(), None, None, maybeParams, FunctionReturnP(Range(headerEnd, headerEnd), None, None)),
+              None, List.empty, None, None, maybeParams, FunctionReturnP(Range(headerEnd, headerEnd), None, None)),
             Some(block)))
       }
     }
@@ -782,7 +782,7 @@ trait ExpressionParser extends RegexParsers with ParserUtils with TemplexParser 
             Range(begin, end),
             FunctionHeaderP(
               Range(begin, paramsEnd),
-              None, List(), None, None,
+              None, List.empty, None, None,
               Some(ParamsP(Range(begin, paramsEnd), List(param))),
               FunctionReturnP(Range(end, end), None, None)), Some(body)))
       }

--- a/Valestrom/Parser/src/net/verdagon/vale/parser/Formatter.scala
+++ b/Valestrom/Parser/src/net/verdagon/vale/parser/Formatter.scala
@@ -26,7 +26,7 @@ object Formatter {
 //  val s = w(" ")
 //  val ls = List(s)
 //  def may(b: Boolean, span: Span*): List[Span] = {
-//    if (b) span.toList else List()
+//    if (b) span.toList else List.empty
 //  }
 //
 //  def toHTML(element: IElement): String = {

--- a/Valestrom/Parser/src/net/verdagon/vale/parser/Parser.scala
+++ b/Valestrom/Parser/src/net/verdagon/vale/parser/Parser.scala
@@ -611,7 +611,7 @@ object Parser {
       if (werePreviousExprs) {
         return Some(Err(BadExpressionEnd(iter.getPos())))
       } else {
-        return Some(Ok(List()))
+        return Some(Ok(List.empty))
       }
     }
 
@@ -738,7 +738,7 @@ object ParserCompilation {
 
     val combinedProgramPMap = alreadyParsedProgramPMap.mergeNonOverlapping(newProgramPMap)
 
-    loadAndParseIteration(List(), combinedCodeMap, combinedProgramPMap, resolver)
+    loadAndParseIteration(List.empty, combinedCodeMap, combinedProgramPMap, resolver)
   }
 }
 

--- a/Valestrom/Parser/src/net/verdagon/vale/parser/ast.scala
+++ b/Valestrom/Parser/src/net/verdagon/vale/parser/ast.scala
@@ -122,7 +122,7 @@ case class FunctionHeaderP(
                             name: Option[NameP],
                             attributes: List[IFunctionAttributeP],
 
-                            // If Some(List()), should show up like the <> in fn moo<>(a int, b bool)
+                            // If Some(List.empty), should show up like the <> in fn moo<>(a int, b bool)
                             maybeUserSpecifiedIdentifyingRunes: Option[IdentifyingRunesP],
                             templateRules: Option[TemplateRulesP],
 

--- a/Valestrom/Parser/src/net/verdagon/vale/parser/pattern.scala
+++ b/Valestrom/Parser/src/net/verdagon/vale/parser/pattern.scala
@@ -133,7 +133,7 @@ object PatternPUtils {
 //
 //  private def getOrderedRunesFromVirtualityWithDuplicates(virtuality: IVirtualityP): List[String] = {
 //    virtuality match {
-//      case AbstractP => List()
+//      case AbstractP => List.empty
 //      case OverrideP(tyype: ITemplexPT) => getOrderedRunesFromTemplexWithDuplicates(tyype)
 //    }
 //  }
@@ -145,10 +145,10 @@ object PatternPUtils {
 
 //  def getOrderedRunesFromTemplexWithDuplicates(templex: ITemplexPT): List[String] = {
 //    templex match {
-//      case IntPT(value) => List()
-//      case BoolPT(value) => List()
-//      case NameOrRunePT(name) => List()
-//      case MutabilityPT(_) => List()
+//      case IntPT(value) => List.empty
+//      case BoolPT(value) => List.empty
+//      case NameOrRunePT(name) => List.empty
+//      case MutabilityPT(_) => List.empty
 //      case OwnershippedPT(_, inner) => getOrderedRunesFromTemplexWithDuplicates(inner)
 //      case CallPT(template, args) => getOrderedRunesFromTemplexesWithDuplicates((template :: args))
 //      case RepeaterSequencePT(mutability, size, element) => getOrderedRunesFromTemplexesWithDuplicates(List(mutability, size, element))

--- a/Valestrom/Parser/src/net/verdagon/vale/parser/rules.scala
+++ b/Valestrom/Parser/src/net/verdagon/vale/parser/rules.scala
@@ -71,17 +71,17 @@ object RulePUtils {
   def getOrderedRuneDeclarationsFromTemplexWithDuplicates(templex: ITemplexPT): List[String] = {
     templex match {
       case BorrowPT(_, inner) => getOrderedRuneDeclarationsFromTemplexWithDuplicates(inner)
-      case StringPT(_, value) => List()
-      case IntPT(_, value) => List()
-      case MutabilityPT(_, mutability) => List()
-      case VariabilityPT(_, mutability) => List()
-      case PermissionPT(_, permission) => List()
-      case LocationPT(_, location) => List()
-      case OwnershipPT(_, ownership) => List()
-      case BoolPT(_, value) => List()
-      case NameOrRunePT(name) => List()
+      case StringPT(_, value) => List.empty
+      case IntPT(_, value) => List.empty
+      case MutabilityPT(_, mutability) => List.empty
+      case VariabilityPT(_, mutability) => List.empty
+      case PermissionPT(_, permission) => List.empty
+      case LocationPT(_, location) => List.empty
+      case OwnershipPT(_, ownership) => List.empty
+      case BoolPT(_, value) => List.empty
+      case NameOrRunePT(name) => List.empty
       case TypedRunePT(_, name, tyype) => List(name.str)
-      case AnonymousRunePT(_) => List()
+      case AnonymousRunePT(_) => List.empty
       case CallPT(_, template, args) => getOrderedRuneDeclarationsFromTemplexesWithDuplicates((template :: args))
       case FunctionPT(range, mutability, parameters, returnType) => {
         getOrderedRuneDeclarationsFromTemplexesWithDuplicates(mutability.toList) ++

--- a/Valestrom/Parser/src/net/verdagon/vale/parser/rules/RuleParser.scala
+++ b/Valestrom/Parser/src/net/verdagon/vale/parser/rules/RuleParser.scala
@@ -108,7 +108,7 @@ trait RuleParser extends RegexParsers with ParserUtils {
       case begin ~ maybeIsRegion ~ name ~ regionAttributes ~ end => {
         val isRegionAttrInList =
           maybeIsRegion match {
-            case None => List()
+            case None => List.empty
             case Some(NameP(range, _)) => List(TypeRuneAttributeP(range, RegionTypePR))
           }
         IdentifyingRuneP(Range(begin, end), name, isRegionAttrInList ++ regionAttributes)

--- a/Valestrom/Parser/test/net/verdagon/vale/parser/ExpressionTests.scala
+++ b/Valestrom/Parser/test/net/verdagon/vale/parser/ExpressionTests.scala
@@ -93,11 +93,11 @@ class ExpressionTests extends FunSuite with Matchers with Collector with TestPar
   }
 
   test("Lending result of function call") {
-    compile(CombinatorParsers.expression,"&Muta()") shouldHave { case LendPE(_,FunctionCallPE(_,None,_,false,LookupPE(NameP(_, "Muta"), None), List(),LendConstraintP(Some(ReadonlyP))), LendConstraintP(Some(ReadonlyP))) => }
+    compile(CombinatorParsers.expression,"&Muta()") shouldHave { case LendPE(_,FunctionCallPE(_,None,_,false,LookupPE(NameP(_, "Muta"), None), Nil,LendConstraintP(Some(ReadonlyP))), LendConstraintP(Some(ReadonlyP))) => }
   }
 
   test("inline call") {
-    compile(CombinatorParsers.expression,"inl Muta()") shouldHave { case FunctionCallPE(_,Some(UnitP(_)),_,false,LookupPE(NameP(_,"Muta"),None),List(),LendConstraintP(Some(ReadonlyP))) => }
+    compile(CombinatorParsers.expression,"inl Muta()") shouldHave { case FunctionCallPE(_,Some(UnitP(_)),_,false,LookupPE(NameP(_,"Muta"),None),Nil,LendConstraintP(Some(ReadonlyP))) => }
   }
 
   test("Method call") {
@@ -108,7 +108,7 @@ class ExpressionTests extends FunSuite with Matchers with Collector with TestPar
       LookupPE(NameP(_,"x"),None),
       _,LendConstraintP(Some(ReadonlyP)),
       false,
-      LookupPE(NameP(_,"shout"),None),List()) =>
+      LookupPE(NameP(_,"shout"),None),Nil) =>
     }
   }
 
@@ -124,7 +124,7 @@ class ExpressionTests extends FunSuite with Matchers with Collector with TestPar
         _,
       LendConstraintP(Some(ReadonlyP)),
         false,
-        LookupPE(NameP(_,"shout"),None),List()) =>
+        LookupPE(NameP(_,"shout"),None), Nil) =>
     }
   }
 
@@ -135,7 +135,7 @@ class ExpressionTests extends FunSuite with Matchers with Collector with TestPar
         PackPE(_, List(LookupPE(NameP(_,"x"),None))),
         _,UseP,false,
         LookupPE(NameP(_,"shout"),None),
-        List()) =>
+        Nil) =>
     }
   }
 
@@ -146,7 +146,7 @@ class ExpressionTests extends FunSuite with Matchers with Collector with TestPar
       LookupPE(NameP(_,"x"),None),
       _,LendConstraintP(Some(ReadonlyP)),true,
       LookupPE(NameP(_,"shout"),None),
-      List()) =>
+      Nil) =>
     }
   }
 
@@ -161,7 +161,7 @@ class ExpressionTests extends FunSuite with Matchers with Collector with TestPar
 
   test("Templated method call") {
     compile(CombinatorParsers.expression,"result.toArray <imm> ()") shouldHave {
-      case MethodCallPE(_,_,LookupPE(NameP(_,"result"),None),_,LendConstraintP(Some(ReadonlyP)),false,LookupPE(NameP(_,"toArray"),Some(TemplateArgsP(_, List(MutabilityPT(_,ImmutableP))))),List()) =>
+      case MethodCallPE(_,_,LookupPE(NameP(_,"result"),None),_,LendConstraintP(Some(ReadonlyP)),false,LookupPE(NameP(_,"toArray"),Some(TemplateArgsP(_, List(MutabilityPT(_,ImmutableP))))),Nil) =>
     }
   }
 
@@ -201,10 +201,10 @@ class ExpressionTests extends FunSuite with Matchers with Collector with TestPar
 
   test("Template calling") {
     compile(CombinatorParsers.expression,"MyNone< int >()") shouldHave {
-      case FunctionCallPE(_,None,_,false,LookupPE(NameP(_, "MyNone"), Some(TemplateArgsP(_, List(NameOrRunePT(NameP(_, "int")))))),List(), LendConstraintP(Some(ReadonlyP))) =>
+      case FunctionCallPE(_,None,_,false,LookupPE(NameP(_, "MyNone"), Some(TemplateArgsP(_, List(NameOrRunePT(NameP(_, "int")))))),Nil, LendConstraintP(Some(ReadonlyP))) =>
     }
     compile(CombinatorParsers.expression,"MySome< MyNone <int> >()") shouldHave {
-      case FunctionCallPE(_,None,_,false,LookupPE(NameP(_, "MySome"), Some(TemplateArgsP(_, List(CallPT(_,NameOrRunePT(NameP(_, "MyNone")),List(NameOrRunePT(NameP(_, "int")))))))),List(), LendConstraintP(Some(ReadonlyP))) =>
+      case FunctionCallPE(_,None,_,false,LookupPE(NameP(_, "MySome"), Some(TemplateArgsP(_, List(CallPT(_,NameOrRunePT(NameP(_, "MyNone")),List(NameOrRunePT(NameP(_, "int")))))))),Nil, LendConstraintP(Some(ReadonlyP))) =>
     }
   }
 
@@ -225,7 +225,7 @@ class ExpressionTests extends FunSuite with Matchers with Collector with TestPar
 
   test("Identity lambda") {
     compile(CombinatorParsers.expression, "{_}") shouldHave {
-      case LambdaPE(_,FunctionP(_,FunctionHeaderP(_, None,List(),None,None,None,FunctionReturnP(_, _, _)),Some(BlockPE(_,List(MagicParamLookupPE(_)))))) =>
+      case LambdaPE(_,FunctionP(_,FunctionHeaderP(_, None,Nil,None,None,None,FunctionReturnP(_, _, _)),Some(BlockPE(_,List(MagicParamLookupPE(_)))))) =>
     }
   }
 
@@ -241,7 +241,7 @@ class ExpressionTests extends FunSuite with Matchers with Collector with TestPar
       _, LendConstraintP(Some(ReadonlyP)),
       false,
       LookupPE(NameP(_,"map"),None),
-      List()) =>
+      Nil) =>
     }
   }
 
@@ -253,7 +253,7 @@ class ExpressionTests extends FunSuite with Matchers with Collector with TestPar
 
   test("lambda without surrounding parens") {
     compile(CombinatorParsers.expression, "{ 0 }()") shouldHave {
-      case FunctionCallPE(_,None,_,false,LambdaPE(None,_),List(),_) =>
+      case FunctionCallPE(_,None,_,false,LambdaPE(None,_),Nil,_) =>
     }
   }
 

--- a/Valestrom/Parser/test/net/verdagon/vale/parser/ImplTests.scala
+++ b/Valestrom/Parser/test/net/verdagon/vale/parser/ImplTests.scala
@@ -12,7 +12,7 @@ class ImplTests extends FunSuite with Matchers with Collector with TestParseUtil
         |impl<T> MyInterface<T> for SomeStruct<T>;
       """.stripMargin) shouldHave {
       case ImplP(_,
-      Some(IdentifyingRunesP(_, List(IdentifyingRuneP(_, NameP(_, "T"), List())))),
+      Some(IdentifyingRunesP(_, List(IdentifyingRuneP(_, NameP(_, "T"), Nil)))),
       None,
       CallPT(_,NameOrRunePT(NameP(_, "SomeStruct")), List(NameOrRunePT(NameP(_, "T")))),
       CallPT(_,NameOrRunePT(NameP(_, "MyInterface")), List(NameOrRunePT(NameP(_, "T"))))) =>

--- a/Valestrom/Parser/test/net/verdagon/vale/parser/SignatureTests.scala
+++ b/Valestrom/Parser/test/net/verdagon/vale/parser/SignatureTests.scala
@@ -12,7 +12,7 @@ class SignatureTests extends FunSuite with Matchers with Collector with TestPars
       "fn maxHp(this Marine impl IUnit) { 5 }") shouldHave {
       case FunctionP(_,
         FunctionHeaderP(_,
-          Some(NameP(_, "maxHp")),List(), None, None,
+          Some(NameP(_, "maxHp")),Nil, None, None,
           Some(
             ParamsP(
               _,
@@ -38,7 +38,7 @@ class SignatureTests extends FunSuite with Matchers with Collector with TestPars
     compile(CombinatorParsers.topLevelFunction, "fn sum () rules() {3}") shouldHave {
       case FunctionP(_,
         FunctionHeaderP(_,
-          Some(NameP(_, "sum")), List(), None, Some(_), Some(_), FunctionReturnP(_, None, None)),
+          Some(NameP(_, "sum")), Nil, None, Some(_), Some(_), FunctionReturnP(_, None, None)),
         Some(BlockPE(_, List(ConstantIntPE(_, 3, _))))) =>
     }
   }
@@ -49,12 +49,12 @@ class SignatureTests extends FunSuite with Matchers with Collector with TestPars
       "fn wrap<A, F>(a A) { }") shouldHave {
       case FunctionP(_,
         FunctionHeaderP(_,
-          Some(NameP(_, "wrap")), List(),
+          Some(NameP(_, "wrap")), Nil,
           Some(
             IdentifyingRunesP(_,
               List(
-              IdentifyingRuneP(_, NameP(_, "A"), List()),
-              IdentifyingRuneP(_, NameP(_, "F"), List())))),
+              IdentifyingRuneP(_, NameP(_, "A"), Nil),
+              IdentifyingRuneP(_, NameP(_, "F"), Nil)))),
           None,
           Some(ParamsP(_, List(Patterns.capturedWithTypeRune("a", "A")))),
           FunctionReturnP(_, None, None)),

--- a/Valestrom/Parser/test/net/verdagon/vale/parser/StatementTests.scala
+++ b/Valestrom/Parser/test/net/verdagon/vale/parser/StatementTests.scala
@@ -61,7 +61,7 @@ class StatementTests extends FunSuite with Matchers with Collector with TestPars
     // This test is here because we had a bug where we didn't check that there
     // was whitespace after a "ret".
     compile(CombinatorParsers.statement, "retcode();") shouldHave {
-      case FunctionCallPE(_,_,_,_,LookupPE(NameP(_,"retcode"),None),List(),_) =>
+      case FunctionCallPE(_,_,_,_,LookupPE(NameP(_,"retcode"),None),Nil,_) =>
     }
   }
 
@@ -113,7 +113,7 @@ class StatementTests extends FunSuite with Matchers with Collector with TestPars
 
   test("Let with destructuring pattern") {
     compile(CombinatorParsers.statement, "Muta() = m;") shouldHave {
-      case LetPE(_,None,PatternPP(_,_,None,Some(NameOrRunePT(NameP(_, "Muta"))),Some(DestructureP(_,List())),None),LookupPE(NameP(_, "m"), None)) =>
+      case LetPE(_,None,PatternPP(_,_,None,Some(NameOrRunePT(NameP(_, "Muta"))),Some(DestructureP(_,Nil)),None),LookupPE(NameP(_, "m"), None)) =>
     }
   }
 
@@ -133,7 +133,7 @@ class StatementTests extends FunSuite with Matchers with Collector with TestPars
           LambdaPE(_,
             FunctionP(_,
               FunctionHeaderP(_,
-                None,List(),None,None,
+                None,Nil,None,None,
                 Some(
                   ParamsP(_,
                     List(
@@ -154,7 +154,7 @@ class StatementTests extends FunSuite with Matchers with Collector with TestPars
           LambdaPE(_,
             FunctionP(_,
               FunctionHeaderP(
-                _,None,List(),None,None,
+                _,None,Nil,None,None,
                 Some(
                   ParamsP(_,
                     List(
@@ -168,11 +168,11 @@ class StatementTests extends FunSuite with Matchers with Collector with TestPars
 
   test("Test block's trailing void presence") {
     compile(CombinatorParsers.filledBody, "{ moo() }") shouldHave {
-      case BlockPE(_, List(FunctionCallPE(_, None, _, false, LookupPE(NameP(_, "moo"), None), List(), LendConstraintP(Some(ReadonlyP))))) =>
+      case BlockPE(_, List(FunctionCallPE(_, None, _, false, LookupPE(NameP(_, "moo"), None), Nil, LendConstraintP(Some(ReadonlyP))))) =>
     }
 
     compile(CombinatorParsers.filledBody, "{ moo(); }") shouldHave {
-      case BlockPE(_, List(FunctionCallPE(_, None, _, false, LookupPE(NameP(_, "moo"), None), List(), LendConstraintP(Some(ReadonlyP))), VoidPE(_))) =>
+      case BlockPE(_, List(FunctionCallPE(_, None, _, false, LookupPE(NameP(_, "moo"), None), Nil, LendConstraintP(Some(ReadonlyP))), VoidPE(_))) =>
     }
   }
 

--- a/Valestrom/Parser/test/net/verdagon/vale/parser/StructTests.scala
+++ b/Valestrom/Parser/test/net/verdagon/vale/parser/StructTests.scala
@@ -36,19 +36,19 @@ class StructTests extends FunSuite with Matchers with Collector {
 
   test("Simple struct") {
     compile(CombinatorParsers.struct, "struct Moo { x &int; }") shouldHave {
-      case StructP(_, NameP(_, "Moo"), List(), MutableP, None, None, StructMembersP(_, List(StructMemberP(_, NameP(_, "x"), FinalP, InterpretedPT(_,ConstraintP,ReadonlyP,NameOrRunePT(NameP(_, "int"))))))) =>
+      case StructP(_, NameP(_, "Moo"), Nil, MutableP, None, None, StructMembersP(_, List(StructMemberP(_, NameP(_, "x"), FinalP, InterpretedPT(_,ConstraintP,ReadonlyP,NameOrRunePT(NameP(_, "int"))))))) =>
     }
   }
 
   test("Struct with weak") {
     compile(CombinatorParsers.struct, "struct Moo { x &&int; }") shouldHave {
-      case StructP(_, NameP(_, "Moo"), List(), MutableP, None, None, StructMembersP(_, List(StructMemberP(_, NameP(_, "x"), FinalP, InterpretedPT(_,WeakP,ReadonlyP,NameOrRunePT(NameP(_, "int"))))))) =>
+      case StructP(_, NameP(_, "Moo"), Nil, MutableP, None, None, StructMembersP(_, List(StructMemberP(_, NameP(_, "x"), FinalP, InterpretedPT(_,WeakP,ReadonlyP,NameOrRunePT(NameP(_, "int"))))))) =>
     }
   }
 
   test("Struct with inl") {
     compile(CombinatorParsers.struct, "struct Moo { x inl Marine; }") shouldHave {
-      case StructP(_,NameP(_,"Moo"),List(), MutableP,None,None,StructMembersP(_,List(StructMemberP(_,NameP(_,"x"),FinalP,InlinePT(_,NameOrRunePT(NameP(_,"Marine"))))))) =>
+      case StructP(_,NameP(_,"Moo"),Nil, MutableP,None,None,StructMembersP(_,List(StructMemberP(_,NameP(_,"x"),FinalP,InlinePT(_,NameOrRunePT(NameP(_,"Marine"))))))) =>
     }
   }
 
@@ -69,9 +69,9 @@ class StructTests extends FunSuite with Matchers with Collector {
       case StructP(
         _,
         NameP(_, "ListNode"),
-        List(),
+        Nil,
         MutableP,
-        Some(IdentifyingRunesP(_, List(IdentifyingRuneP(_, NameP(_, "E"), List())))),
+        Some(IdentifyingRunesP(_, List(IdentifyingRuneP(_, NameP(_, "E"), Nil)))),
         None,
         StructMembersP(_,
           List(
@@ -93,9 +93,9 @@ class StructTests extends FunSuite with Matchers with Collector {
       case StructP(
         _,
         NameP(_, "Vecf"),
-        List(),
+        Nil,
         MutableP,
-        Some(IdentifyingRunesP(_, List(IdentifyingRuneP(_, NameP(_, "N"), List())))),
+        Some(IdentifyingRunesP(_, List(IdentifyingRuneP(_, NameP(_, "N"), Nil)))),
         Some(TemplateRulesP(_, List(TypedPR(_,Some(NameP(_, "N")), IntTypePR)))),
         StructMembersP(_, List(StructMemberP(_,NameP(_, "values"), FinalP, RepeaterSequencePT(_,MutabilityPT(_,MutableP), VariabilityPT(_,FinalP), NameOrRunePT(NameP(_, "N")), NameOrRunePT(NameP(_, "float"))))))) =>
     }
@@ -114,9 +114,9 @@ class StructTests extends FunSuite with Matchers with Collector {
       case StructP(
           _,
           NameP(_, "Vecf"),
-          List(),
+          Nil,
           MutableP,
-          Some(IdentifyingRunesP(_, List(IdentifyingRuneP(_, NameP(_, "N"), List())))),
+          Some(IdentifyingRunesP(_, List(IdentifyingRuneP(_, NameP(_, "N"), Nil)))),
           Some(TemplateRulesP(_, List(TypedPR(_,Some(NameP(_, "N")),IntTypePR)))),
           StructMembersP(_, List(StructMemberP(_,NameP(_, "values"),FinalP,RepeaterSequencePT(_,MutabilityPT(_,ImmutableP), VariabilityPT(_, FinalP), NameOrRunePT(NameP(_, "N")), NameOrRunePT(NameP(_, "float"))))))) =>
     }

--- a/Valestrom/Parser/test/net/verdagon/vale/parser/TestParseUtils.scala
+++ b/Valestrom/Parser/test/net/verdagon/vale/parser/TestParseUtils.scala
@@ -8,8 +8,8 @@ trait TestParseUtils {
       case ParseFailure(err) => {
         vfail(
           ParseErrorHumanizer.humanize(
-            FileCoordinateMap(Map()).add("my", List(), "0", code),
-            FileCoordinate("my", List(), "0"),
+            FileCoordinateMap(Map()).add("my", List.empty, "0", code),
+            FileCoordinate("my", List.empty, "0"),
             err))
       }
       case ParseSuccess(result) => result._1
@@ -20,8 +20,8 @@ trait TestParseUtils {
       case ParseFailure(err) => {
         vfail(
           ParseErrorHumanizer.humanize(
-            FileCoordinateMap(Map()).add("my", List(), "0", code),
-            FileCoordinate("my", List(), "0"),
+            FileCoordinateMap(Map()).add("my", List.empty, "0", code),
+            FileCoordinate("my", List.empty, "0"),
             err))
       }
       case ParseSuccess(result) => result

--- a/Valestrom/Parser/test/net/verdagon/vale/parser/TopLevelTests.scala
+++ b/Valestrom/Parser/test/net/verdagon/vale/parser/TopLevelTests.scala
@@ -58,14 +58,14 @@ class TopLevelTests extends FunSuite with Matchers with Collector with TestParse
   test("import wildcard") {
     val program = compileProgram("import somemodule.*;")
     program.topLevelThings(0) match {
-      case TopLevelImportP(ImportP(_, NameP(_, "somemodule"), List(), NameP(_, "*"))) =>
+      case TopLevelImportP(ImportP(_, NameP(_, "somemodule"), Nil, NameP(_, "*"))) =>
     }
   }
 
   test("import just module and thing") {
     val program = compileProgram("import somemodule.List;")
     program.topLevelThings(0) match {
-      case TopLevelImportP(ImportP(_, NameP(_, "somemodule"), List(), NameP(_, "List"))) =>
+      case TopLevelImportP(ImportP(_, NameP(_, "somemodule"), Nil, NameP(_, "List"))) =>
     }
   }
 

--- a/Valestrom/Parser/test/net/verdagon/vale/parser/functions/FunctionTests.scala
+++ b/Valestrom/Parser/test/net/verdagon/vale/parser/functions/FunctionTests.scala
@@ -21,7 +21,7 @@ class BiggerTests extends FunSuite with Matchers with Collector with TestParseUt
     compile(CombinatorParsers.topLevelFunction, "fn sum() int {3}") match {
       case FunctionP(_,
         FunctionHeaderP(_,
-          Some(NameP(_, "sum")), List(), None, None, Some(ParamsP(_,List())), FunctionReturnP(_, None, Some(_))),
+          Some(NameP(_, "sum")), Nil, None, None, Some(ParamsP(_,Nil)), FunctionReturnP(_, None, Some(_))),
         Some(BlockPE(_, List(ConstantIntPE(_, 3, _))))) =>
     }
   }
@@ -30,7 +30,7 @@ class BiggerTests extends FunSuite with Matchers with Collector with TestParseUt
     compile(CombinatorParsers.topLevelFunction, "fn sum() pure {3}") match {
       case FunctionP(_,
         FunctionHeaderP(_,
-          Some(NameP(_, "sum")), List(PureAttributeP(_)), None, None, Some(ParamsP(_,List())), FunctionReturnP(_, None, None)),
+          Some(NameP(_, "sum")), List(PureAttributeP(_)), None, None, Some(ParamsP(_,Nil)), FunctionReturnP(_, None, None)),
         Some(BlockPE(_, List(ConstantIntPE(_, 3, _))))) =>
     }
   }
@@ -39,7 +39,7 @@ class BiggerTests extends FunSuite with Matchers with Collector with TestParseUt
     compile(CombinatorParsers.topLevelFunction, "fn sum() extern;") match {
       case FunctionP(_,
         FunctionHeaderP(_,
-          Some(NameP(_, "sum")), List(ExternAttributeP(_)), None, None, Some(ParamsP(_,List())), FunctionReturnP(_, None, None)),
+          Some(NameP(_, "sum")), List(ExternAttributeP(_)), None, None, Some(ParamsP(_,Nil)), FunctionReturnP(_, None, None)),
         None) =>
     }
   }
@@ -48,7 +48,7 @@ class BiggerTests extends FunSuite with Matchers with Collector with TestParseUt
     compile(CombinatorParsers.topLevelFunction, "fn sum() abstract;") match {
       case FunctionP(_,
         FunctionHeaderP(_,
-          Some(NameP(_, "sum")), List(AbstractAttributeP(_)), None, None, Some(ParamsP(_,List())), FunctionReturnP(_, None, None)),
+          Some(NameP(_, "sum")), List(AbstractAttributeP(_)), None, None, Some(ParamsP(_,Nil)), FunctionReturnP(_, None, None)),
         None) =>
     }
   }
@@ -64,7 +64,7 @@ class BiggerTests extends FunSuite with Matchers with Collector with TestParseUt
           List(PureAttributeP(_)),
           None,
           None,
-          Some(ParamsP(_,List())),
+          Some(ParamsP(_,Nil)),
           FunctionReturnP(_, None, Some(NameOrRunePT(NameP(_,"int"))))),
         Some(BlockPE(_,List(VoidPE(_))))) =>
     }
@@ -78,7 +78,7 @@ class BiggerTests extends FunSuite with Matchers with Collector with TestParseUt
           List(AbstractAttributeP(_)),
           None,
           None,
-          Some(ParamsP(_,List())),
+          Some(ParamsP(_,Nil)),
           FunctionReturnP(_, None, Some(NameOrRunePT(NameP(_,"Int"))))),
         None) =>
     }
@@ -92,7 +92,7 @@ class BiggerTests extends FunSuite with Matchers with Collector with TestParseUt
           List(AbstractAttributeP(_)),
           None,
           None,
-          Some(ParamsP(_,List())),
+          Some(ParamsP(_,Nil)),
           FunctionReturnP(_, None, Some(NameOrRunePT(NameP(_,"Int"))))),
         None) =>
     }
@@ -101,7 +101,7 @@ class BiggerTests extends FunSuite with Matchers with Collector with TestParseUt
   test("Simple function with identifying rune") {
     val func = compile(CombinatorParsers.topLevelFunction, "fn sum<A>(a A){a}")
     func.header.maybeUserSpecifiedIdentifyingRunes.get.runes.head match {
-      case IdentifyingRuneP(_, NameP(_, "A"), List()) =>
+      case IdentifyingRuneP(_, NameP(_, "A"), Nil) =>
     }
   }
 
@@ -168,7 +168,7 @@ class BiggerTests extends FunSuite with Matchers with Collector with TestParseUt
       """.stripMargin) shouldHave {
       case FunctionP(_,
         FunctionHeaderP(_,
-          Some(NameP(_, "doCivicDance")), List(), None, None,
+          Some(NameP(_, "doCivicDance")), Nil, None, None,
           Some(ParamsP(_, List(PatternPP(_, _,Some(CaptureP(_,LocalNameP(NameP(_, "this")))), Some(NameOrRunePT(NameP(_, "Car"))), None, Some(AbstractP))))),
           FunctionReturnP(_, None, Some(NameOrRunePT(NameP(_, "int"))))),
         None) =>

--- a/Valestrom/Parser/test/net/verdagon/vale/parser/patterns/CaptureAndDestructureTests.scala
+++ b/Valestrom/Parser/test/net/verdagon/vale/parser/patterns/CaptureAndDestructureTests.scala
@@ -53,16 +53,16 @@ class CaptureAndDestructureTests extends FunSuite with Matchers with Collector {
   }
   test("capture with empty sequence type") {
     compile("a []") shouldHave {
-      case capturedWithType("a", ManualSequencePT(_,List())) =>
+      case capturedWithType("a", ManualSequencePT(_,Nil)) =>
     }
   }
   test("empty destructure") {
-    compile(destructure,"()") shouldHave { case List() =>
+    compile(destructure,"()") shouldHave { case Nil =>
     }
   }
   test("capture with empty destructure") {
     compile("a ()") shouldHave {
-      case PatternPP(_,_,Some(CaptureP(_,LocalNameP(NameP(_, "a")))),None,Some(DestructureP(_,List())),None) =>
+      case PatternPP(_,_,Some(CaptureP(_,LocalNameP(NameP(_, "a")))),None,Some(DestructureP(_,Nil)),None) =>
     }
   }
   test("Destructure with nested atom") {

--- a/Valestrom/Parser/test/net/verdagon/vale/parser/patterns/DestructureParserTests.scala
+++ b/Valestrom/Parser/test/net/verdagon/vale/parser/patterns/DestructureParserTests.scala
@@ -39,7 +39,7 @@ class DestructureParserTests extends FunSuite with Matchers with Collector {
 
   test("Only empty destructure") {
     compile("()") shouldHave {
-      case withDestructure(List()) =>
+      case withDestructure(Nil) =>
     }
   }
   test("One element destructure") {

--- a/Valestrom/Parser/test/net/verdagon/vale/parser/patterns/PatternParserTests.scala
+++ b/Valestrom/Parser/test/net/verdagon/vale/parser/patterns/PatternParserTests.scala
@@ -54,7 +54,7 @@ class PatternParserTests extends FunSuite with Matchers with Collector {
     }
   }
   test("Empty pattern list") {
-    compile(patternPrototypeParams,"()").patterns shouldEqual List()
+    compile(patternPrototypeParams,"()").patterns shouldEqual List.empty
   }
   test("Pattern list with only two captures") {
     val list = compile(patternPrototypeParams, "(a, b)")

--- a/Valestrom/Parser/test/net/verdagon/vale/parser/patterns/TypeAndDestructureTests.scala
+++ b/Valestrom/Parser/test/net/verdagon/vale/parser/patterns/TypeAndDestructureTests.scala
@@ -45,7 +45,7 @@ class TypeAndDestructureTests extends FunSuite with Matchers with Collector {
       case PatternPP(_,_,
           None,
           Some(NameOrRunePT(NameP(_, "Muta"))),
-          Some(DestructureP(_,List())),
+          Some(DestructureP(_,Nil)),
           None) =>
     }
   }
@@ -58,7 +58,7 @@ class TypeAndDestructureTests extends FunSuite with Matchers with Collector {
             CallPT(_,
               NameOrRunePT(NameP(_, "Muta")),
               List(NameOrRunePT(NameP(_, "int"))))),
-          Some(DestructureP(_,List())),
+          Some(DestructureP(_,Nil)),
           None) =>
     }
     compile("_ Muta<R>()") shouldHave {
@@ -68,7 +68,7 @@ class TypeAndDestructureTests extends FunSuite with Matchers with Collector {
             CallPT(_,
               NameOrRunePT(NameP(_, "Muta")),
               List(NameOrRunePT(NameP(_, "R"))))),
-          Some(DestructureP(_,List())),
+          Some(DestructureP(_,Nil)),
           None) =>
     }
   }

--- a/Valestrom/Parser/test/net/verdagon/vale/parser/rules/KindRuleTests.scala
+++ b/Valestrom/Parser/test/net/verdagon/vale/parser/rules/KindRuleTests.scala
@@ -193,7 +193,7 @@ class KindRuleTests extends FunSuite with Matchers with Collector {
 
   test("Regular sequence") {
     compile(manualSeqRulePR, "[]") shouldHave {
-        case ManualSequencePT(_,List()) =>
+        case ManualSequencePT(_,Nil) =>
     }
     compile(manualSeqRulePR, "[int]") shouldHave {
         case ManualSequencePT(_,List(NameOrRunePT(NameP(_, "int")))) =>

--- a/Valestrom/Scout/src/net/verdagon/vale/scout/ExpressionScout.scala
+++ b/Valestrom/Scout/src/net/verdagon/vale/scout/ExpressionScout.scala
@@ -280,12 +280,12 @@ object ExpressionScout {
         val endRange = RangeS(rightRange.end, rightRange.end)
 
         val (NormalResult(_, condSE), condUses, condChildUses) =
-          scoutBlock(stackFrame0, leftPE, VariableDeclarations(List()))
+          scoutBlock(stackFrame0, leftPE, VariableDeclarations(List.empty))
         val (NormalResult(_, thenSE), thenUses, thenChildUses) =
-          scoutBlock(stackFrame0, rightPE, VariableDeclarations(List()))
-        val elseUses = VariableUses(List())
-        val elseChildUses = VariableUses(List())
-        val elseSE = BlockSE(endRange, List(), List(ConstantBoolSE(endRange, false)))
+          scoutBlock(stackFrame0, rightPE, VariableDeclarations(List.empty))
+        val elseUses = VariableUses(List.empty)
+        val elseChildUses = VariableUses(List.empty)
+        val elseSE = BlockSE(endRange, List.empty, List(ConstantBoolSE(endRange, false)))
 
         val selfCaseUses = thenUses.branchMerge(elseUses)
         val selfUses = condUses.thenMerge(selfCaseUses);
@@ -300,12 +300,12 @@ object ExpressionScout {
         val endRange = RangeS(rightRange.end, rightRange.end)
 
         val (NormalResult(_, condSE), condUses, condChildUses) =
-          scoutBlock(stackFrame0, leftPE, VariableDeclarations(List()))
-        val thenUses = VariableUses(List())
-        val thenChildUses = VariableUses(List())
-        val thenSE = BlockSE(endRange, List(), List(ConstantBoolSE(endRange, true)))
+          scoutBlock(stackFrame0, leftPE, VariableDeclarations(List.empty))
+        val thenUses = VariableUses(List.empty)
+        val thenChildUses = VariableUses(List.empty)
+        val thenSE = BlockSE(endRange, List.empty, List(ConstantBoolSE(endRange, true)))
         val (NormalResult(_, elseSE), elseUses, elseChildUses) =
-          scoutBlock(stackFrame0, rightPE, VariableDeclarations(List()))
+          scoutBlock(stackFrame0, rightPE, VariableDeclarations(List.empty))
 
         val selfCaseUses = thenUses.branchMerge(elseUses)
         val selfUses = condUses.thenMerge(selfCaseUses);
@@ -370,13 +370,13 @@ object ExpressionScout {
             patternP)
         val rulesS = userRulesS ++ implicitRulesS
 
-        val allRunes = PredictorEvaluator.getAllRunes(List(), rulesS, List(patternS), None)
+        val allRunes = PredictorEvaluator.getAllRunes(List.empty, rulesS, List(patternS), None)
 
         // See MKKRFA
         val knowableRunesFromAbove = stackFrame1.parentEnv.allUserDeclaredRunes()
         val allUnknownRunes = allRunes -- knowableRunesFromAbove
         val Conclusions(knowableValueRunes, predictedTypeByRune) =
-          PredictorEvaluator.solve(Set(), rulesS, List())
+          PredictorEvaluator.solve(Set(), rulesS, List.empty)
         val localRunes = allRunes -- knowableRunesFromAbove
 
         val declarationsFromPattern = VariableDeclarations(PatternScout.getParameterCaptures(patternS))

--- a/Valestrom/Scout/src/net/verdagon/vale/scout/FunctionScout.scala
+++ b/Valestrom/Scout/src/net/verdagon/vale/scout/FunctionScout.scala
@@ -95,7 +95,7 @@ object FunctionScout {
           val rule = EqualsSR(rangeS, TemplexSR(NameST(rangeS, CodeTypeNameS("void"))), TypedSR(rangeS, rune, CoordTypeSR))
           (List(rule), Some(rune))
         }
-        case (Some(_), None) => (List(), None) // Infer the return
+        case (Some(_), None) => (List.empty, None) // Infer the return
         case (None, Some(retTypePT)) => {
           PatternScout.translateMaybeTypeIntoMaybeRune(
             functionEnv,
@@ -125,7 +125,7 @@ object FunctionScout {
         GeneratedBody1(attributes.collectFirst({ case BuiltinAttributeP(_, generatorId) => generatorId}).head.str)
       } else {
         vassert(maybeBody0.nonEmpty)
-        val (body1, _, List()) = scoutBody(myStackFrame, maybeBody0.get, captureDeclarations)
+        val (body1, _, Nil) = scoutBody(myStackFrame, maybeBody0.get, captureDeclarations)
         vassert(body1.closuredNames.isEmpty)
         CodeBody1(body1)
       }
@@ -165,7 +165,7 @@ object FunctionScout {
 //          if (paramP.templex.isEmpty) {
 //            List(explicitParamPatternS.coordRune)
 //          } else {
-//            List()
+//            List.empty
 //          }
 //        }
 //      })
@@ -324,7 +324,7 @@ object FunctionScout {
 
     val (implicitRulesFromReturn, maybeRetCoordRune) =
       (maybeInferRet, maybeRetType) match {
-        case (_, None) => (List(), None) // Infer the return
+        case (_, None) => (List.empty, None) // Infer the return
         case (None, Some(retTypePT)) => {
           PatternScout.translateMaybeTypeIntoMaybeRune(
             functionEnv,
@@ -375,7 +375,7 @@ object FunctionScout {
 //          if (paramP.templex.isEmpty) {
 //            List(explicitParamPatternS.coordRune)
 //          } else {
-//            List()
+//            List.empty
 //          }
 //        }
 //      })

--- a/Valestrom/Scout/src/net/verdagon/vale/scout/Scout.scala
+++ b/Valestrom/Scout/src/net/verdagon/vale/scout/Scout.scala
@@ -88,8 +88,8 @@ case class StackFrame(
 }
 
 object Scout {
-  def noVariableUses = VariableUses(List())
-  def noDeclarations = VariableDeclarations(List())
+  def noVariableUses = VariableUses(List.empty)
+  def noDeclarations = VariableDeclarations(List.empty)
 
 //  val unnamedParamNamePrefix = "__param_"
 //  val unrunedParamOverrideRuneSuffix = "Override"
@@ -136,8 +136,8 @@ object Scout {
       RuleScout.translateRulexes(implEnv, rate, implEnv.allUserDeclaredRunes(), templateRulesP)
 
     // We gather all the runes from the scouted rules to be consistent with the function scout.
-    val allRunes = PredictorEvaluator.getAllRunes(identifyingRunes, userRulesS, List(), None)
-    val Conclusions(knowableValueRunes, _) = PredictorEvaluator.solve(Set(), userRulesS, List())
+    val allRunes = PredictorEvaluator.getAllRunes(identifyingRunes, userRulesS, List.empty, None)
+    val Conclusions(knowableValueRunes, _) = PredictorEvaluator.solve(Set(), userRulesS, List.empty)
     val localRunes = allRunes
     val isTemplate = knowableValueRunes != allRunes
 
@@ -180,7 +180,7 @@ object Scout {
       implName,
       rulesFromStructDirectionS,
       rulesFromInterfaceDirectionS,
-      knowableValueRunes ++ (if (isTemplate) List() else List(structRune, interfaceRune)),
+      knowableValueRunes ++ (if (isTemplate) List.empty else List(structRune, interfaceRune)),
       localRunes ++ List(structRune, interfaceRune),
       isTemplate,
       structRune,
@@ -249,8 +249,8 @@ object Scout {
           TemplexSR(MutabilityST(structRangeS, mutability)))
 
     // We gather all the runes from the scouted rules to be consistent with the function scout.
-    val allRunes = PredictorEvaluator.getAllRunes(identifyingRunes, rulesS, List(), None)
-    val Conclusions(knowableValueRunes, predictedTypeByRune) = PredictorEvaluator.solve(Set(), rulesS, List())
+    val allRunes = PredictorEvaluator.getAllRunes(identifyingRunes, rulesS, List.empty, None)
+    val Conclusions(knowableValueRunes, predictedTypeByRune) = PredictorEvaluator.solve(Set(), rulesS, List.empty)
     val localRunes = allRunes
     val isTemplate = knowableValueRunes != allRunes
 
@@ -261,7 +261,7 @@ object Scout {
         }
         case (StructMethodP(_), memberRune) => {
           // Implement struct methods one day
-          List()
+          List.empty
         }
       })
 
@@ -333,9 +333,9 @@ object Scout {
         TemplexSR(MutabilityST(interfaceRangeS, mutability)))
 
     // We gather all the runes from the scouted rules to be consistent with the function scout.
-    val allRunes = PredictorEvaluator.getAllRunes(identifyingRunes, rulesS, List(), None)
+    val allRunes = PredictorEvaluator.getAllRunes(identifyingRunes, rulesS, List.empty, None)
     val Conclusions(knowableValueRunes, predictedTypeByRune) =
-      PredictorEvaluator.solve(Set(), rulesS, List())
+      PredictorEvaluator.solve(Set(), rulesS, List.empty)
     val localRunes = allRunes
     val isTemplate = knowableValueRunes != allRunes.toSet
 

--- a/Valestrom/Scout/src/net/verdagon/vale/scout/ast.scala
+++ b/Valestrom/Scout/src/net/verdagon/vale/scout/ast.scala
@@ -71,7 +71,7 @@ object CodeLocationS {
   val testZero = CodeLocationS.internal(-1)
   def internal(internalNum: Int): CodeLocationS = {
     vassert(internalNum < 0)
-    CodeLocationS(FileCoordinate("", List(), "internal"), internalNum)
+    CodeLocationS(FileCoordinate("", List.empty, "internal"), internalNum)
   }
 }
 
@@ -299,7 +299,7 @@ case class FunctionS(
 //  // See SSRR.
 //  private def orderedRunes: List[String] = {
 //    (
-//      maybeUserSpecifiedIdentifyingRunes.getOrElse(List()) ++
+//      maybeUserSpecifiedIdentifyingRunes.getOrElse(List.empty) ++
 //      params.map(_.pattern).flatMap(PatternSUtils.getDistinctOrderedRunesForPattern) ++
 //      RuleSUtils.getDistinctOrderedRunesForRulexes(templateRules) ++
 //      maybeRetCoordRune.toList

--- a/Valestrom/Scout/src/net/verdagon/vale/scout/patterns/PatternScout.scala
+++ b/Valestrom/Scout/src/net/verdagon/vale/scout/patterns/PatternScout.scala
@@ -42,7 +42,7 @@ case class LetRuleState(
 object PatternScout {
   def getParameterCaptures(pattern: AtomSP): List[VariableDeclaration] = {
     val AtomSP(_, maybeCapture, _, _, maybeDestructure) = pattern
-    List() ++
+    List.empty ++
         getCaptureCaptures(maybeCapture) ++
         maybeDestructure.toList.flatten.flatMap(getParameterCaptures)
   }
@@ -83,8 +83,8 @@ object PatternScout {
 
     val (newRulesFromVirtuality, maybeVirtualityS) =
       maybeVirtualityP match {
-        case None => (List(), None)
-        case Some(AbstractP) => (List(), Some(AbstractSP))
+        case None => (List.empty, None)
+        case Some(AbstractP) => (List.empty, Some(AbstractSP))
         case Some(OverrideP(range, typeP)) => {
           typeP match {
             case InterpretedPT(range, _, _, _) => {
@@ -110,7 +110,7 @@ object PatternScout {
 
     val (newRulesFromDestructures, maybePatternsS) =
       maybeDestructureP match {
-        case None => (List(), None)
+        case None => (List.empty, None)
         case Some(DestructureP(_, destructureP)) => {
           val (newRulesFromDestructures, patternsS) =
             destructureP.foldLeft((List[IRulexSR](), List[AtomSP]()))({
@@ -198,7 +198,7 @@ object PatternScout {
     runeOnLeft: Boolean = true):
   (List[IRulexSR], Option[IRuneS]) = {
     if (maybeTypeP.isEmpty) {
-      (List(), None)
+      (List.empty, None)
     } else {
       val (newRules, rune) =
         translateMaybeTypeIntoRune(
@@ -248,19 +248,19 @@ object PatternScout {
     templexP match {
       case AnonymousRunePT(range) => {
         val rune = rulesS.newImplicitRune()
-        (List(), RuneST(evalRange(range), rune), Some(rune))
+        (List.empty, RuneST(evalRange(range), rune), Some(rune))
       }
-      case IntPT(range,value) => (List(), IntST(evalRange(range), value), None)
-      case BoolPT(range,value) => (List(), BoolST(evalRange(range), value), None)
+      case IntPT(range,value) => (List.empty, IntST(evalRange(range), value), None)
+      case BoolPT(range,value) => (List.empty, BoolST(evalRange(range), value), None)
       case NameOrRunePT(NameP(range, nameOrRune)) => {
         if (env.allUserDeclaredRunes().contains(CodeRuneS(nameOrRune))) {
-          (List(), RuneST(evalRange(range), CodeRuneS(nameOrRune)), Some(CodeRuneS(nameOrRune)))
+          (List.empty, RuneST(evalRange(range), CodeRuneS(nameOrRune)), Some(CodeRuneS(nameOrRune)))
         } else {
-          (List(), NameST(Scout.evalRange(env.file, range), CodeTypeNameS(nameOrRune)), None)
+          (List.empty, NameST(Scout.evalRange(env.file, range), CodeTypeNameS(nameOrRune)), None)
         }
       }
-      case MutabilityPT(range, mutability) => (List(), MutabilityST(evalRange(range), mutability), None)
-      case VariabilityPT(range, variability) => (List(), VariabilityST(evalRange(range), variability), None)
+      case MutabilityPT(range, mutability) => (List.empty, MutabilityST(evalRange(range), mutability), None)
+      case VariabilityPT(range, variability) => (List.empty, VariabilityST(evalRange(range), variability), None)
       case InterpretedPT(range,ownership,permission, innerP) => {
         val (newRules, innerS, _) =
           translatePatternTemplex(env, rulesS, innerP)

--- a/Valestrom/Scout/src/net/verdagon/vale/scout/patterns/patterns.scala
+++ b/Valestrom/Scout/src/net/verdagon/vale/scout/patterns/patterns.scala
@@ -26,8 +26,8 @@ object PatternSUtils {
   def getDistinctOrderedRunesForPattern(pattern: AtomSP): List[IRuneS] = {
     val runesFromVirtuality =
       pattern.virtuality match {
-        case None => List()
-        case Some(AbstractSP) => List()
+        case None => List.empty
+        case Some(AbstractSP) => List.empty
         case Some(OverrideSP(range, kindRune)) => List(kindRune)
       }
     val runesFromDestructures =

--- a/Valestrom/Scout/src/net/verdagon/vale/scout/templex.scala
+++ b/Valestrom/Scout/src/net/verdagon/vale/scout/templex.scala
@@ -122,16 +122,16 @@ case class ManualSequenceST(
 object TemplexSUtils {
   def getDistinctOrderedRunesForTemplex(templex: ITemplexS): List[IRuneS] = {
     templex match {
-      case StringST(_, _) => List()
-      case IntST(_, _) => List()
-      case MutabilityST(_, _) => List()
-      case PermissionST(_, _) => List()
-      case LocationST(_, _) => List()
-      case OwnershipST(_, _) => List()
-      case VariabilityST(_, _) => List()
-      case BoolST(_, _) => List()
-      case NameST(_, _) => List()
-      case AbsoluteNameST(_, _) => List()
+      case StringST(_, _) => List.empty
+      case IntST(_, _) => List.empty
+      case MutabilityST(_, _) => List.empty
+      case PermissionST(_, _) => List.empty
+      case LocationST(_, _) => List.empty
+      case OwnershipST(_, _) => List.empty
+      case VariabilityST(_, _) => List.empty
+      case BoolST(_, _) => List.empty
+      case NameST(_, _) => List.empty
+      case AbsoluteNameST(_, _) => List.empty
       case RuneST(_, rune) => List(rune)
       case InterpretedST(_, _, _, inner) => getDistinctOrderedRunesForTemplex(inner)
       case BorrowST(_, inner) => getDistinctOrderedRunesForTemplex(inner)
@@ -157,7 +157,7 @@ object TemplexSUtils {
 //  // we do elsewhere.
 //  def templexNamesToRunes(envName: INameS, runes: Set[IRuneS])(templex: ITemplexS): ITemplexS = {
 //    templex match {
-//      case NameST(ImpreciseNameS(List(), CodeTypeNameS(name))) if (runes.exists(_.last == CodeRuneS(name))) => RuneST(envName.addStep(CodeRuneS(name)))
+//      case NameST(ImpreciseNameS(List.empty, CodeTypeNameS(name))) if (runes.exists(_.last == CodeRuneS(name))) => RuneST(envName.addStep(CodeRuneS(name)))
 //      case NameST(iname) => NameST(iname)
 //      case IntST(value) => IntST(value)
 //      case MutabilityST(mutability) => MutabilityST(mutability)

--- a/Valestrom/Scout/test/net/verdagon/vale/scout/RunePredictorTests.scala
+++ b/Valestrom/Scout/test/net/verdagon/vale/scout/RunePredictorTests.scala
@@ -14,7 +14,7 @@ import scala.collection.immutable.List
 class RunePredictorTests extends FunSuite with Matchers {
   test("Predict doesnt crash for simple templex") {
     val conclusions =
-      PredictorEvaluator.solve(Set(), List(TemplexSR(NameST(RangeS.testZero, CodeTypeNameS("int")))), List())
+      PredictorEvaluator.solve(Set(), List(TemplexSR(NameST(RangeS.testZero, CodeTypeNameS("int")))), List.empty)
     conclusions shouldEqual Conclusions(Set(), Map())
   }
 
@@ -24,7 +24,7 @@ class RunePredictorTests extends FunSuite with Matchers {
         Set(),
         List(
           EqualsSR(RangeS.testZero,TemplexSR(RuneST(RangeS.testZero,CodeRuneS("T"))), TemplexSR(NameST(RangeS.testZero, CodeTypeNameS("int"))))),
-        List())
+        List.empty)
     conclusions shouldEqual Conclusions(Set(CodeRuneS("T")), Map())
   }
 
@@ -37,7 +37,7 @@ class RunePredictorTests extends FunSuite with Matchers {
           EqualsSR(RangeS.testZero,
             TemplexSR(RuneST(RangeS.testZero,CodeRuneS("Z"))),
             TemplexSR(CallST(RangeS.testZero,NameST(RangeS.testZero, CodeTypeNameS("MyOption")),List(InterpretedST(RangeS.testZero,ShareP,ReadonlyP, NameST(RangeS.testZero, CodeTypeNameS("int")))))))),
-        List())
+        List.empty)
     conclusions shouldEqual Conclusions(Set(CodeRuneS("Z")), Map(CodeRuneS("Z") -> CoordTypeSR))
   }
 
@@ -56,7 +56,7 @@ class RunePredictorTests extends FunSuite with Matchers {
               OrSR(RangeS.testZero,List(TemplexSR(OwnershipST(RangeS.testZero,OwnP)), TemplexSR(OwnershipST(RangeS.testZero,ShareP)))),
               // Not exactly valid but itll do for this test
               OrSR(RangeS.testZero,List(TypedSR(RangeS.testZero,aRune,KindTypeSR), TypedSR(RangeS.testZero,bRune,CoordTypeSR)))))),
-        List())
+        List.empty)
     conclusions shouldEqual
       Conclusions(Set(), Map(tRune -> CoordTypeSR, aRune -> KindTypeSR, bRune -> CoordTypeSR))
   }
@@ -76,7 +76,7 @@ class RunePredictorTests extends FunSuite with Matchers {
             OrSR(RangeS.testZero,List(TemplexSR(OwnershipST(RangeS.testZero,OwnP)), TemplexSR(OwnershipST(RangeS.testZero,ShareP)))),
             CallSR(RangeS.testZero,"passThroughIfConcrete",List(TemplexSR(RuneST(RangeS.testZero,CodeRuneS("Z"))))))),
         EqualsSR(RangeS.testZero,TypedSR(RangeS.testZero,CodeRuneS("V"),CoordTypeSR),CallSR(RangeS.testZero,"toRef",List(TemplexSR(NameST(RangeS.testZero, CodeTypeNameS("void"))))))),
-      List())
+      List.empty)
     conclusions shouldEqual
       Conclusions(
         Set(CodeRuneS("V")),
@@ -97,7 +97,7 @@ class RunePredictorTests extends FunSuite with Matchers {
         EqualsSR(RangeS.testZero,
           TemplexSR(RuneST(RangeS.testZero,CodeRuneS("Z"))),
           TemplexSR(RepeaterSequenceST(RangeS.testZero,MutabilityST(RangeS.testZero,MutableP), VariabilityST(RangeS.testZero,VaryingP), IntST(RangeS.testZero,5),InterpretedST(RangeS.testZero,ShareP,ReadonlyP,NameST(RangeS.testZero, CodeTypeNameS("int"))))))),
-      List())
+      List.empty)
     conclusions shouldEqual Conclusions(Set(CodeRuneS("Z")), Map(CodeRuneS("Z") -> CoordTypeSR))
   }
 
@@ -116,7 +116,7 @@ class RunePredictorTests extends FunSuite with Matchers {
             OrSR(RangeS.testZero,List(TemplexSR(OwnershipST(RangeS.testZero,OwnP)), TemplexSR(OwnershipST(RangeS.testZero,ShareP)))),
             CallSR(RangeS.testZero,"passThroughIfInterface",List(TemplexSR(RuneST(RangeS.testZero,CodeRuneS("Z"))))))),
         EqualsSR(RangeS.testZero,TypedSR(RangeS.testZero,CodeRuneS("V"),CoordTypeSR),CallSR(RangeS.testZero,"toRef",List(TemplexSR(NameST(RangeS.testZero, CodeTypeNameS("void"))))))),
-      List())
+      List.empty)
     conclusions shouldEqual
       Conclusions(
         Set(CodeRuneS("V")),
@@ -141,7 +141,7 @@ class RunePredictorTests extends FunSuite with Matchers {
             OrSR(RangeS.testZero,List(TemplexSR(OwnershipST(RangeS.testZero,OwnP)), TemplexSR(OwnershipST(RangeS.testZero,ShareP)))),
             CallSR(RangeS.testZero,"passThroughIfStruct",List(TemplexSR(RuneST(RangeS.testZero,CodeRuneS("Z"))))))),
         CallSR(RangeS.testZero,"passThroughIfInterface",List(TemplexSR(RuneST(RangeS.testZero,CodeRuneS("I")))))),
-      List())
+      List.empty)
     conclusions shouldEqual Conclusions(Set(), Map(CodeRuneS("T") -> CoordTypeSR))
   }
 
@@ -164,7 +164,7 @@ class RunePredictorTests extends FunSuite with Matchers {
                     RuneST(RangeS.testZero,CodeRuneS("R"))))))),
           TypedSR(RangeS.testZero,CodeRuneS("P1"),CoordTypeSR),
           TypedSR(RangeS.testZero,CodeRuneS("R"),CoordTypeSR)),
-        List())
+        List.empty)
     vassert(conclusions.knowableValueRunes.contains(CodeRuneS("P1")))
     vassert(conclusions.knowableValueRunes.contains(CodeRuneS("R")))
     vassert(conclusions.knowableValueRunes.contains(CodeRuneS("Z")))

--- a/Valestrom/Scout/test/net/verdagon/vale/scout/ScoutTests.scala
+++ b/Valestrom/Scout/test/net/verdagon/vale/scout/ScoutTests.scala
@@ -141,7 +141,7 @@ class ScoutTests extends FunSuite with Matchers {
     }
 
     // Yes, even though the user didnt specify any. See CCAUIR.
-    blork.identifyingRunes shouldEqual List()
+    blork.identifyingRunes shouldEqual List.empty
   }
 
   test("Impl") {
@@ -356,7 +356,7 @@ class ScoutTests extends FunSuite with Matchers {
     val CodeBody1(BodySE(_, _, block)) = main.body
     block match {
       case BlockSE(
-      _,List(),
+      _,Nil,
       List(
       DotSE(_,OutsideLoadSE(_,moo,None,LendConstraintP(None)),x,true))) =>
     }
@@ -374,7 +374,7 @@ class ScoutTests extends FunSuite with Matchers {
     val CodeBody1(BodySE(_, _, block)) = main.body
     block match {
       case BlockSE(
-      _,List(),
+      _,Nil,
       List(
       OwnershippedSE(_,
       DotSE(_,OutsideLoadSE(_,moo,None,LendConstraintP(None)),x,true),LendConstraintP(Some(ReadonlyP))))) =>
@@ -423,7 +423,7 @@ class ScoutTests extends FunSuite with Matchers {
     main.body match {
       case CodeBody1(
       BodySE(_,
-      List(),
+      Nil,
       BlockSE(_,
       List(LocalS(CodeVarNameS("this"), Used, NotUsed, NotUsed, NotUsed, NotUsed, NotUsed)),
       List(

--- a/Valestrom/Templar/Templar.iml
+++ b/Valestrom/Templar/Templar.iml
@@ -21,5 +21,6 @@
     <orderEntry type="module" module-name="Hinputs" />
     <orderEntry type="library" name="scala-sdk-2.12.6" level="application" />
     <orderEntry type="module" module-name="Builtins" />
+    <orderEntry type="library" name="scala-sdk-2.12.6" level="application" />
   </component>
 </module>

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/EdgeTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/EdgeTemplar.scala
@@ -47,7 +47,7 @@ object EdgeTemplar {
                     case _ => vwat()
                   }
                 }
-                case Some(List()) => vfail("wot")
+                case Some(Nil) => vfail("wot")
                 case Some(List(onlyOverride)) => FoundFunction(onlyOverride.header.toPrototype)
                 case Some(multipleOverrides) => {
                   vfail("Multiple overrides for struct " + struct + " for interface " + superInterface + ": " + multipleOverrides.map(_.header.toSignature).mkString(", "))
@@ -67,7 +67,7 @@ object EdgeTemplar {
   ): Map[(StructRefT, InterfaceRefT), List[(FunctionT, Int)]] = {
     temputs.getAllFunctions().toList.flatMap({ case overrideFunction =>
       overrideFunction.header.getOverride match {
-        case None => List()
+        case None => List.empty
         case Some((struct, superInterface)) => {
           // Make sure that the struct actually overrides that function
           if (!temputs.getAllImpls().exists(impl => impl.struct == struct && impl.interface == superInterface)) {
@@ -132,7 +132,7 @@ object EdgeTemplar {
     val abstractFunctionHeadersByInterfaceWithoutEmpties =
       temputs.getAllFunctions().flatMap({ case function =>
         function.header.getAbstractInterface match {
-          case None => List()
+          case None => List.empty
           case Some(abstractInterface) => List(abstractInterface -> function)
         }
       })

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/InferTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/InferTemplar.scala
@@ -61,7 +61,7 @@ class InferTemplar(
     localRunes: Set[IRuneA],
   ): (Map[IRuneT, ITemplata]) = {
     profiler.childFrame("inferOrdinaryRules", () => {
-      solve(env0, temputs, rules, typeByRune, localRunes, RangeS.internal(-13337), Map(), List(), None, true) match {
+      solve(env0, temputs, rules, typeByRune, localRunes, RangeS.internal(-13337), Map(), List.empty, None, true) match {
         case (InferSolveSuccess(inferences)) => {
           (inferences.templatasByRune)
         }

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/OverloadTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/OverloadTemplar.scala
@@ -201,17 +201,17 @@ class OverloadTemplar(
             templata match {
               case KindTemplata(OverloadSet(overloadsEnv, nameInOverloadsEnv, _)) => {
                 getCandidateBanners(
-                  overloadsEnv, temputs, callRange, nameInOverloadsEnv, explicitlySpecifiedTemplateArgTemplexesS, paramFilters, List(), exact)
+                  overloadsEnv, temputs, callRange, nameInOverloadsEnv, explicitlySpecifiedTemplateArgTemplexesS, paramFilters, List.empty, exact)
               }
               case KindTemplata(sr @ StructRefT(_)) => {
                 val structEnv = temputs.getEnvForStructRef(sr)
                 getCandidateBanners(
-                  structEnv, temputs, callRange, GlobalFunctionFamilyNameA(CallTemplar.CALL_FUNCTION_NAME), explicitlySpecifiedTemplateArgTemplexesS, paramFilters, List(), exact)
+                  structEnv, temputs, callRange, GlobalFunctionFamilyNameA(CallTemplar.CALL_FUNCTION_NAME), explicitlySpecifiedTemplateArgTemplexesS, paramFilters, List.empty, exact)
               }
               case KindTemplata(sr @ InterfaceRefT(_)) => {
                 val interfaceEnv = temputs.getEnvForInterfaceRef(sr)
                 getCandidateBanners(
-                  interfaceEnv, temputs, callRange, GlobalFunctionFamilyNameA(CallTemplar.CALL_FUNCTION_NAME), explicitlySpecifiedTemplateArgTemplexesS, paramFilters, List(), exact)
+                  interfaceEnv, temputs, callRange, GlobalFunctionFamilyNameA(CallTemplar.CALL_FUNCTION_NAME), explicitlySpecifiedTemplateArgTemplexesS, paramFilters, List.empty, exact)
               }
               case ExternFunctionTemplata(header) => {
                 paramsMatch(temputs, paramFilters, header.params, exact) match {
@@ -219,7 +219,7 @@ class OverloadTemplar(
                     (List(PotentialBannerFromExternFunction(header)), Map(), Map())
                   }
                   case (Some(rejectionReason)) => {
-                    (List(), Map(header.toBanner -> rejectionReason), Map())
+                    (List.empty, Map(header.toBanner -> rejectionReason), Map())
                   }
                 }
               }
@@ -277,13 +277,13 @@ class OverloadTemplar(
                         // And now that we know the types that are expected of these template arguments, we can
                         // run these template argument templexes through the solver so it can evaluate them in
                         // context of the current environment and spit out some templatas.
-                        ruleTyper.solve(temputs, env, equalsRules, callRange, List(), Some(templateArgRuneNamesA.toSet))
+                        ruleTyper.solve(temputs, env, equalsRules, callRange, List.empty, Some(templateArgRuneNamesA.toSet))
                       } catch {
                         case CompileErrorExceptionA(err) => throw CompileErrorExceptionT(InferAstronomerError(err))
                       }) match {
                         case (_, rtsf @ RuleTyperSolveFailure(_, _, _, _)) => {
                           val reason = WrongNumberOfTemplateArguments(identifyingRuneTemplataTypes.size, explicitlySpecifiedTemplateArgTemplexesS.size)
-                          (List(), Map(), Map(function -> reason))
+                          (List.empty, Map(), Map(function -> reason))
                         }
                         case (runeTypeConclusions, RuleTyperSolveSuccess(rulesA)) => {
                           // rulesA is the equals rules, but rule typed. Now we'll run them through the solver to get
@@ -294,9 +294,9 @@ class OverloadTemplar(
                           // We only want to solve the template arg runes
                           profiler.childFrame("late astronoming", () => {
                             inferTemplar.inferFromExplicitTemplateArgs(
-                                env, temputs, List(), rulesA, runeTypeConclusions.typeByRune, templateArgRuneNamesA.toSet, List(), None, callRange, List()) match {
+                                env, temputs, List.empty, rulesA, runeTypeConclusions.typeByRune, templateArgRuneNamesA.toSet, List.empty, None, callRange, List.empty) match {
                               case (isf @ InferSolveFailure(_, _, _, _, _, _, _)) => {
-                                (List(), Map(), Map(function -> InferFailure(isf)))
+                                (List.empty, Map(), Map(function -> InferFailure(isf)))
                               }
                               case (InferSolveSuccess(inferences)) => {
                                 val explicitlySpecifiedTemplateArgTemplatas = templateArgRuneNames2.map(inferences.templatasByRune)
@@ -304,12 +304,12 @@ class OverloadTemplar(
                                 functionTemplar.evaluateTemplatedFunctionFromCallForBanner(
                                   temputs, callRange, ft, explicitlySpecifiedTemplateArgTemplatas, paramFilters) match {
                                   case (EvaluateFunctionFailure(reason)) => {
-                                    (List(), Map(), Map(function -> reason))
+                                    (List.empty, Map(), Map(function -> reason))
                                   }
                                   case (EvaluateFunctionSuccess(banner)) => {
                                     paramsMatch(temputs, paramFilters, banner.params, exact) match {
                                       case (Some(rejectionReason)) => {
-                                        (List(), Map(banner -> rejectionReason), Map())
+                                        (List.empty, Map(banner -> rejectionReason), Map())
                                       }
                                       case (None) => {
                                         (List(PotentialBannerFromFunctionS(banner, ft)), Map(), Map())
@@ -327,14 +327,14 @@ class OverloadTemplar(
                       // So it's not a template, but it's a template in context. We'll still need to
                       // feed it into the inferer.
                       functionTemplar.evaluateTemplatedFunctionFromCallForBanner(
-                        temputs, callRange, ft, List(), paramFilters) match {
+                        temputs, callRange, ft, List.empty, paramFilters) match {
                         case (EvaluateFunctionFailure(reason)) => {
-                          (List(), Map(), Map(function -> reason))
+                          (List.empty, Map(), Map(function -> reason))
                         }
                         case (EvaluateFunctionSuccess(banner)) => {
                           paramsMatch(temputs, paramFilters, banner.params, exact) match {
                             case (Some(rejectionReason)) => {
-                              (List(), Map(banner -> rejectionReason), Map())
+                              (List.empty, Map(banner -> rejectionReason), Map())
                             }
                             case (None) => {
                               (List(PotentialBannerFromFunctionS(banner, ft)), Map(), Map())
@@ -353,7 +353,7 @@ class OverloadTemplar(
                         (List(PotentialBannerFromFunctionS(banner, ft)), Map(), Map())
                       }
                       case (Some(rejectionReason)) => {
-                        (List(), Map(banner -> rejectionReason), Map())
+                        (List.empty, Map(banner -> rejectionReason), Map())
                       }
                     }
                 }
@@ -372,11 +372,11 @@ class OverloadTemplar(
       (tyype.kind match {
         case sr @ StructRefT(_) => List(temputs.getEnvForStructRef(sr))
         case ir @ InterfaceRefT(_) => List(temputs.getEnvForInterfaceRef(ir))
-        case _ => List()
+        case _ => List.empty
       }) ++
         (virtuality match {
-          case None => List()
-          case Some(AbstractT$) => List()
+          case None => List.empty
+          case Some(AbstractT$) => List.empty
           case Some(OverrideT(ir)) => List(temputs.getEnvForInterfaceRef(ir))
         })
     })
@@ -521,16 +521,16 @@ class OverloadTemplar(
 
 
     val bannerWithBestScore =
-      if (bannerByIsBestScore.getOrElse(true, List()).isEmpty) {
+      if (bannerByIsBestScore.getOrElse(true, List.empty).isEmpty) {
         vfail("wat")
-      } else if (bannerByIsBestScore.getOrElse(true, List()).size > 1) {
+      } else if (bannerByIsBestScore.getOrElse(true, List.empty).size > 1) {
         throw CompileErrorExceptionT(RangedInternalErrorT(callRange, "Can't resolve between:\n" + bannerByIsBestScore.mapValues(_.mkString("\n")).mkString("\n")))
       } else {
         bannerByIsBestScore(true).head._1
       };
 
     val rejectedBanners =
-      bannerByIsBestScore.getOrElse(false, List()).map(_._1)
+      bannerByIsBestScore.getOrElse(false, List.empty).map(_._1)
     val rejectionReasonByBanner =
       rejectedBanners.map((_, Outscored())).toMap
 
@@ -548,7 +548,7 @@ class OverloadTemplar(
         if (ft.function.isTemplate) {
           val (EvaluateFunctionSuccess(banner)) =
             functionTemplar.evaluateTemplatedLightFunctionFromCallForBanner(
-              temputs, callRange, ft, List(), signature.paramTypes.map(p => ParamFilter(p, None)));
+              temputs, callRange, ft, List.empty, signature.paramTypes.map(p => ParamFilter(p, None)));
           (banner)
         } else {
           functionTemplar.evaluateOrdinaryFunctionFromNonCallForBanner(
@@ -603,7 +603,7 @@ class OverloadTemplar(
         ParamFilter(CoordT(ShareT, ReadonlyT, IntT.i32), None))
     val prototype =
       scoutExpectedFunctionForPrototype(
-        fate.snapshot, temputs, range, funcName, List(), paramFilters, List(), false) match {
+        fate.snapshot, temputs, range, funcName, List.empty, paramFilters, List.empty, false) match {
         case seff@ScoutExpectedFunctionFailure(name, args, outscoredReasonByPotentialBanner, rejectedReasonByBanner, rejectedReasonByFunction) => {
           throw CompileErrorExceptionT(RangedInternalErrorT(range, seff.toString))
         }

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/Templar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/Templar.scala
@@ -81,12 +81,12 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
           maybeReturnType2: Option[CoordT]):
         (FunctionHeaderT) = {
           val header =
-            FunctionHeaderT(namedEnv.fullName, List(), paramCoords, maybeReturnType2.get, maybeOriginFunction1)
+            FunctionHeaderT(namedEnv.fullName, List.empty, paramCoords, maybeReturnType2.get, maybeOriginFunction1)
           temputs.declareFunctionReturnType(header.toSignature, header.returnType)
           temputs.addFunction(
             FunctionT(
               header,
-              List(),
+              List.empty,
               BlockTE(List(ReturnTE(IsSameInstanceTE(ArgLookupTE(0, paramCoords(0).tyype), ArgLookupTE(1, paramCoords(1).tyype)))))))
           header
         }
@@ -105,7 +105,7 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
           maybeReturnType2: Option[CoordT]):
         (FunctionHeaderT) = {
           val header =
-            FunctionHeaderT(namedEnv.fullName, List(), paramCoords, maybeReturnType2.get, maybeOriginFunction1)
+            FunctionHeaderT(namedEnv.fullName, List.empty, paramCoords, maybeReturnType2.get, maybeOriginFunction1)
           temputs.declareFunctionReturnType(header.toSignature, header.returnType)
 
           val sourceKind = vassertSome(paramCoords.headOption).tyype.kind
@@ -162,7 +162,7 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
               }
             }
 
-          temputs.addFunction(FunctionT(header, List(), BlockTE(List(ReturnTE(asSubtypeExpr)))))
+          temputs.addFunction(FunctionT(header, List.empty, BlockTE(List(ReturnTE(asSubtypeExpr)))))
           header
         }
       })
@@ -357,7 +357,7 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
 
         override def resolveExactSignature(env: IEnvironment, state: Temputs, range: RangeS, name: String, coords: List[CoordT]): PrototypeT = {
           profiler.childFrame("InferTemplarDelegate.resolveExactSignature", () => {
-            overloadTemplar.scoutExpectedFunctionForPrototype(env, state, range, GlobalFunctionFamilyNameA(name), List(), coords.map(ParamFilter(_, None)), List(), true) match {
+            overloadTemplar.scoutExpectedFunctionForPrototype(env, state, range, GlobalFunctionFamilyNameA(name), List.empty, coords.map(ParamFilter(_, None)), List.empty, true) match {
               case sef@ScoutExpectedFunctionFailure(humanName, args, outscoredReasonByPotentialBanner, rejectedReasonByBanner, rejectedReasonByFunction) => {
                 throw new CompileErrorExceptionT(CouldntFindFunctionToCallT(range, sef))
                 throw CompileErrorExceptionT(RangedInternalErrorT(range, sef.toString))
@@ -507,7 +507,7 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
         val env0 =
           PackageEnvironment(
             None,
-            FullNameT(PackageCoordinate.BUILTIN, List(), PackageTopLevelNameT()),
+            FullNameT(PackageCoordinate.BUILTIN, List.empty, PackageTopLevelNameT()),
             newTemplataStore()
                 .addEntries(
                   opts.useOptimization,
@@ -581,7 +581,7 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
               if (isRootStruct(structS)) {
                 val _ =
                   structTemplar.getStructRef(
-                    temputs, structS.range, StructTemplata.make(env11, structS), List())
+                    temputs, structS.range, StructTemplata.make(env11, structS), List.empty)
               }
             }
           }
@@ -595,7 +595,7 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
               if (isRootInterface(interfaceS)) {
                 val _ =
                   structTemplar.getInterfaceRef(
-                    temputs, interfaceS.range, InterfaceTemplata.make(env11, interfaceS), List())
+                    temputs, interfaceS.range, InterfaceTemplata.make(env11, interfaceS), List.empty)
               }
             }
           }
@@ -622,7 +622,7 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
 //        // Should get a conflict if there are more than one.
 //        val (maybeNoArgMain, _, _, _) =
 //          overloadTemplar.scoutMaybeFunctionForPrototype(
-//            env11, temputs, RangeS.internal(-1398), GlobalFunctionFamilyNameA("main"), List(), List(), List(), true)
+//            env11, temputs, RangeS.internal(-1398), GlobalFunctionFamilyNameA("main"), List.empty, List.empty, List.empty, true)
 
 
         val edgeBlueprints = EdgeTemplar.makeInterfaceEdgeBlueprints(temputs)
@@ -671,45 +671,45 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
         val reachables = Reachability.findReachables(temputs, edgeBlueprintsAsList, edges)
 
         val categorizedFunctions = temputs.getAllFunctions().groupBy(f => reachables.functions.contains(f.header.toSignature))
-        val reachableFunctions = categorizedFunctions.getOrElse(true, List())
-        val unreachableFunctions = categorizedFunctions.getOrElse(false, List())
+        val reachableFunctions = categorizedFunctions.getOrElse(true, List.empty)
+        val unreachableFunctions = categorizedFunctions.getOrElse(false, List.empty)
         unreachableFunctions.foreach(f => debugOut("Shaking out unreachable: " + f.header.fullName))
         reachableFunctions.foreach(f => debugOut("Including: " + f.header.fullName))
 
         val categorizedSSAs = temputs.getAllStaticSizedArrays().groupBy(f => reachables.staticSizedArrays.contains(f))
-        val reachableSSAs = categorizedSSAs.getOrElse(true, List())
-        val unreachableSSAs = categorizedSSAs.getOrElse(false, List())
+        val reachableSSAs = categorizedSSAs.getOrElse(true, List.empty)
+        val unreachableSSAs = categorizedSSAs.getOrElse(false, List.empty)
         unreachableSSAs.foreach(f => debugOut("Shaking out unreachable: " + f))
         reachableSSAs.foreach(f => debugOut("Including: " + f))
 
         val categorizedRSAs = temputs.getAllRuntimeSizedArrays().groupBy(f => reachables.runtimeSizedArrays.contains(f))
-        val reachableRSAs = categorizedRSAs.getOrElse(true, List())
-        val unreachableRSAs = categorizedRSAs.getOrElse(false, List())
+        val reachableRSAs = categorizedRSAs.getOrElse(true, List.empty)
+        val unreachableRSAs = categorizedRSAs.getOrElse(false, List.empty)
         unreachableRSAs.foreach(f => debugOut("Shaking out unreachable: " + f))
         reachableRSAs.foreach(f => debugOut("Including: " + f))
 
         val categorizedStructs = temputs.getAllStructs().groupBy(f => reachables.structs.contains(f.getRef))
-        val reachableStructs = categorizedStructs.getOrElse(true, List())
-        val unreachableStructs = categorizedStructs.getOrElse(false, List())
+        val reachableStructs = categorizedStructs.getOrElse(true, List.empty)
+        val unreachableStructs = categorizedStructs.getOrElse(false, List.empty)
         unreachableStructs.foreach(f => debugOut("Shaking out unreachable: " + f.fullName))
         reachableStructs.foreach(f => debugOut("Including: " + f.fullName))
 
         val categorizedInterfaces = temputs.getAllInterfaces().groupBy(f => reachables.interfaces.contains(f.getRef))
-        val reachableInterfaces = categorizedInterfaces.getOrElse(true, List())
-        val unreachableInterfaces = categorizedInterfaces.getOrElse(false, List())
+        val reachableInterfaces = categorizedInterfaces.getOrElse(true, List.empty)
+        val unreachableInterfaces = categorizedInterfaces.getOrElse(false, List.empty)
         unreachableInterfaces.foreach(f => debugOut("Shaking out unreachable: " + f.fullName))
         reachableInterfaces.foreach(f => debugOut("Including: " + f.fullName))
 
         val categorizedEdges = edges.groupBy(f => reachables.edges.contains(f))
-        val reachableEdges = categorizedEdges.getOrElse(true, List())
-        val unreachableEdges = categorizedEdges.getOrElse(false, List())
+        val reachableEdges = categorizedEdges.getOrElse(true, List.empty)
+        val unreachableEdges = categorizedEdges.getOrElse(false, List.empty)
         unreachableEdges.foreach(f => debugOut("Shaking out unreachable: " + f))
         reachableEdges.foreach(f => debugOut("Including: " + f))
 
         val reachableKinds = (reachableStructs.map(_.getRef) ++ reachableInterfaces.map(_.getRef) ++ reachableSSAs ++ reachableRSAs).toSet[KindT]
         val categorizedDestructors = temputs.getKindToDestructorMap().groupBy({ case (kind, destructor) => reachableKinds.contains(kind) })
-        val reachableDestructors = categorizedDestructors.getOrElse(true, List())
-        val unreachableDestructors = categorizedDestructors.getOrElse(false, List())
+        val reachableDestructors = categorizedDestructors.getOrElse(true, List.empty)
+        val unreachableDestructors = categorizedDestructors.getOrElse(false, List.empty)
         unreachableDestructors.foreach(f => debugOut("Shaking out unreachable: " + f))
         reachableDestructors.foreach(f => debugOut("Including: " + f))
 
@@ -806,7 +806,7 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
         val partialEdges = EdgeTemplar.assemblePartialEdges(temputs)
         partialEdges.flatMap(e => e.methods.flatMap({
           case n @ NeededOverride(_, _) => List(n)
-          case FoundFunction(_) => List()
+          case FoundFunction(_) => List.empty
         }))
       })
     if (neededOverrides.isEmpty) {
@@ -824,9 +824,9 @@ class Templar(debugOut: (String) => Unit, verbose: Boolean, profiler: IProfiler,
           temputs,
           RangeS.internal(-1900),
           neededOverride.name,
-          List(), // No explicitly specified ones. It has to be findable just by param filters.
+          List.empty, // No explicitly specified ones. It has to be findable just by param filters.
           neededOverride.paramFilters,
-          List(),
+          List.empty,
           true) match {
           case (seff@ScoutExpectedFunctionFailure(_, _, _, _, _)) => {
             throw CompileErrorExceptionT(RangedInternalErrorT(RangeS.internal(-1674), "Couldn't find function for vtable!\n" + seff.toString))

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/citizen/ImplTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/citizen/ImplTemplar.scala
@@ -49,7 +49,7 @@ class AncestorHelper(
           rules,
           typeByRune,
           localRunes,
-          List(),
+          List.empty,
           None,
           RangeS.internal(-1875),
           List(KindTemplata(childCitizenRef)))
@@ -70,7 +70,7 @@ class AncestorHelper(
           }
           case it @ InterfaceTemplata(_, _) => {
             val interfaceRef =
-              delegate.getInterfaceRef(temputs, vimpl(), it, List())
+              delegate.getInterfaceRef(temputs, vimpl(), it, List.empty)
             (Some(interfaceRef))
           }
         }
@@ -84,7 +84,7 @@ class AncestorHelper(
   (List[InterfaceRefT]) = {
     val needleImplName =
       NameTranslator.getImplNameForName(opts.useOptimization, childCitizenRef) match {
-        case None => return List()
+        case None => return List.empty
         case Some(x) => x
       }
 
@@ -96,7 +96,7 @@ class AncestorHelper(
     citizenEnv.getAllTemplatasWithName(profiler, needleImplName, Set(TemplataLookupContext, ExpressionLookupContext))
       .flatMap({
         case it @ ImplTemplata(_, _) => getMaybeImplementedInterface(temputs, childCitizenRef, it).toList
-        case ExternImplTemplata(structRef, interfaceRef) => if (structRef == childCitizenRef) List(interfaceRef) else List()
+        case ExternImplTemplata(structRef, interfaceRef) => if (structRef == childCitizenRef) List(interfaceRef) else List.empty
         case other => vwat(other.toString)
       })
   }

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/citizen/StructTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/citizen/StructTemplar.scala
@@ -126,7 +126,7 @@ class StructTemplar(
           case KindTemplataType => FunctionTemplataType
           case TemplateTemplataType(params, KindTemplataType) => TemplateTemplataType(params, FunctionTemplataType)
         },
-        struct1.knowableRunes ++ (if (isTemplate) List() else List(retRune)),
+        struct1.knowableRunes ++ (if (isTemplate) List.empty else List(retRune)),
         struct1.identifyingRunes,
         struct1.localRunes ++ List(retRune),
         struct1.typeByRune + (retRune -> CoordTemplataType),
@@ -187,7 +187,7 @@ class StructTemplar(
 
       val templateParams =
         (interfaceA.tyype match {
-          case KindTemplataType => List()
+          case KindTemplataType => List.empty
           case TemplateTemplataType(params, KindTemplataType) => params
         }) ++
           interfaceA.internalMethods.map(meth => CoordTemplataType)
@@ -200,7 +200,7 @@ class StructTemplar(
         FunctionNameA(name, codeLocation),
         List(UserFunctionA),
         functionType,
-        interfaceA.knowableRunes ++ functorRunes ++ (if (isTemplate) List() else List(AnonymousSubstructParentInterfaceRuneA())),
+        interfaceA.knowableRunes ++ functorRunes ++ (if (isTemplate) List.empty else List(AnonymousSubstructParentInterfaceRuneA())),
         identifyingRunes,
         interfaceA.localRunes ++ functorRunes ++ List(AnonymousSubstructParentInterfaceRuneA()),
         typeByRune,
@@ -323,7 +323,7 @@ class StructTemplar(
       val constructorName =
         interfaceRef2.fullName
           .addStep(AnonymousSubstructNameT(List(functionStructType)))
-          .addStep(ConstructorNameT(List()))
+          .addStep(ConstructorNameT(List.empty))
       temputs.prototypeDeclared(constructorName) match {
         case Some(func) => return (anonymousSubstructRef, func)
         case None =>
@@ -334,11 +334,11 @@ class StructTemplar(
         FunctionT(
           FunctionHeaderT(
             constructorName,
-            List(),
-            List(),
+            List.empty,
+            List.empty,
             anonymousSubstructType,
             None),
-          List(),
+          List.empty,
           BlockTE(
             List(
               ReturnTE(
@@ -349,7 +349,7 @@ class StructTemplar(
                     ConstructTE(
                       functionStructRef,
                       CoordT(ShareT, ReadonlyT, functionStructRef),
-                      List())))))))
+                      List.empty)))))))
       temputs.declareFunctionSignature(range, constructor2.header.toSignature, None)
       temputs.declareFunctionReturnType(constructor2.header.toSignature, constructor2.header.returnType)
       temputs.addFunction(constructor2);

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/citizen/StructTemplarCore.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/citizen/StructTemplarCore.scala
@@ -23,7 +23,7 @@ class StructTemplarCore(
   def addBuiltInStructs(env: PackageEnvironment[INameT], temputs: Temputs): Unit = {
     val emptyTupleFullName = Program2.emptyTupleStructRef.fullName
     val emptyTupleEnv = PackageEnvironment(Some(env), emptyTupleFullName, newTemplataStore())
-    val structDef2 = StructDefinitionT(emptyTupleFullName, List(), false, ImmutableT, List(), false)
+    val structDef2 = StructDefinitionT(emptyTupleFullName, List.empty, false, ImmutableT, List.empty, false)
     temputs.declareStruct(structDef2.getRef)
     temputs.declareStructMutability(structDef2.getRef, ImmutableT)
     temputs.declareStructEnv(structDef2.getRef, emptyTupleEnv)
@@ -31,7 +31,7 @@ class StructTemplarCore(
     // Normally after adding a struct we would add its destructor. Void is the only one we don't
     // have a destructor for.
 
-    temputs.declarePack(List(), structDef2.getRef)
+    temputs.declarePack(List.empty, structDef2.getRef)
   }
 
   def makeStruct(
@@ -117,9 +117,9 @@ class StructTemplarCore(
                   temputs,
                   struct1.range,
                   GlobalFunctionFamilyNameA(CallTemplar.MUT_INTERFACE_DESTRUCTOR_NAME),
-                  List(),
+                  List.empty,
                   List(ParamFilter(CoordT(OwnT,ReadwriteT, structDef2.getRef), Some(OverrideT(implementedInterfaceRefT)))),
-                  List(),
+                  List.empty,
                   true)
               sefResult match {
                 case ScoutExpectedFunctionSuccess(_) =>
@@ -287,7 +287,7 @@ class StructTemplarCore(
 //    val mutability = Immutable
 //
 //    val nearName = FunctionScout.CLOSURE_STRUCT_NAME // For example "__Closure<main>:lam1"
-//    val fullName = FullName2(header.fullName.steps :+ NamePart2(nearName, Some(List()), None, None))
+//    val fullName = FullName2(header.fullName.steps :+ NamePart2(nearName, Some(List.empty), None, None))
 //
 //    val structRef = StructRef2(fullName)
 //
@@ -308,7 +308,7 @@ class StructTemplarCore(
 //    temputs.declareStructMutability(structRef, mutability)
 //    temputs.declareStructEnv(structRef, structEnv);
 //
-//    val closureStructDefinition = StructDefinition2(fullName, mutability, List(), true);
+//    val closureStructDefinition = StructDefinition2(fullName, mutability, List.empty, true);
 //    temputs.add(closureStructDefinition)
 //
 //    val closuredVarsStructRef = closureStructDefinition.getRef;
@@ -373,7 +373,7 @@ class StructTemplarCore(
     temputs.declareStructMutability(structRef, mutability)
     temputs.declareStructEnv(structRef, structEnv);
 
-    val closureStructDefinition = StructDefinitionT(fullName, List(), false, mutability, members, true);
+    val closureStructDefinition = StructDefinitionT(fullName, List.empty, false, mutability, members, true);
     temputs.add(closureStructDefinition)
 
     // If it's immutable, make sure there's a zero-arg destructor.
@@ -412,7 +412,7 @@ class StructTemplarCore(
         fullName,
         newTemplataStore())
 
-    val newStructDef = StructDefinitionT(structInnerEnv.fullName, List(), false, packMutability, members, false);
+    val newStructDef = StructDefinitionT(structInnerEnv.fullName, List.empty, false, packMutability, members, false);
     if (memberCoords.isEmpty && packMutability != ImmutableT)
       vfail("curiosity")
 
@@ -478,11 +478,11 @@ class StructTemplarCore(
 
           val FunctionNameT(humanName, _, _) = superFunctionName.last
           val fowarderName =
-            anonymousSubstructName.addStep(FunctionNameT(humanName, List(), params.map(_.tyype)))
+            anonymousSubstructName.addStep(FunctionNameT(humanName, List.empty, params.map(_.tyype)))
           val forwarderHeader =
             FunctionHeaderT(
               fowarderName,
-              List(),
+              List.empty,
               params,
               superReturnType,
               None)
@@ -523,7 +523,7 @@ class StructTemplarCore(
     val structDef =
       StructDefinitionT(
         anonymousSubstructName,
-        List(),
+        List.empty,
         interfaceDef.weakable,
         mutability,
         callables.zipWithIndex.map({ case (lambda, index) =>
@@ -561,9 +561,9 @@ class StructTemplarCore(
             temputs,
             range,
             GlobalFunctionFamilyNameA(CallTemplar.CALL_FUNCTION_NAME),
-            List(),
+            List.empty,
             forwardedCallArgs,
-            List(),
+            List.empty,
             true) match {
             case seff@ScoutExpectedFunctionFailure(_, _, _, _, _) => throw CompileErrorExceptionT(RangedInternalErrorT(range, seff.toString))
             case ScoutExpectedFunctionSuccess(prototype) => prototype
@@ -641,8 +641,8 @@ class StructTemplarCore(
       })
     val forwarderHeader =
       FunctionHeaderT(
-        structFullName.addStep(FunctionNameT(CallTemplar.CALL_FUNCTION_NAME, List(), forwarderParams.map(_.tyype))),
-        List(),
+        structFullName.addStep(FunctionNameT(CallTemplar.CALL_FUNCTION_NAME, List.empty, forwarderParams.map(_.tyype))),
+        List.empty,
         forwarderParams,
         prototype.returnType,
         None)
@@ -660,10 +660,10 @@ class StructTemplarCore(
     val structDef =
       StructDefinitionT(
         structFullName,
-        List(),
+        List.empty,
         false,
         ImmutableT,
-        List(),
+        List.empty,
         false)
     temputs.add(structDef)
 
@@ -677,7 +677,7 @@ class StructTemplarCore(
     val forwarderFunction =
       FunctionT(
         forwarderHeader,
-        List(),
+        List.empty,
         BlockTE(
           List(
             DiscardTE(ArgLookupTE(0, CoordT(ShareT, ReadonlyT, structRef))),
@@ -713,11 +713,11 @@ class StructTemplarCore(
       FunctionT(
         FunctionHeaderT(
           constructorFullName,
-          List(),
+          List.empty,
           constructorParams,
           constructorReturnType,
           maybeConstructorOriginFunctionA),
-        List(),
+        List.empty,
         BlockTE(
           List(
             ReturnTE(

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/citizen/StructTemplarTemplateArgsLayer.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/citizen/StructTemplarTemplateArgsLayer.scala
@@ -71,7 +71,7 @@ class StructTemplarTemplateArgsLayer(
               structA.rules,
               structA.typeByRune,
               structA.localRunes,
-              List(),
+              List.empty,
               None,
               callRange,
               templateArgs)
@@ -137,7 +137,7 @@ class StructTemplarTemplateArgsLayer(
               interfaceS.rules,
               interfaceS.typeByRune,
               interfaceS.localRunes,
-              List(),
+              List.empty,
               None,
               callRange,
               templateArgs)

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/expression/BlockTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/expression/BlockTemplar.scala
@@ -134,7 +134,7 @@ class BlockTemplar(
     expr1: List[IExpressionAE]):
   (List[ReferenceExpressionTE], Set[CoordT]) = {
     expr1 match {
-      case Nil => (List(), Set())
+      case Nil => (List.empty, Set())
       case first1 :: rest1 => {
         val (perhapsUndestructedFirstExpr2, returnsFromFirst) =
           delegate.evaluateAndCoerceToReferenceExpression(
@@ -167,7 +167,7 @@ class BlockTemplar(
     variables: List[ILocalVariableT]):
   (List[ReferenceExpressionTE]) = {
     variables match {
-      case Nil => (List())
+      case Nil => (List.empty)
       case head :: tail => {
         val unlet = UnreachableMootTE(localHelper.unletLocal(fate, head))
         val tailExprs2 = mootAll(temputs, fate, tail)

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/expression/CallTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/expression/CallTemplar.scala
@@ -69,7 +69,7 @@ class CallTemplar(
               functionName,
               explicitlySpecifiedTemplateArgTemplexesS,
               argsParamFilters,
-              List(),
+              List.empty,
               false) match {
             case (seff @ ScoutExpectedFunctionFailure(_, _, _, _, _)) => {
               throw CompileErrorExceptionT(CouldntFindFunctionToCallT(range, seff))
@@ -135,7 +135,7 @@ class CallTemplar(
         functionName,
         explicitlySpecifiedTemplateArgTemplexesS,
         argsParamFilters,
-        List(),
+        List.empty,
         false) match {
         case (seff @ ScoutExpectedFunctionFailure(_, _, _, _, _)) => {
           ErrorReporter.report(CouldntFindFunctionToCallT(range, seff))
@@ -205,7 +205,7 @@ class CallTemplar(
         argsTypes2.map(argType => ParamFilter(argType, None))
     val prototype2 =
       overloadTemplar.scoutExpectedFunctionForPrototype(
-        env, temputs, range, GlobalFunctionFamilyNameA(CallTemplar.CALL_FUNCTION_NAME), explicitlySpecifiedTemplateArgTemplexesS, paramFilters, List(), false) match {
+        env, temputs, range, GlobalFunctionFamilyNameA(CallTemplar.CALL_FUNCTION_NAME), explicitlySpecifiedTemplateArgTemplexesS, paramFilters, List.empty, false) match {
         case ScoutExpectedFunctionSuccess(p) => p
         case seff @ ScoutExpectedFunctionFailure(_, _, _, _, _) => {
           throw CompileErrorExceptionT(CouldntFindFunctionToCallT(range, seff))

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/expression/ExpressionTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/expression/ExpressionTemplar.scala
@@ -66,7 +66,7 @@ class ExpressionTemplar(
       exprs1: List[IExpressionAE]):
   (List[ReferenceExpressionTE], Set[CoordT]) = {
     exprs1 match {
-      case Nil => (List(), Set())
+      case Nil => (List.empty, Set())
       case first1 :: rest1 => {
         val (first2, returnsFromFirst) =
           evaluateAndCoerceToReferenceExpression(temputs, fate, first1);
@@ -377,7 +377,7 @@ class ExpressionTemplar(
           val (argsExprs2, returnsFromArgs) =
             evaluateAndCoerceToReferenceExpressions(temputs, fate, argsPackExpr1)
           val callExpr2 =
-            callTemplar.evaluateNamedPrefixCall(temputs, fate, range, GlobalFunctionFamilyNameA(name), List(), argsExprs2)
+            callTemplar.evaluateNamedPrefixCall(temputs, fate, range, GlobalFunctionFamilyNameA(name), List.empty, argsExprs2)
           (callExpr2, returnsFromArgs)
         }
         case FunctionCallAE(range, callableExpr1, argsExprs1) => {
@@ -390,7 +390,7 @@ class ExpressionTemplar(
           val (argsExprs2, returnsFromArgs) =
             evaluateAndCoerceToReferenceExpressions(temputs, fate, argsExprs1)
           val functionPointerCall2 =
-            callTemplar.evaluatePrefixCall(temputs, fate, range, decayedCallableReferenceExpr2, List(), argsExprs2)
+            callTemplar.evaluatePrefixCall(temputs, fate, range, decayedCallableReferenceExpr2, List.empty, argsExprs2)
           (functionPointerCall2, returnsFromCallable ++ returnsFromArgs)
         }
 
@@ -495,7 +495,7 @@ class ExpressionTemplar(
               case things if things.size > 1 => {
                 throw CompileErrorExceptionT(RangedInternalErrorT(range, "Found too many different things named \"" + name + "\" in env:\n" + things.map("\n" + _)))
               }
-              case List() => {
+              case Nil => {
                 //              println("members: " + fate.getAllTemplatasWithName(name, Set(ExpressionLookupContext, TemplataLookupContext)))
                 throw CompileErrorExceptionT(CouldntFindIdentifierToLoadT(range, name))
                 throw CompileErrorExceptionT(RangedInternalErrorT(range, "Couldn't find anything named \"" + name + "\" in env:\n" + fate))
@@ -1091,7 +1091,7 @@ class ExpressionTemplar(
       }
     val noneConstructor =
       delegate.evaluateTemplatedFunctionFromCallForPrototype(
-        temputs, range, noneConstructorTemplata, List(CoordTemplata(containedCoord)), List()) match {
+        temputs, range, noneConstructorTemplata, List(CoordTemplata(containedCoord)), List.empty) match {
         case seff@EvaluateFunctionFailure(_) => throw CompileErrorExceptionT(RangedInternalErrorT(range, seff.toString))
         case EvaluateFunctionSuccess(p) => p
       }

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/expression/LocalHelper.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/expression/LocalHelper.scala
@@ -60,7 +60,7 @@ class LocalHelper(
     variables: List[ILocalVariableT]):
   (List[ReferenceExpressionTE]) = {
     variables match {
-      case Nil => (List())
+      case Nil => (List.empty)
       case head :: tail => {
         val unlet = unletLocal(fate, head)
         val maybeHeadExpr2 =

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/expression/PatternTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/expression/PatternTemplar.scala
@@ -75,7 +75,7 @@ class PatternTemplar(
     profiler.newProfile("nonCheckingInferAndTranslate", fate.fullName.toString, () => {
 
       val templatasByRune =
-        inferTemplar.inferFromArgCoords(fate.snapshot, temputs, List(), rules, typeByRune, localRunes, List(pattern), None, pattern.range, List(), List(ParamFilter(inputExpr.resultRegister.reference, None))) match {
+        inferTemplar.inferFromArgCoords(fate.snapshot, temputs, List.empty, rules, typeByRune, localRunes, List(pattern), None, pattern.range, List.empty, List(ParamFilter(inputExpr.resultRegister.reference, None))) match {
           case (isf@InferSolveFailure(_, _, _, _, range, _, _)) => {
             throw CompileErrorExceptionT(RangedInternalErrorT(range, "Couldn't figure out runes for pattern!\n" + isf))
           }
@@ -223,7 +223,7 @@ class PatternTemplar(
 //        // Don't need output, since we're just doing a compile time check here
 //        ConvertHelper.convert(env, temputs, inputExpr, expectedPointerType)
 //
-//        (temputs, fate, List(), List())
+//        (temputs, fate, List.empty, List.empty)
 //      }
 //      case TypeOfSP(type1) => {
 //        val unborrowedTargetReference =
@@ -244,7 +244,7 @@ class PatternTemplar(
 //        // Don't need output, since we're just doing a compile time check here
 //        ConvertHelper.convert(env, temputs, inputExpr, targetReference)
 //
-//        (temputs, fate, List(), List())
+//        (temputs, fate, List.empty, List.empty)
 //      }
 //      case CaptureSP(name, variability, _, None) => already moved
 //      case CaptureSP(name, variability, _, Some(TypeOfSP(expectedType1))) => {

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/function/BuiltInFunctions.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/function/BuiltInFunctions.scala
@@ -57,7 +57,7 @@ object BuiltInFunctions {
         CodeBodyA(
           BodyAE(
             RangeS.internal(-62),
-            List(),
+            List.empty,
             BlockAE(
               RangeS.internal(-62),
               List(
@@ -104,7 +104,7 @@ object BuiltInFunctions {
         CodeBodyA(
           BodyAE(
             RangeS.internal(-62),
-            List(),
+            List.empty,
             BlockAE(
               RangeS.internal(-62),
               List(
@@ -115,10 +115,10 @@ object BuiltInFunctions {
         List(UserFunctionA),
         FunctionTemplataType,
         Set(),
-        List(),
+        List.empty,
         Set(CodeRuneA("N")),
         Map(CodeRuneA("N") -> CoordTemplataType),
-        List(),
+        List.empty,
         Some(CodeRuneA("N")),
         List(
           EqualsAR(RangeS.internal(-9125),
@@ -151,7 +151,7 @@ object BuiltInFunctions {
         CodeBodyA(
           BodyAE(
             RangeS.internal(-62),
-            List(),
+            List.empty,
             BlockAE(
               RangeS.internal(-62),
               List(

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/function/DestructorTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/function/DestructorTemplar.scala
@@ -34,9 +34,9 @@ class DestructorTemplar(
           } else {
             GlobalFunctionFamilyNameA(CallTemplar.MUT_DESTRUCTOR_NAME)
           },
-          List(),
+          List.empty,
           List(ParamFilter(type2, None)),
-          List(),
+          List.empty,
           true) match {
           case (seff@ScoutExpectedFunctionFailure(_, _, _, _, _)) => {
             throw CompileErrorExceptionT(RangedInternalErrorT(RangeS.internal(-1674), "Couldn't find concrete destructor!\n" + seff.toString))
@@ -54,9 +54,9 @@ class DestructorTemplar(
           } else {
             GlobalFunctionFamilyNameA(CallTemplar.MUT_INTERFACE_DESTRUCTOR_NAME)
           },
-          List(),
+          List.empty,
           List(ParamFilter(type2, None)),
-          List(),
+          List.empty,
           true) match {
           case (seff@ScoutExpectedFunctionFailure(_, _, _, _, _)) => {
             throw CompileErrorExceptionT(RangedInternalErrorT(RangeS.internal(-1674), "Couldn't find interface destructor!\n" + seff.toString))
@@ -84,9 +84,9 @@ class DestructorTemplar(
       } else {
         GlobalFunctionFamilyNameA(CallTemplar.MUT_DESTRUCTOR_NAME)
       },
-      List(),
+      List.empty,
       List(ParamFilter(type2, None)),
-      List(),
+      List.empty,
       true) match {
       case (seff@ScoutExpectedFunctionFailure(_, _, _, _, _)) => {
         throw CompileErrorExceptionT(RangedInternalErrorT(RangeS.internal(-1674), "Couldn't find array destructor!\n" + seff.toString))
@@ -111,9 +111,9 @@ class DestructorTemplar(
       } else {
         GlobalFunctionFamilyNameA(CallTemplar.MUT_DROP_FUNCTION_NAME)
       },
-      List(),
+      List.empty,
       List(ParamFilter(type2, None)),
-      List(),
+      List.empty,
       true) match {
       case (seff@ScoutExpectedFunctionFailure(_, _, _, _, _)) => {
         throw CompileErrorExceptionT(RangedInternalErrorT(RangeS.internal(-1674), "Couldn't find drop function!\n" + seff.toString))
@@ -225,11 +225,11 @@ class DestructorTemplar(
     val header =
       FunctionHeaderT(
         bodyEnv.fullName,
-        List(),
+        List.empty,
         List(ParameterT(CodeVarNameT("x"), None, type2)),
         CoordT(ShareT, ReadonlyT, VoidT()),
         Some(originFunction1))
-    val function2 = FunctionT(header, List(), BlockTE(List(dropExpr2, ReturnTE(VoidLiteralTE()))))
+    val function2 = FunctionT(header, List.empty, BlockTE(List(dropExpr2, ReturnTE(VoidLiteralTE()))))
     temputs.declareFunctionReturnType(header.toSignature, CoordT(ShareT, ReadonlyT, VoidT()))
     temputs.addFunction(function2)
     vassert(temputs.getDeclaredSignatureOrigin(bodyEnv.fullName) == Some(originFunction1.range))
@@ -256,7 +256,7 @@ class DestructorTemplar(
     val header =
       FunctionHeaderT(
         destructorFullName,
-        List(),
+        List.empty,
         params2,
         CoordT(ShareT, ReadonlyT, VoidT()),
         Some(originFunction1));
@@ -273,7 +273,7 @@ class DestructorTemplar(
         case StructMemberT(name, variability, AddressMemberTypeT(reference)) => {
           // See Destructure2 and its handling of addressible members for why
           // we don't include these in the destination variables.
-          List()
+          List.empty
         }
       })
 
@@ -318,7 +318,7 @@ class DestructorTemplar(
 
     val ifunctionExpression =
       StructToInterfaceUpcastTE(
-        FunctionCallTE(constructorPrototype, List()),
+        FunctionCallTE(constructorPrototype, List.empty),
         ifunction1InterfaceRef)
 
 
@@ -326,9 +326,9 @@ class DestructorTemplar(
       overloadTemplar.scoutExpectedFunctionForPrototype(
         env, temputs, RangeS.internal(-108),
         GlobalFunctionFamilyNameA(CallTemplar.CALL_FUNCTION_NAME),
-        List(),
+        List.empty,
         List(ParamFilter(ifunctionExpression.resultRegister.reference, None), ParamFilter(sequence.array.memberType, None)),
-        List(), true) match {
+        List.empty, true) match {
         case seff@ScoutExpectedFunctionFailure(_, _, _, _, _) => {
           vimpl()
         }
@@ -339,11 +339,11 @@ class DestructorTemplar(
       FunctionT(
         FunctionHeaderT(
           env.fullName,
-          List(),
+          List.empty,
           List(ParameterT(CodeVarNameT("this"), None, arrayRefType)),
           CoordT(ShareT, ReadonlyT, VoidT()),
           maybeOriginFunction1),
-        List(),
+        List.empty,
         BlockTE(
           List(
             DestroyStaticSizedArrayIntoFunctionTE(
@@ -375,16 +375,16 @@ class DestructorTemplar(
 
     val ifunctionExpression =
       StructToInterfaceUpcastTE(
-        FunctionCallTE(constructorPrototype, List()),
+        FunctionCallTE(constructorPrototype, List.empty),
         ifunction1InterfaceRef)
 
     val consumerMethod2 =
       overloadTemplar.scoutExpectedFunctionForPrototype(
         env, temputs, RangeS.internal(-108),
         GlobalFunctionFamilyNameA(CallTemplar.CALL_FUNCTION_NAME),
-        List(),
+        List.empty,
         List(ParamFilter(ifunctionExpression.resultRegister.reference, None), ParamFilter(array.array.memberType, None)),
-        List(), true) match {
+        List.empty, true) match {
         case seff@ScoutExpectedFunctionFailure(_, _, _, _, _) => {
           vimpl(seff.toString)
         }
@@ -395,11 +395,11 @@ class DestructorTemplar(
       FunctionT(
         FunctionHeaderT(
           env.fullName,
-          List(),
+          List.empty,
           List(ParameterT(CodeVarNameT("this"), None, arrayRefType2)),
           CoordT(ShareT, ReadonlyT, VoidT()),
           maybeOriginFunction1),
-        List(),
+        List.empty,
         BlockTE(
           List(
             DestroyRuntimeSizedArrayTE(
@@ -426,9 +426,9 @@ class DestructorTemplar(
       temputs,
       RangeS.internal(-1673),
       ImmConcreteDestructorImpreciseNameA(),
-      List(),
+      List.empty,
       List(ParamFilter(CoordT(ShareT, ReadonlyT, structRef2), None)),
-      List(),
+      List.empty,
       true) match {
       case (seff@ScoutExpectedFunctionFailure(_, _, _, _, _)) => {
         throw CompileErrorExceptionT(CouldntFindFunctionToCallT(RangeS.internal(-49), seff))
@@ -450,9 +450,9 @@ class DestructorTemplar(
         temputs,
         RangeS.internal(-1677),
         ImmInterfaceDestructorImpreciseNameA(),
-        List(),
+        List.empty,
         List(ParamFilter(CoordT(ShareT, ReadonlyT, interfaceRef2), None)),
-        List(),
+        List.empty,
         true) match {
         case (seff@ScoutExpectedFunctionFailure(_, _, _, _, _)) => {
           throw CompileErrorExceptionT(CouldntFindFunctionToCallT(RangeS.internal(-48), seff))
@@ -477,9 +477,9 @@ class DestructorTemplar(
         temputs,
         RangeS.internal(-1674),
         ImmInterfaceDestructorImpreciseNameA(),
-        List(),
+        List.empty,
         List(ParamFilter(CoordT(ShareT, ReadonlyT, structRef2), Some(OverrideT(implementedInterfaceRefT)))),
-        List(),
+        List.empty,
         true)
     sefResult match {
       case ScoutExpectedFunctionSuccess(prototype) => prototype

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/function/FunctionTemplarClosureOrLightLayer.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/function/FunctionTemplarClosureOrLightLayer.scala
@@ -153,7 +153,7 @@ class FunctionTemplarClosureOrLightLayer(
     vassert(!function.isTemplate)
 
     val name = makeNameWithClosureds(outerEnv, function.name)
-    val newEnv = BuildingFunctionEnvironmentWithClosureds(outerEnv, name, function, List(), newTemplataStore())
+    val newEnv = BuildingFunctionEnvironmentWithClosureds(outerEnv, name, function, List.empty, newTemplataStore())
     ordinaryOrTemplatedLayer.evaluateOrdinaryFunctionFromNonCallForPrototype(
       newEnv, temputs, callRange)
   }
@@ -246,7 +246,7 @@ class FunctionTemplarClosureOrLightLayer(
     function: FunctionA
   ): BuildingFunctionEnvironmentWithClosureds = {
     val name = makeNameWithClosureds(outerEnv, function.name)
-    BuildingFunctionEnvironmentWithClosureds(outerEnv, name, function, List(), newTemplataStore())
+    BuildingFunctionEnvironmentWithClosureds(outerEnv, name, function, List.empty, newTemplataStore())
   }
 
   private def makeNameWithClosureds(

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/function/FunctionTemplarCore.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/function/FunctionTemplarCore.scala
@@ -207,10 +207,10 @@ class FunctionTemplarCore(
 //        vassert(rightParamType == tyype)
 //
 //      }
-      case FunctionNameT(humanName, List(), params) => {
+      case FunctionNameT(humanName, Nil, params) => {
         val header = FunctionHeaderT(fullName, Extern2(range.file.packageCoordinate) :: attributes, params2, returnType2, maybeOrigin)
 
-        val externFullName = FullNameT(fullName.packageCoord, List(), ExternFunctionNameT(humanName, params))
+        val externFullName = FullNameT(fullName.packageCoord, List.empty, ExternFunctionNameT(humanName, params))
         val externPrototype = PrototypeT(externFullName, header.returnType)
         temputs.addFunctionExtern(externPrototype, fullName.packageCoord, humanName)
 
@@ -219,7 +219,7 @@ class FunctionTemplarCore(
         val function2 =
           FunctionT(
             header,
-            List(),
+            List.empty,
             ReturnTE(ExternFunctionCallTE(externPrototype, argLookups)))
 
         temputs.declareFunctionReturnType(header.toSignature, header.returnType)
@@ -250,14 +250,14 @@ class FunctionTemplarCore(
     val header =
       FunctionHeaderT(
         env.fullName,
-        List(),
+        List.empty,
         params2,
         returnReferenceType2,
         origin)
     val function2 =
       FunctionT(
         header,
-        List(),
+        List.empty,
         BlockTE(
           List(
             ReturnTE(
@@ -291,11 +291,11 @@ class FunctionTemplarCore(
       FunctionT(
         FunctionHeaderT(
           env.fullName,
-          List(),
+          List.empty,
           List(ParameterT(CodeVarNameT("this"), Some(OverrideT(interfaceRef2)), structType2)),
           CoordT(ShareT, ReadonlyT, VoidT()),
           maybeOriginFunction1),
-        List(),
+        List.empty,
         BlockTE(
           List(
             ReturnTE(

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/function/FunctionTemplarMiddleLayer.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/function/FunctionTemplarMiddleLayer.scala
@@ -65,7 +65,7 @@ class FunctionTemplarMiddleLayer(
           case Some(KindTemplata(ir @ InterfaceRefT(_))) => (Some(OverrideT(ir)))
           case Some(it @ InterfaceTemplata(_, _)) => {
             val ir =
-              structTemplar.getInterfaceRef(temputs, range, it, List())
+              structTemplar.getInterfaceRef(temputs, range, it, List.empty)
             (Some(OverrideT(ir)))
           }
         }

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/function/FunctionTemplarOrdinaryOrTemplatedLayer.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/function/FunctionTemplarOrdinaryOrTemplatedLayer.scala
@@ -47,7 +47,7 @@ class FunctionTemplarOrdinaryOrTemplatedLayer(
     val inferences =
       inferTemplar.inferOrdinaryRules(
         nearEnv, temputs, function.templateRules, function.typeByRune, function.localRunes)
-    val runedEnv = addRunedDataToNearEnv(nearEnv, List(), inferences)
+    val runedEnv = addRunedDataToNearEnv(nearEnv, List.empty, inferences)
 
     middleLayer.predictOrdinaryFunctionBanner(
       runedEnv, temputs, function)
@@ -66,7 +66,7 @@ class FunctionTemplarOrdinaryOrTemplatedLayer(
     val inferences =
       inferTemplar.inferOrdinaryRules(
         nearEnv, temputs, function.templateRules, function.typeByRune, function.localRunes)
-    val runedEnv = addRunedDataToNearEnv(nearEnv, List(), inferences)
+    val runedEnv = addRunedDataToNearEnv(nearEnv, List.empty, inferences)
 
     middleLayer.getOrEvaluateFunctionForBanner(runedEnv, temputs, callRange, function)
   }
@@ -97,7 +97,7 @@ class FunctionTemplarOrdinaryOrTemplatedLayer(
 //        function.params.map(_.pattern),
 //        function.maybeRetCoordRune,
 //        callRange,
-//        List(),
+//        List.empty,
 //        argTypes2.map(arg => ParamFilter(arg, None)))
 //    val InferSolveSuccess(inferredTemplatas) = maybeInferredTemplatas
 //
@@ -215,7 +215,7 @@ class FunctionTemplarOrdinaryOrTemplatedLayer(
 //    checkClosureConcernsHandled(nearEnv)
 //    vassert(nearEnv.function.isTemplate)
 //
-//    vassert(nearEnv.function.identifyingRunes.size == List().size);
+//    vassert(nearEnv.function.identifyingRunes.size == List.empty.size);
 //
 //    val result =
 //      inferTemplar.inferFromExplicitTemplateArgs(
@@ -228,7 +228,7 @@ class FunctionTemplarOrdinaryOrTemplatedLayer(
 //        function.params.map(_.pattern),
 //        callRange,
 //        function.maybeRetCoordRune,
-//        List())
+//        List.empty)
 //    val inferences =
 //      result match {
 //        case isf @ InferSolveFailure(_, _, _, _, _, _, _) => {
@@ -237,7 +237,7 @@ class FunctionTemplarOrdinaryOrTemplatedLayer(
 //        case InferSolveSuccess(i) => i
 //      }
 //
-//    val runedEnv = addRunedDataToNearEnv(nearEnv, List(), inferences.templatasByRune)
+//    val runedEnv = addRunedDataToNearEnv(nearEnv, List.empty, inferences.templatasByRune)
 //
 //    middleLayer.getOrEvaluateFunctionForHeader(runedEnv, temputs, function)
 //  }
@@ -259,7 +259,7 @@ class FunctionTemplarOrdinaryOrTemplatedLayer(
     val inferences =
       inferTemplar.inferOrdinaryRules(
         nearEnv, temputs, function.templateRules, function.typeByRune, function.localRunes)
-    val runedEnv = addRunedDataToNearEnv(nearEnv, List(), inferences)
+    val runedEnv = addRunedDataToNearEnv(nearEnv, List.empty, inferences)
 
     middleLayer.getOrEvaluateFunctionForHeader(
       runedEnv, temputs, callRange, function)
@@ -282,7 +282,7 @@ class FunctionTemplarOrdinaryOrTemplatedLayer(
     val inferences =
       inferTemplar.inferOrdinaryRules(
         nearEnv, temputs, function.templateRules, function.typeByRune, function.localRunes)
-    val runedEnv = addRunedDataToNearEnv(nearEnv, List(), inferences)
+    val runedEnv = addRunedDataToNearEnv(nearEnv, List.empty, inferences)
 
     middleLayer.getOrEvaluateFunctionForPrototype(
       runedEnv, temputs, callRange, function)

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/function/VirtualTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/function/VirtualTemplar.scala
@@ -59,7 +59,7 @@ class VirtualTemplar(opts: TemplarOptions, overloadTemplar: OverloadTemplar) {
         val extraEnvsToLookIn = List(superInterfaceEnv)
 
         overloadTemplar.scoutExpectedFunctionForPrototype(
-          env, temputs, RangeS.internal(-1388), nameToScoutFor, List(), needleSuperFunctionParamFilters, extraEnvsToLookIn, true) match {
+          env, temputs, RangeS.internal(-1388), nameToScoutFor, List.empty, needleSuperFunctionParamFilters, extraEnvsToLookIn, true) match {
           case (ScoutExpectedFunctionSuccess(_)) => {
             // Throw away the prototype, we just want it to be in the temputs.
 

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/infer/InfererEquator.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/infer/InfererEquator.scala
@@ -21,7 +21,7 @@ class InfererEquator[Env, State](
     (left, right) match {
       case (KindTemplata(leftKind), rightStructTemplata @ StructTemplata(_, _)) => {
         val rightKind =
-          templataTemplarInner.evaluateStructTemplata(state, range, rightStructTemplata, List(), expectedType)
+          templataTemplarInner.evaluateStructTemplata(state, range, rightStructTemplata, List.empty, expectedType)
         (leftKind == rightKind)
       }
       case (KindTemplata(leftKind), KindTemplata(rightKind)) => {

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/infer/InfererEvaluator.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/infer/InfererEvaluator.scala
@@ -70,7 +70,7 @@ class InfererEvaluator[Env, State](
         case ((rune, directInputTemplata)) => {
           val expectedType = vassertSome(typeByRune.get(rune))
           if (directInputTemplata.tyype != expectedType) {
-            return (InferSolveFailure(typeByRune, directInputs, maybeParamInputs, inferences.inferences, invocationRange, "Input for rune " + rune + " has type " + directInputTemplata.tyype + " that doesn't match expected type: " + expectedType, List()))
+            return (InferSolveFailure(typeByRune, directInputs, maybeParamInputs, inferences.inferences, invocationRange, "Input for rune " + rune + " has type " + directInputTemplata.tyype + " that doesn't match expected type: " + expectedType, List.empty))
           }
           inferences.addConclusion(rune, directInputTemplata)
         }
@@ -92,7 +92,7 @@ class InfererEvaluator[Env, State](
 
     val rulesAndAddedRunesTypeByRuneFromParamInputs =
       maybeParamInputs match {
-        case None => List()
+        case None => List.empty
         case Some(paramInputs) => {
           if (paramAtoms.size != paramInputs.size) {
             return InferSolveFailure(
@@ -104,7 +104,7 @@ class InfererEvaluator[Env, State](
               "Expected " + paramAtoms.size + " args but got " + paramInputs.size + "\n" +
               "Expected:\n" + paramAtoms.zipWithIndex.map({ case (paramAtom, i) => "  " + i + " " + paramAtom }).mkString("\n") + "\n" +
               "Got:\n" + paramInputs.zipWithIndex.map({ case (paramInput, i) => "  " + i + " " + paramInput }).mkString("\n"),
-              List())
+              List.empty)
           }
           paramAtoms.zip(paramInputs).zipWithIndex.map({
             case (((paramAtom, paramFilterInstance), paramIndex)) => {
@@ -137,11 +137,11 @@ class InfererEvaluator[Env, State](
       val neededRunes = localRunes
       if ((neededRunes -- inferences.inferences.templatasByRune.keySet).nonEmpty) {
         val message = "Not enough to solve! Couldn't figure out: " + (neededRunes -- inferences.inferences.templatasByRune.keySet)
-        return (InferSolveFailure(combinedTypeByRune, directInputs, maybeParamInputs, inferences.inferences, invocationRange, message, List()))
+        return (InferSolveFailure(combinedTypeByRune, directInputs, maybeParamInputs, inferences.inferences, invocationRange, message, List.empty))
       }
     }
     if (!deeplySatisfied) {
-      return (InferSolveFailure(combinedTypeByRune, directInputs, maybeParamInputs, inferences.inferences, invocationRange, "Not deeply satisfied!", List()))
+      return (InferSolveFailure(combinedTypeByRune, directInputs, maybeParamInputs, inferences.inferences, invocationRange, "Not deeply satisfied!", List.empty))
     }
 
     (InferSolveSuccess(inferences.inferences))
@@ -207,13 +207,13 @@ class InfererEvaluator[Env, State](
             case _ =>
           }
           inferences.addConclusion(patternCoordRune2, CoordTemplata(paramFilterInstance.tyype))
-          (List(), Map[IRuneT, ITemplataType]())
+          (List.empty, Map[IRuneT, ITemplataType]())
         }
       }
     val rulesFromVirtuality =
       (paramFilterInstance.virtuality, patternVirtuality) match {
-        case (None, _) => List()
-        case (Some(AbstractT$), Some(AbstractAP)) => List()
+        case (None, _) => List.empty
+        case (Some(AbstractT$), Some(AbstractAP)) => List.empty
         case (Some(OverrideT(superInterface)), Some(OverrideAP(range, superInterfaceRune))) => {
           // We might already have this superInterface figured out.
           inferences.templatasByRune.get(NameTranslator.translateRune(superInterfaceRune)) match {
@@ -223,11 +223,11 @@ class InfererEvaluator[Env, State](
               inferences.addPossibilities(
                 NameTranslator.translateRune(superInterfaceRune),
                 selfAndAncestors.map(KindTemplata))
-              List()
+              List.empty
             }
             case Some(existingInference) => {
               vassert(existingInference == KindTemplata(superInterface))
-              List()
+              List.empty
             }
           }
         }
@@ -241,10 +241,10 @@ class InfererEvaluator[Env, State](
             Map())
         }
       }
-    vcurious(rulesFromVirtuality == List()) // do no rules come from virtuality?
+    vcurious(rulesFromVirtuality == List.empty) // do no rules come from virtuality?
     val rulesFromPatternDestructure =
       maybePatternDestructure match {
-        case None => List()
+        case None => List.empty
         case Some(patternDestructures) => {
           addDestructureRules(state, inferences, invocationRange, paramFilterInstance.tyype, patternDestructures, paramLocation) match {
             case iec @ InferEvaluateConflict(_, _, _, _) => return (iec, Map())
@@ -300,7 +300,7 @@ class InfererEvaluator[Env, State](
 
           val rulesFromPatternDestructure =
             maybePatternDestructure match {
-              case None => List()
+              case None => List.empty
               case Some(patternDestructures) => {
                 val memberLocation = paramLocation :+ memberIndex
                 addDestructureRules(state, inferences, range, memberCoord, patternDestructures, memberLocation) match {
@@ -357,7 +357,7 @@ class InfererEvaluator[Env, State](
 //          println("possibilities to try:\n" + possibilities.mkString("\n"))
 
           possibilities match {
-            case List() => vwat()
+            case Nil => vwat()
             case List(onlyPossibility) => {
               inferences.addConclusion(rune, onlyPossibility)
               solveUntilSettled(env, state, rules, typeByRune, localRunes, inferences, invocationRange)
@@ -388,7 +388,7 @@ class InfererEvaluator[Env, State](
                       case (iss @ InferEvaluateSuccess(_, _)) => {
 //                        println("it worked!")
                         inferences.inferences = alternateUniverseInferencesBox.inferences
-                        (List(), Some(iss))
+                        (List.empty, Some(iss))
                       }
                     }
                   }
@@ -438,7 +438,7 @@ class InfererEvaluator[Env, State](
     rules: List[IRulexTR],
   ): (IInferEvaluateResult[List[ITemplata]]) = {
     val initialResult: IInferEvaluateResult[List[ITemplata]] =
-      InferEvaluateSuccess(List(), true)
+      InferEvaluateSuccess(List.empty, true)
     rules.zipWithIndex.foldLeft((initialResult))({
       case ((InferEvaluateUnknown(deeplySatisfiedSoFar)), (rule, index)) => {
         evaluateRule(env, state, typeByRune, localRunes, inferences, rule) match {
@@ -556,7 +556,7 @@ class InfererEvaluator[Env, State](
           case k @ KindTemplata(StructRefT(_) | PackTT(_, _) | TupleTT(_, _) | StaticSizedArrayTT(_, _) | RuntimeSizedArrayTT(_)) => {
             (InferEvaluateSuccess(k, deeplySatisfied))
           }
-          case _ => return (InferEvaluateConflict(inferences.inferences, range, "passThroughIfConcrete expected concrete kind, but got " + templata, List()))
+          case _ => return (InferEvaluateConflict(inferences.inferences, range, "passThroughIfConcrete expected concrete kind, but got " + templata, List.empty))
         }
       }
       case "passThroughIfInterface" => {
@@ -582,7 +582,7 @@ class InfererEvaluator[Env, State](
             (InferEvaluateSuccess(k, deeplySatisfied))
           }
           case _ => {
-            return (InferEvaluateConflict(inferences.inferences, range, "passThroughIfInterface expected interface kind, but got " + templata, List()))
+            return (InferEvaluateConflict(inferences.inferences, range, "passThroughIfInterface expected interface kind, but got " + templata, List.empty))
           }
         }
       }
@@ -609,7 +609,7 @@ class InfererEvaluator[Env, State](
             (InferEvaluateSuccess(k, deeplySatisfied))
           }
           case _ => {
-            return (InferEvaluateConflict(inferences.inferences, range, "passThroughIfStruct expected struct kind, but got " + templata, List()))
+            return (InferEvaluateConflict(inferences.inferences, range, "passThroughIfStruct expected struct kind, but got " + templata, List.empty))
           }
         }
       }
@@ -659,7 +659,7 @@ class InfererEvaluator[Env, State](
           inferences.templatasByRune.get(rune) match {
             case Some(templata) => {
               if (templata.tyype != expectedType) {
-                return (InferEvaluateConflict(inferences.inferences, range, "Rune " + rune + " is of type " + expectedType + ", but it received a " + templata.tyype + ", specifically " + templata, List()))
+                return (InferEvaluateConflict(inferences.inferences, range, "Rune " + rune + " is of type " + expectedType + ", but it received a " + templata.tyype + ", specifically " + templata, List.empty))
               }
               (InferEvaluateSuccess(templata, true))
             }
@@ -673,7 +673,7 @@ class InfererEvaluator[Env, State](
           // such as when we do spaceship.fly() in TMRE.
           val templata = delegate.lookupTemplata(env, range, rune)
           if (templata.tyype != expectedType) {
-            return (InferEvaluateConflict(inferences.inferences, range, "Rune " + rune + " is of type " + expectedType + ", but it received a " + templata.tyype + ", specifically " + templata, List()))
+            return (InferEvaluateConflict(inferences.inferences, range, "Rune " + rune + " is of type " + expectedType + ", but it received a " + templata.tyype + ", specifically " + templata, List.empty))
           }
           (InferEvaluateSuccess(templata, true))
         }
@@ -694,21 +694,21 @@ class InfererEvaluator[Env, State](
 
             val resultingOwnership =
               (innerCoordOwnership, targetOwnership) match {
-                case (OwnT, ShareP) => return (InferEvaluateConflict(inferences.inferences, range, "Expected a share, but was an own!", List()))
+                case (OwnT, ShareP) => return (InferEvaluateConflict(inferences.inferences, range, "Expected a share, but was an own!", List.empty))
                 case (OwnT, OwnP) => OwnT // No change, allow it
                 case (OwnT, ConstraintP) => ConstraintT // Can borrow an own, allow it
                 case (OwnT, WeakP) => WeakT // Can weak an own, allow it
-                case (ConstraintT, ShareP) => return (InferEvaluateConflict(inferences.inferences, range, "Expected a share, but was a borrow!", List()))
+                case (ConstraintT, ShareP) => return (InferEvaluateConflict(inferences.inferences, range, "Expected a share, but was a borrow!", List.empty))
                 case (ConstraintT, OwnP) => OwnT // Can turn a borrow into an own, allow it
                 case (ConstraintT, ConstraintP) => ConstraintT // No change, allow it
                 case (ConstraintT, WeakP) => WeakT // Can weak a borrow, allow it
-                case (WeakT, ShareP) => return (InferEvaluateConflict(inferences.inferences, range, "Expected a share, but was a weak!", List()))
-                case (WeakT, OwnP) => return (InferEvaluateConflict(inferences.inferences, range, "Expected a own, but was a weak!", List()))
-                case (WeakT, ConstraintP) => return (InferEvaluateConflict(inferences.inferences, range, "Expected a borrow, but was a weak!", List()))
+                case (WeakT, ShareP) => return (InferEvaluateConflict(inferences.inferences, range, "Expected a share, but was a weak!", List.empty))
+                case (WeakT, OwnP) => return (InferEvaluateConflict(inferences.inferences, range, "Expected a own, but was a weak!", List.empty))
+                case (WeakT, ConstraintP) => return (InferEvaluateConflict(inferences.inferences, range, "Expected a borrow, but was a weak!", List.empty))
                 case (WeakT, WeakP) => WeakT // No change, allow it
                 case (ShareT, OwnP) => ShareT // Can own a share, just becomes another share.
                 case (ShareT, ConstraintP) => ShareT // Can borrow a share, just becomes another share.
-                case (ShareT, WeakP) => return (InferEvaluateConflict(inferences.inferences, range, "Expected a weak, but was a share!", List())) // Cant get a weak ref to a share because it doesnt have lock().
+                case (ShareT, WeakP) => return (InferEvaluateConflict(inferences.inferences, range, "Expected a weak, but was a share!", List.empty)) // Cant get a weak ref to a share because it doesnt have lock().
                 case (ShareT, ShareP) => ShareT // No change, allow it
               }
 
@@ -1032,7 +1032,7 @@ class InfererEvaluator[Env, State](
           val deeplySatisfied = subDeeplySatisfied && conceptDeeplySatisfied && isaSatisfied
           (InferEvaluateSuccess(KindTemplata(sub), deeplySatisfied))
         } else {
-          return (InferEvaluateConflict(inferences.inferences, range, "Isa failed!\nSub: " + sub + "\nSuper: " + suuper, List()))
+          return (InferEvaluateConflict(inferences.inferences, range, "Isa failed!\nSub: " + sub + "\nSuper: " + suuper, List.empty))
         }
       }
       case (Some(_), Some(_)) => vfail()
@@ -1321,19 +1321,19 @@ class InfererEvaluator[Env, State](
       case sr @ StructRefT(_) => {
         val memberCoords = delegate.getMemberCoords(state, sr)
         if (memberCoords.size != expectedNumMembers) {
-          return InferEvaluateConflict(inferences.inferences, range, "Expected something with " + expectedNumMembers + " members but received " + kind, List())
+          return InferEvaluateConflict(inferences.inferences, range, "Expected something with " + expectedNumMembers + " members but received " + kind, List.empty)
         }
         InferEvaluateSuccess(memberCoords, true)
       }
       case PackTT(members, _) => {
         if (members.size != expectedNumMembers) {
-          return InferEvaluateConflict(inferences.inferences, range, "Expected something with " + expectedNumMembers + " members but received " + kind, List())
+          return InferEvaluateConflict(inferences.inferences, range, "Expected something with " + expectedNumMembers + " members but received " + kind, List.empty)
         }
         InferEvaluateSuccess(members, true)
       }
       case TupleTT(members, _) => {
         if (members.size != expectedNumMembers) {
-          return InferEvaluateConflict(inferences.inferences, range, "Expected something with " + expectedNumMembers + " members but received " + kind, List())
+          return InferEvaluateConflict(inferences.inferences, range, "Expected something with " + expectedNumMembers + " members but received " + kind, List.empty)
         }
         InferEvaluateSuccess(members, true)
       }
@@ -1341,12 +1341,12 @@ class InfererEvaluator[Env, State](
         // We need to do this check right here because right after this we're making an array of size `size`
         // which we just received as an integer from the user.
         if (size != expectedNumMembers) {
-          return InferEvaluateConflict(inferences.inferences, range, "Expected something with " + expectedNumMembers + " members but received " + kind, List())
+          return InferEvaluateConflict(inferences.inferences, range, "Expected something with " + expectedNumMembers + " members but received " + kind, List.empty)
         }
         InferEvaluateSuccess((0 until size).toList.map(_ => memberType), true)
       }
       case _ => {
-        return InferEvaluateConflict(inferences.inferences, range, "Expected something destructurable but received " + kind, List())
+        return InferEvaluateConflict(inferences.inferences, range, "Expected something destructurable but received " + kind, List.empty)
       }
     }
   }

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/infer/InfererMatcher.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/infer/InfererMatcher.scala
@@ -71,7 +71,7 @@ class InfererMatcher[Env, State](
         // such as when we do spaceship.fly() in TMRE.
         val templataFromEnv = delegate.lookupTemplata(env, range, rune)
         if (templataFromEnv.tyype != expectedType) {
-          return (InferMatchConflict(inferences.inferences, range, "Rune " + rune + " is of type " + expectedType + ", but it received a " + templataFromEnv.tyype + ", specifically " + templataFromEnv, List()))
+          return (InferMatchConflict(inferences.inferences, range, "Rune " + rune + " is of type " + expectedType + ", but it received a " + templataFromEnv.tyype + ", specifically " + templataFromEnv, List.empty))
         }
         templataFromEnv
       }
@@ -80,7 +80,7 @@ class InfererMatcher[Env, State](
     if (equal) {
       (InferMatchSuccess(true))
     } else {
-      (InferMatchConflict(inferences.inferences, range, s"Disagreement about templata #${rune}:\n${alreadyExistingTemplata}\n${instance}", List()))
+      (InferMatchConflict(inferences.inferences, range, s"Disagreement about templata #${rune}:\n${alreadyExistingTemplata}\n${instance}", List.empty))
     }
   }
 
@@ -104,7 +104,7 @@ class InfererMatcher[Env, State](
         if (instance == alreadyInferredCoord) {
           (InferMatchSuccess(true))
         } else {
-          (InferMatchConflict(inferences.inferences, range, s"Disagreement about ref #${coordRune}:\n${CoordTemplata(alreadyInferredCoord)}\n${instance}", List()))
+          (InferMatchConflict(inferences.inferences, range, s"Disagreement about ref #${coordRune}:\n${CoordTemplata(alreadyInferredCoord)}\n${instance}", List.empty))
         }
       }
     }
@@ -129,7 +129,7 @@ class InfererMatcher[Env, State](
         if (instance == alreadyInferredKind) {
           (InferMatchSuccess(true))
         } else {
-          (InferMatchConflict(inferences.inferences, range, s"Disagreement about kind #${alreadyInferredKind}:\n${KindTemplata(alreadyInferredKind)}\n${instance}", List()))
+          (InferMatchConflict(inferences.inferences, range, s"Disagreement about kind #${alreadyInferredKind}:\n${KindTemplata(alreadyInferredKind)}\n${instance}", List.empty))
         }
       }
     }
@@ -199,7 +199,7 @@ class InfererMatcher[Env, State](
       ((instance.virtuality, virtuality) match {
         case (None, _) => (true)
         case (Some(AbstractT$), Some(AbstractSP)) => (true)
-        case (Some(AbstractT$), _) => return (InferMatchConflict(inferences.inferences, patternRange, s"ParamFilter virtuality didn't match rule:\n${instance.virtuality}\n${virtuality}", List()))
+        case (Some(AbstractT$), _) => return (InferMatchConflict(inferences.inferences, patternRange, s"ParamFilter virtuality didn't match rule:\n${instance.virtuality}\n${virtuality}", List.empty))
         case (Some(OverrideT(instanceSuperInterfaceRef2)), Some(OverrideSP(range, kindRuneS))) => {
           val kindRuneA = Astronomer.translateRune(kindRuneS)
           matchKind2AgainstRuneSP(env, state, typeByRune, localRunes, inferences, range, instanceSuperInterfaceRef2, NameTranslator.translateRune(kindRuneA)) match {
@@ -207,7 +207,7 @@ class InfererMatcher[Env, State](
             case (InferMatchSuccess(ds)) => (ds)
           }
         }
-        case (Some(OverrideT(_)), _) => return (InferMatchConflict(inferences.inferences, patternRange, s"ParamFilter virtuality didn't match rule:\n${instance.virtuality}\n${virtuality}", List()))
+        case (Some(OverrideT(_)), _) => return (InferMatchConflict(inferences.inferences, patternRange, s"ParamFilter virtuality didn't match rule:\n${instance.virtuality}\n${virtuality}", List.empty))
       })
 
     (InferMatchSuccess(coordDeeplySatisfied && destructureDeeplySatisfied && virtualityDeeplySatisfied))
@@ -227,7 +227,7 @@ class InfererMatcher[Env, State](
       case (iec @ InferEvaluateConflict(_, _, _, _)) => return (InferMatchConflict(inferences.inferences, range, "Couldn't evaluate template!", List(iec)))
       case (InferEvaluateUnknown(_)) => {
         vcurious() // Can this ever happen? If it does, is the below conflict appropriate?
-        (InferMatchConflict(inferences.inferences, range, "Couldn't figure out template!", List()))
+        (InferMatchConflict(inferences.inferences, range, "Couldn't figure out template!", List.empty))
       }
       case (InferEvaluateSuccess(callTemplateTemplata, templateDeeplySatisfied)) => {
         // debt: TEST THIS!
@@ -253,7 +253,7 @@ class InfererMatcher[Env, State](
           // This is important for avoiding stack overflows, see NMORFI.
           InferMatchSuccess(templateDeeplySatisfied && argsDeeplySatisfied)
         } else {
-          return InferMatchConflict(inferences.inferences, range, "Given citizen didn't come from expected template!\nCitizen: " + actualCitizen + "\nTemplate: " + callTemplateTemplata, List())
+          return InferMatchConflict(inferences.inferences, range, "Given citizen didn't come from expected template!\nCitizen: " + actualCitizen + "\nTemplate: " + callTemplateTemplata, List.empty)
         }
       }
     }
@@ -279,7 +279,7 @@ class InfererMatcher[Env, State](
     // Check to see that the actual template args match the expected template args
 
     if (expectedArgs.size != actualArgs.size) {
-      return InferMatchConflict(inferences.inferences, range, "Supplied wrong number of template arguments!", List())
+      return InferMatchConflict(inferences.inferences, range, "Supplied wrong number of template arguments!", List.empty)
     }
     val argsDeeplySatisfied =
       expectedArgs.zip(actualArgs).foldLeft((true))({
@@ -319,34 +319,34 @@ class InfererMatcher[Env, State](
           // Anything is compatible with share
           return (InferMatchSuccess(true))
         }
-        return (InferMatchConflict(inferences.inferences, range, s"Supplied ownership ${actualOwnership} doesn't match expected ${expectedOwnership}", List()))
+        return (InferMatchConflict(inferences.inferences, range, s"Supplied ownership ${actualOwnership} doesn't match expected ${expectedOwnership}", List.empty))
       }
       case (MutabilityTT(range, expectedMutability), MutabilityTemplata(actualMutability)) => {
         if (actualMutability == Conversions.evaluateMutability(expectedMutability)) {
           (InferMatchSuccess(true))
         } else {
-          return (InferMatchConflict(inferences.inferences, range, s"Supplied mutability ${actualMutability} doesn't match expected ${expectedMutability}", List()))
+          return (InferMatchConflict(inferences.inferences, range, s"Supplied mutability ${actualMutability} doesn't match expected ${expectedMutability}", List.empty))
         }
       }
       case (PermissionTT(range, expectedPermission), PermissionTemplata(actualPermission)) => {
         if (actualPermission == Conversions.evaluatePermission(expectedPermission)) {
           (InferMatchSuccess(true))
         } else {
-          return (InferMatchConflict(inferences.inferences, range, s"Supplied permission ${actualPermission} doesn't match expected ${expectedPermission}", List()))
+          return (InferMatchConflict(inferences.inferences, range, s"Supplied permission ${actualPermission} doesn't match expected ${expectedPermission}", List.empty))
         }
       }
       case (LocationTT(range, expectedLocation), LocationTemplata(actualLocation)) => {
         if (actualLocation == Conversions.evaluateLocation(expectedLocation)) {
           (InferMatchSuccess(true))
         } else {
-          return (InferMatchConflict(inferences.inferences, range, s"Supplied location ${actualLocation} doesn't match expected ${expectedLocation}", List()))
+          return (InferMatchConflict(inferences.inferences, range, s"Supplied location ${actualLocation} doesn't match expected ${expectedLocation}", List.empty))
         }
       }
       case (VariabilityTT(range, expectedVariability), VariabilityTemplata(actualVariability)) => {
         if (actualVariability == Conversions.evaluateVariability(expectedVariability)) {
           (InferMatchSuccess(true))
         } else {
-          return (InferMatchConflict(inferences.inferences, range, s"Supplied variability ${actualVariability} doesn't match expected ${expectedVariability}", List()))
+          return (InferMatchConflict(inferences.inferences, range, s"Supplied variability ${actualVariability} doesn't match expected ${expectedVariability}", List.empty))
         }
       }
       case (AbsoluteNameTT(range, expectedName, expectedType), actualTemplata) => {
@@ -355,7 +355,7 @@ class InfererMatcher[Env, State](
         if (templataTemplar.uncoercedTemplataEquals(env, state, actualTemplata, expectedUncoercedTemplata, expectedType)) {
           return InferMatchSuccess(true)
         } else {
-          return (InferMatchConflict(inferences.inferences, range, s"Supplied templata doesn't match '${expectedName}':\n'${expectedName}' in environment:${expectedUncoercedTemplata}\nActual:${actualTemplata}", List()))
+          return (InferMatchConflict(inferences.inferences, range, s"Supplied templata doesn't match '${expectedName}':\n'${expectedName}' in environment:${expectedUncoercedTemplata}\nActual:${actualTemplata}", List.empty))
         }
       }
       case (NameTT(range, expectedName, expectedType), actualTemplata) => {
@@ -364,7 +364,7 @@ class InfererMatcher[Env, State](
         if (templataTemplar.uncoercedTemplataEquals(env, state, actualTemplata, expectedUncoercedTemplata, expectedType)) {
           return InferMatchSuccess(true)
         } else {
-          return (InferMatchConflict(inferences.inferences, range, s"Supplied templata doesn't match '${expectedName}':\n'${expectedName}' in environment:${expectedUncoercedTemplata}\nActual:${actualTemplata}", List()))
+          return (InferMatchConflict(inferences.inferences, range, s"Supplied templata doesn't match '${expectedName}':\n'${expectedName}' in environment:${expectedUncoercedTemplata}\nActual:${actualTemplata}", List.empty))
         }
 
 //        if (actualTemplata != expectedTemplata) {
@@ -382,13 +382,13 @@ class InfererMatcher[Env, State](
 //          //
 //          // If we decide to check for subtypes here, it will do the incorrect thing in
 //          // that latter case. So, we don't check for subtypes here, just strict equality.
-//          return (InferMatchConflict(inferences.inferences, range, s"Supplied templata doesn't match '${name}':\n'${name}' in environment:${expectedTemplata}\nActual:${actualTemplata}", List()))
+//          return (InferMatchConflict(inferences.inferences, range, s"Supplied templata doesn't match '${name}':\n'${name}' in environment:${expectedTemplata}\nActual:${actualTemplata}", List.empty))
 //        }
 //        (InferMatchSuccess(true))
       }
       case (RuneTT(range, rune, expectedType), actualTemplata) => {
         if (actualTemplata.tyype != expectedType) {
-          return InferMatchConflict(inferences.inferences, range, s"Doesn't match type! Expected ${expectedType} but received ${actualTemplata.tyype}", List())
+          return InferMatchConflict(inferences.inferences, range, s"Doesn't match type! Expected ${expectedType} but received ${actualTemplata.tyype}", List.empty)
         }
         // Catch any mismatch between the type as declared by the struct/function/whatever,
         // and the type we think it is in the actual RuneTT.
@@ -411,7 +411,7 @@ class InfererMatcher[Env, State](
           case ShareT => // fine, continue
           case OwnT => // fine, continue
           case ConstraintT | WeakT => {
-            return InferMatchConflict(inferences.inferences, range, "Expected Own or Share, but was given " + ownership, List())
+            return InferMatchConflict(inferences.inferences, range, "Expected Own or Share, but was given " + ownership, List.empty)
           }
         }
 
@@ -460,7 +460,7 @@ class InfererMatcher[Env, State](
           case ShareT => // fine, continue
           case OwnT => // fine, continue
           case ConstraintT | WeakT => {
-            return InferMatchConflict(inferences.inferences, range, "Expected Own or Share, but was given " + ownership, List())
+            return InferMatchConflict(inferences.inferences, range, "Expected Own or Share, but was given " + ownership, List.empty)
           }
         }
 
@@ -509,7 +509,7 @@ class InfererMatcher[Env, State](
         matchCitizenAgainstCallTT(env, state, typeByRune, localRunes, inferences, range, ct, cit)
       }
       case (ct @ CallTT(range, _, _, _), KindTemplata(StrT())) => {
-        return (InferMatchConflict(inferences.inferences, range, "Can't match string against a CallTT, no such rule exists", List()))
+        return (InferMatchConflict(inferences.inferences, range, "Can't match string against a CallTT, no such rule exists", List.empty))
       }
       case (CallTT(range, expectedTemplate, expectedArgs, resultType), KindTemplata(RuntimeSizedArrayTT(RawArrayTT(elementArg,mutability, variability)))) => {
         vassert(instance.tyype == resultType)
@@ -517,10 +517,10 @@ class InfererMatcher[Env, State](
           env, state, typeByRune, localRunes, inferences, range, expectedTemplate, expectedArgs, List(MutabilityTemplata(mutability), VariabilityTemplata(variability), CoordTemplata(elementArg)))
       }
       case (CallTT(range, _, _, _), KindTemplata(StaticSizedArrayTT(_, RawArrayTT(_, _, _)))) => {
-        return (InferMatchConflict(inferences.inferences, range, "Can't match array sequence against a CallTT, no such rule exists", List()))
+        return (InferMatchConflict(inferences.inferences, range, "Can't match array sequence against a CallTT, no such rule exists", List.empty))
       }
       case (CallTT(range, _, _, _), CoordTemplata(CoordT(_, _, StaticSizedArrayTT(_, _)))) => {
-        return (InferMatchConflict(inferences.inferences, range, "Can't match array sequence against a CallTT, no such rule exists", List()))
+        return (InferMatchConflict(inferences.inferences, range, "Can't match array sequence against a CallTT, no such rule exists", List.empty))
       }
       case (CallTT(range, expectedTemplate, expectedArgs, resultType), CoordTemplata(CoordT(_, _, RuntimeSizedArrayTT(RawArrayTT(elementArg,mutability,variability))))) => {
         vassert(instance.tyype == resultType)
@@ -528,7 +528,7 @@ class InfererMatcher[Env, State](
           env, state, typeByRune, localRunes, inferences, range, expectedTemplate, expectedArgs, List(MutabilityTemplata(mutability), VariabilityTemplata(variability), CoordTemplata(elementArg)))
       }
       case (CallTT(range, expectedTemplate, expectedArgs, resultType), ct @ CoordTemplata(_)) => {
-        return (InferMatchConflict(inferences.inferences, range, "Can't match " + ct + " against CallTT", List()))
+        return (InferMatchConflict(inferences.inferences, range, "Can't match " + ct + " against CallTT", List.empty))
       }
       case (PrototypeTT(_, _, _, _), _) => {
         vfail("what even is this")
@@ -555,10 +555,10 @@ class InfererMatcher[Env, State](
         matchStaticSizedArrayKind(env, state, typeByRune, localRunes, inferences, mutabilityTemplex, variabilityTemplex, sizeTemplex, elementTemplex, size, elementCoord, mutability, variability)
       }
       case (RepeaterSequenceTT(range, _, _, _, _, _), KindTemplata(otherKind)) => {
-        (InferMatchConflict(inferences.inferences, range, "Expected repeater sequence, was: " + otherKind, List()))
+        (InferMatchConflict(inferences.inferences, range, "Expected repeater sequence, was: " + otherKind, List.empty))
       }
       case (RepeaterSequenceTT(range, _, _, _, _, _), CoordTemplata(otherCoord)) => {
-        (InferMatchConflict(inferences.inferences, range, "Expected repeater sequence, was: " + otherCoord, List()))
+        (InferMatchConflict(inferences.inferences, range, "Expected repeater sequence, was: " + otherCoord, List.empty))
       }
       case (ManualSequenceTT(range, expectedElementTemplexesT, resultType), CoordTemplata(CoordT(ownership, _, TupleTT(elements, _)))) => {
         vassert(resultType == CoordTemplataType)
@@ -570,10 +570,10 @@ class InfererMatcher[Env, State](
         matchTupleKind(env, state, typeByRune, localRunes, inferences, expectedElementTemplexesT, elements)
       }
       case (ManualSequenceTT(range, _, _), KindTemplata(otherKind)) => {
-        (InferMatchConflict(inferences.inferences, range, "Expected repeater sequence, was: " + otherKind, List()))
+        (InferMatchConflict(inferences.inferences, range, "Expected repeater sequence, was: " + otherKind, List.empty))
       }
       case (ManualSequenceTT(range, _, _), CoordTemplata(otherCoord)) => {
-        (InferMatchConflict(inferences.inferences, range, "Expected repeater sequence, was: " + otherCoord, List()))
+        (InferMatchConflict(inferences.inferences, range, "Expected repeater sequence, was: " + otherCoord, List.empty))
       }
       case (OwnershipTT(range, ownershipP), OwnershipTemplata(ownershipT)) => {
         if (ownershipT == ShareT) {
@@ -582,14 +582,14 @@ class InfererMatcher[Env, State](
         } else if (ownershipT == Conversions.evaluateOwnership(ownershipP)) {
           (InferMatchSuccess(true))
         } else {
-          (InferMatchConflict(inferences.inferences, range, s"Ownerships don't match: ${ownershipP} and ${ownershipT}", List()))
+          (InferMatchConflict(inferences.inferences, range, s"Ownerships don't match: ${ownershipP} and ${ownershipT}", List.empty))
         }
       }
       case (StringTT(range, expectedValue), StringTemplata(actualValue)) => {
         if (actualValue == expectedValue) {
           (InferMatchSuccess(true))
         } else {
-          (InferMatchConflict(inferences.inferences, range, s"Strings don't match: ${actualValue} and ${expectedValue}", List()))
+          (InferMatchConflict(inferences.inferences, range, s"Strings don't match: ${actualValue} and ${expectedValue}", List.empty))
         }
       }
       case (CoordListTT(range, expectedCoordRules), CoordListTemplata(actualCoords)) => {
@@ -641,7 +641,7 @@ class InfererMatcher[Env, State](
             case (ShareT, ShareP) => true
           }
         if (!ownershipCompatible) {
-          return InferMatchConflict(inferences.inferences, range, s"Couldn't match incoming ${instanceOwnership} against expected ${expectedOwnership}", List())
+          return InferMatchConflict(inferences.inferences, range, s"Couldn't match incoming ${instanceOwnership} against expected ${expectedOwnership}", List.empty)
         }
 
         val permissionCompatible =
@@ -658,7 +658,7 @@ class InfererMatcher[Env, State](
           }
 
         if (!permissionCompatible) {
-          return InferMatchConflict(inferences.inferences, range, s"Couldn't match incoming ${instancePermission} against expected ${expectedPermission}", List())
+          return InferMatchConflict(inferences.inferences, range, s"Couldn't match incoming ${instancePermission} against expected ${expectedPermission}", List.empty)
         }
 
         val resultCoord =
@@ -788,7 +788,7 @@ class InfererMatcher[Env, State](
     val CallTR(range, name, args, resultType) = rule
 
     if (instance.tyype != resultType) {
-      return (InferMatchConflict(inferences.inferences, range, "Call result expected type " + resultType + ", but was " + instance, List()))
+      return (InferMatchConflict(inferences.inferences, range, "Call result expected type " + resultType + ", but was " + instance, List.empty))
     }
 
     name match {
@@ -799,11 +799,11 @@ class InfererMatcher[Env, State](
             val defaultOwnershipForKind =
               if (delegate.getMutability(state, instanceKind) == MutableT) OwnT else ShareT
             if (instanceOwnership != defaultOwnershipForKind) {
-              return (InferMatchConflict(inferences.inferences, range, "Coord matching into toRef doesn't have default ownership: " + instanceOwnership, List()))
+              return (InferMatchConflict(inferences.inferences, range, "Coord matching into toRef doesn't have default ownership: " + instanceOwnership, List.empty))
             }
             matchTemplataAgainstRulexTR(env, state, typeByRune, localRunes, inferences, KindTemplata(instanceKind), kindRule)
           }
-          case _ => return (InferMatchConflict(inferences.inferences, range, "Bad arguments to toRef: " + args, List()))
+          case _ => return (InferMatchConflict(inferences.inferences, range, "Bad arguments to toRef: " + args, List.empty))
         }
       }
       case "passThroughIfConcrete" => {
@@ -812,7 +812,7 @@ class InfererMatcher[Env, State](
           case KindTemplata(StructRefT(_) | PackTT(_, _) | TupleTT(_, _) | StaticSizedArrayTT(_, _) | RuntimeSizedArrayTT(_)) => {
             matchTemplataAgainstRulexTR(env, state, typeByRune, localRunes, inferences, instance, kindRule)
           }
-          case _ => return (InferMatchConflict(inferences.inferences, range, "Bad arguments to passThroughIfConcrete: " + args, List()))
+          case _ => return (InferMatchConflict(inferences.inferences, range, "Bad arguments to passThroughIfConcrete: " + args, List.empty))
         }
       }
       case "passThroughIfInterface" => {
@@ -821,7 +821,7 @@ class InfererMatcher[Env, State](
           case KindTemplata(InterfaceRefT(_)) => {
             matchTemplataAgainstRulexTR(env, state, typeByRune, localRunes, inferences, instance, kindRule)
           }
-          case _ => return (InferMatchConflict(inferences.inferences, range, "Bad arguments to passThroughIfInterface: " + args, List()))
+          case _ => return (InferMatchConflict(inferences.inferences, range, "Bad arguments to passThroughIfInterface: " + args, List.empty))
         }
       }
       case "passThroughIfStruct" => {
@@ -830,7 +830,7 @@ class InfererMatcher[Env, State](
           case KindTemplata(StructRefT(_)) => {
             matchTemplataAgainstRulexTR(env, state, typeByRune, localRunes, inferences, instance, kindRule)
           }
-          case _ => return (InferMatchConflict(inferences.inferences, range, "Bad arguments to passThroughIfStruct: " + instance, List()))
+          case _ => return (InferMatchConflict(inferences.inferences, range, "Bad arguments to passThroughIfStruct: " + instance, List.empty))
         }
       }
     }
@@ -848,7 +848,7 @@ class InfererMatcher[Env, State](
     val ComponentsTR(range, tyype, components) = rule
 
     if (!equator.templataMatchesType(instance, tyype)) {
-      return (InferMatchConflict(inferences.inferences, range, s"Supplied templata isn't the right type! Type: ${rule.tyype} but gave: ${instance}", List()))
+      return (InferMatchConflict(inferences.inferences, range, s"Supplied templata isn't the right type! Type: ${rule.tyype} but gave: ${instance}", List.empty))
     }
 
     instance match {
@@ -889,7 +889,7 @@ class InfererMatcher[Env, State](
         val actualHumanNameTemplata =
           actualPrototype.fullName.last match {
             case FunctionNameT(humanName, _, _) => StringTemplata(humanName)
-            case _ => return InferMatchConflict(inferences.inferences, range, "Actual prototype doesn't have a human name: " + actualPrototype.fullName.last, List())
+            case _ => return InferMatchConflict(inferences.inferences, range, "Actual prototype doesn't have a human name: " + actualPrototype.fullName.last, List.empty)
           }
         val actualParamsTemplata = CoordListTemplata(actualPrototype.paramTypes)
         val actualRetTemplata = CoordTemplata(actualPrototype.returnType)
@@ -977,7 +977,7 @@ class InfererMatcher[Env, State](
               val deeplySatisfied = subDeeplySatisfied && conceptDeeplySatisfied && isaSatisfied
               InferMatchSuccess(deeplySatisfied)
             } else {
-              return (InferMatchConflict(inferences.inferences, range, "Isa failed!\nSub: " + sub + "\nSuper: " + interface, List()))
+              return (InferMatchConflict(inferences.inferences, range, "Isa failed!\nSub: " + sub + "\nSuper: " + interface, List.empty))
             }
           }
         }
@@ -1027,7 +1027,7 @@ class InfererMatcher[Env, State](
 //          if (subTemplar.matchKind2AgainstKindRefSP(interfaceRef2, Some(overrideRule.tyype))) {
 //            List((interfaceRef2, subTemplar))
 //          } else {
-//            List()
+//            List.empty
 //          }
 //        })
 //    if (matchingInterfacesAndSubTemplars.size > 1) {

--- a/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarInfererTests.scala
+++ b/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarInfererTests.scala
@@ -36,7 +36,7 @@ object InfererTestUtils {
 
 case class SimpleEnvironment(templatas: TemplatasStore) extends IEnvironment {
   override def getParentEnv(): Option[IEnvironment] = None
-  def fullName = FullNameT(PackageCoordinate.BUILTIN, List(), PackageTopLevelNameT())
+  def fullName = FullNameT(PackageCoordinate.BUILTIN, Nil, PackageTopLevelNameT())
   def globalEnv: PackageEnvironment[INameT] = {
     vfail()
   }
@@ -144,7 +144,7 @@ class FakeTemplataTemplarInnerDelegate extends ITemplataTemplarInnerDelegate[Sim
 
 class InfererTests extends FunSuite with Matchers {
   val incrementPrototype =
-    PrototypeT(FullNameT(PackageCoordinate.TEST_TLD, List(), FunctionNameT("increment", List(), List(CoordT(ShareT, ReadonlyT, IntT.i32)))), CoordT(ShareT, ReadonlyT, IntT.i32))
+    PrototypeT(FullNameT(PackageCoordinate.TEST_TLD, Nil, FunctionNameT("increment", Nil, List(CoordT(ShareT, ReadonlyT, IntT.i32)))), CoordT(ShareT, ReadonlyT, IntT.i32))
 
   def makeCannedEnvironment(): SimpleEnvironment = {
     var entries: TemplatasStore = TemplatasStore(Map(), Map())
@@ -155,35 +155,35 @@ class InfererTests extends FunSuite with Matchers {
     val boolName = PrimitiveNameT("bool")
     entries = entries.addEntry(true, boolName, TemplataEnvEntry(KindTemplata(BoolT())))
     entries = entries.addEntry(true,
-      CitizenNameT("ImmInterface", List()),
+      CitizenNameT("ImmInterface", Nil),
         InterfaceEnvEntry(
           InterfaceA(
             RangeS.internal(-70),
             TopLevelCitizenDeclarationNameA("ImmInterface", CodeLocationS.internal(-24)),
-            List(),
+            Nil,
             false,
             CodeRuneA("M"),
             Some(ImmutableP),
             KindTemplataType,
             Set(CodeRuneA("M")),
-            List(),
+            Nil,
             Set(CodeRuneA("M")),
             Map(CodeRuneA("M") -> MutabilityTemplataType),
             List(EqualsAR(RangeS.testZero,TemplexAR(RuneAT(RangeS.testZero,CodeRuneA("M"), MutabilityTemplataType)), TemplexAR(MutabilityAT(RangeS.testZero,ImmutableP)))),
-            List())))
+            Nil)))
     entries = entries.addEntry(true,
-      CitizenNameT("ImmStruct", List()),
+      CitizenNameT("ImmStruct", Nil),
         StructEnvEntry(
           StructA(
             RangeS.internal(-71),
             TopLevelCitizenDeclarationNameA("ImmStruct", CodeLocationS.internal(-24)),
-            List(),
+            Nil,
             false,
             CodeRuneA("M"),
             Some(ImmutableP),
             KindTemplataType,
             Set(CodeRuneA("M")),
-            List(),
+            Nil,
             Set(CodeRuneA("M"), CodeRuneA("I"), CodeRuneA("B")),
             Map(CodeRuneA("M") -> MutabilityTemplataType, CodeRuneA("I") -> CoordTemplataType, CodeRuneA("B") -> CoordTemplataType),
             List(
@@ -200,7 +200,7 @@ class InfererTests extends FunSuite with Matchers {
             StructA(
               RangeS.internal(-74),
               TopLevelCitizenDeclarationNameA("MutTStruct", CodeLocationS.internal(-26)),
-              List(),
+              Nil,
               false,
               CodeRuneA("M"),
               Some(MutableP),
@@ -210,13 +210,13 @@ class InfererTests extends FunSuite with Matchers {
               Set(CodeRuneA("T"), CodeRuneA("M")),
               Map(CodeRuneA("T") -> CoordTemplataType, CodeRuneA("M") -> MutabilityTemplataType),
               List(EqualsAR(RangeS.testZero,TemplexAR(RuneAT(RangeS.testZero,CodeRuneA("M"), MutabilityTemplataType)), TemplexAR(MutabilityAT(RangeS.testZero,MutableP)))),
-              List())))
+              Nil)))
     entries = entries.addEntry(true, CitizenTemplateNameT("MutTInterface", CodeLocationT.internal(-27)),
       InterfaceEnvEntry(
         InterfaceA(
           RangeS.internal(-75),
           TopLevelCitizenDeclarationNameA("MutTInterface", CodeLocationS.internal(-28)),
-          List(),
+          Nil,
           false,
           CodeRuneA("M"),
           Some(MutableP),
@@ -226,57 +226,57 @@ class InfererTests extends FunSuite with Matchers {
           Set(CodeRuneA("T"), CodeRuneA("M")),
           Map(CodeRuneA("T") -> CoordTemplataType, CodeRuneA("M") -> MutabilityTemplataType),
           List(EqualsAR(RangeS.testZero,TemplexAR(RuneAT(RangeS.testZero,CodeRuneA("M"), MutabilityTemplataType)), TemplexAR(MutabilityAT(RangeS.testZero,MutableP)))),
-          List())))
+          Nil)))
     entries = entries.addEntry(true, CitizenTemplateNameT("MutStruct", CodeLocationT.internal(-29)),
       StructEnvEntry(
         StructA(
           RangeS.internal(-73),
           TopLevelCitizenDeclarationNameA("MutStruct", CodeLocationS.internal(-30)),
-          List(),
+          Nil,
           false,
           CodeRuneA("M"),
           Some(MutableP),
           KindTemplataType,
           Set(CodeRuneA("M")),
-          List(),
+          Nil,
           Set(CodeRuneA("M")),
           Map(CodeRuneA("M") -> MutabilityTemplataType),
           List(EqualsAR(RangeS.testZero,TemplexAR(RuneAT(RangeS.testZero,CodeRuneA("M"), MutabilityTemplataType)), TemplexAR(MutabilityAT(RangeS.testZero,MutableP)))),
-          List())))
+          Nil)))
     entries = entries.addEntry(true, CitizenTemplateNameT("MutInterface", CodeLocationT.internal(-31)),
       InterfaceEnvEntry(
         InterfaceA(
           RangeS.internal(-72),
           TopLevelCitizenDeclarationNameA("MutInterface", CodeLocationS.internal(-32)),
-          List(),
+          Nil,
           false,
           CodeRuneA("M"),
           Some(MutableP),
           KindTemplataType,
           Set(CodeRuneA("M")),
-          List(),
+          Nil,
           Set(CodeRuneA("M")),
           Map(CodeRuneA("M") -> MutabilityTemplataType),
           List(EqualsAR(RangeS.testZero,TemplexAR(RuneAT(RangeS.testZero,CodeRuneA("M"), MutabilityTemplataType)), TemplexAR(MutabilityAT(RangeS.testZero,MutableP)))),
-          List())))
-    entries = entries.addEntry(true, CitizenNameT("MutStructConstraint", List()),
-      TemplataEnvEntry(CoordTemplata(CoordT(ConstraintT,ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List())))))))
-    entries = entries.addEntry(true, CitizenNameT("MutStructConstraintRW", List()),
-      TemplataEnvEntry(CoordTemplata(CoordT(ConstraintT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List())))))))
-    entries = entries.addEntry(true, CitizenNameT("MutStructWeak", List()),
-      TemplataEnvEntry(CoordTemplata(CoordT(WeakT, ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List())))))))
-    entries = entries.addEntry(true, CitizenNameT("MutStructWeakRW", List()),
-      TemplataEnvEntry(CoordTemplata(CoordT(WeakT, ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List())))))))
-    entries = entries.addEntry(true, CitizenNameT("MutStaticSizedArrayOf4Int", List()),
+          Nil)))
+    entries = entries.addEntry(true, CitizenNameT("MutStructConstraint", Nil),
+      TemplataEnvEntry(CoordTemplata(CoordT(ConstraintT,ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil)))))))
+    entries = entries.addEntry(true, CitizenNameT("MutStructConstraintRW", Nil),
+      TemplataEnvEntry(CoordTemplata(CoordT(ConstraintT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil)))))))
+    entries = entries.addEntry(true, CitizenNameT("MutStructWeak", Nil),
+      TemplataEnvEntry(CoordTemplata(CoordT(WeakT, ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil)))))))
+    entries = entries.addEntry(true, CitizenNameT("MutStructWeakRW", Nil),
+      TemplataEnvEntry(CoordTemplata(CoordT(WeakT, ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil)))))))
+    entries = entries.addEntry(true, CitizenNameT("MutStaticSizedArrayOf4Int", Nil),
       TemplataEnvEntry(KindTemplata(StaticSizedArrayTT(4, RawArrayTT(CoordT(ShareT, ReadonlyT, IntT.i32), MutableT, VaryingT)))))
     // Tuples are normally addressed by TupleNameT, but that's a detail this test doesn't need to care about.
-    entries = entries.addEntry(true, CitizenNameT("IntAndBoolTupName", List()),
+    entries = entries.addEntry(true, CitizenNameT("IntAndBoolTupName", Nil),
       TemplataEnvEntry(
         KindTemplata(
           TupleTT(
             List(Program2.intType, Program2.boolType),
             // Normally this would be backed by a struct simply named "Tup"
-            StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("ImmStruct", List())))))))
+            StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("ImmStruct", Nil)))))))
     val callPrototype = PrototypeTemplata(incrementPrototype)
     entries = entries.addEntry(true, callPrototype.value.fullName.last, TemplataEnvEntry(callPrototype))
     SimpleEnvironment(entries)
@@ -302,13 +302,13 @@ class InfererTests extends FunSuite with Matchers {
         override def evaluateInterfaceTemplata(state: FakeState, callRange: RangeS, templata: InterfaceTemplata, templateArgs: List[ITemplata]): (KindT) = {
           (templata, templateArgs) match {
             case (InterfaceTemplata(_,interfaceName(TopLevelCitizenDeclarationNameA("MutTInterface", _))), List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)) )) => {
-              InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutTInterface", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32))))))
+              InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutTInterface", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32))))))
             }
-            case (InterfaceTemplata(_,interfaceName(TopLevelCitizenDeclarationNameA("MutInterface", _))), List()) => {
-              InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutInterface", List())))
+            case (InterfaceTemplata(_,interfaceName(TopLevelCitizenDeclarationNameA("MutInterface", _))), Nil) => {
+              InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutInterface", Nil)))
             }
-            case (InterfaceTemplata(_,interfaceName(TopLevelCitizenDeclarationNameA("ImmInterface", _))), List()) => {
-              InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("ImmInterface", List())))
+            case (InterfaceTemplata(_,interfaceName(TopLevelCitizenDeclarationNameA("ImmInterface", _))), Nil) => {
+              InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("ImmInterface", Nil)))
             }
           }
         }
@@ -316,10 +316,10 @@ class InfererTests extends FunSuite with Matchers {
         override def evaluateStructTemplata(state: FakeState, callRange: RangeS, templata: StructTemplata, templateArgs: List[ITemplata]): (KindT) = {
           (templata, templateArgs) match {
             case (StructTemplata(_,structName(TopLevelCitizenDeclarationNameA("MutTStruct", _))), List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)) )) => {
-              StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutTStruct", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32))))))
+              StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutTStruct", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32))))))
             }
-            case (StructTemplata(_,structName(TopLevelCitizenDeclarationNameA("MutStruct", _))), List()) => {
-              StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List())))
+            case (StructTemplata(_,structName(TopLevelCitizenDeclarationNameA("MutStruct", _))), Nil) => {
+              StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil)))
             }
           }
         }
@@ -342,17 +342,17 @@ class InfererTests extends FunSuite with Matchers {
 
         override def getTupleKind(env: SimpleEnvironment, state: FakeState, elements: List[CoordT]): TupleTT = {
           // Theres only one tuple in this test, and its backed by the ImmStruct.
-          TupleTT(elements, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("ImmStruct", List()))))
+          TupleTT(elements, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("ImmStruct", Nil))))
         }
       }
     val delegate =
       new FakeInfererEvaluatorDelegate() {
         override def getAncestorInterfaces(state: FakeState, descendantCitizenRef: CitizenRefT): (Set[InterfaceRefT]) = {
           descendantCitizenRef match {
-            case StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutTStruct",List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))) => Set(InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutTInterface", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))))
-            case StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct",List()))) => Set(InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutInterface", List()))))
-            case InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutInterface",List()))) => Set()
-            case StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutSoloStruct",List()))) => Set()
+            case StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutTStruct",List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))) => Set(InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutTInterface", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))))
+            case StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct",Nil))) => Set(InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutInterface", Nil))))
+            case InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutInterface",Nil))) => Set()
+            case StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutSoloStruct",Nil))) => Set()
             case _ => vfail(descendantCitizenRef.toString)
           }
         }
@@ -404,13 +404,13 @@ class InfererTests extends FunSuite with Matchers {
           Map(CodeRuneT("__C") -> CoordTemplataType),
           Set(CodeRuneT("__C")),
           Map(),
-          List(),
+          Nil,
           None,
           true)
 
     vassert(
       inferences.templatasByRune(CodeRuneT("__C")) ==
-        CoordTemplata(CoordT(ShareT, ReadonlyT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("ImmInterface", List()))))))
+        CoordTemplata(CoordT(ShareT, ReadonlyT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("ImmInterface", Nil))))))
   }
 
   test("Can infer coord rune from an incoming kind") {
@@ -423,8 +423,8 @@ class InfererTests extends FunSuite with Matchers {
           RangeS.testZero,
           Map(CodeRuneT("C") -> CoordTemplataType),
           Set(CodeRuneT("C")),
-          Map(CodeRuneT("C") -> KindTemplata(InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("ImmInterface",List(KindTemplata(IntT.i32))))))),
-          List(),
+          Map(CodeRuneT("C") -> KindTemplata(InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("ImmInterface",List(KindTemplata(IntT.i32))))))),
+          Nil,
           None,
           true)
 
@@ -442,7 +442,7 @@ class InfererTests extends FunSuite with Matchers {
           Map(CodeRuneT("A") -> KindTemplataType),
           Set(CodeRuneT("A"), CodeRuneT("C")),
           Map(CodeRuneT("A") -> KindTemplata(IntT.i32)),
-          List(),
+          Nil,
           None,
           true)
 
@@ -463,7 +463,7 @@ class InfererTests extends FunSuite with Matchers {
           Map(CodeRuneT("C") -> CoordTemplataType, CodeRuneT("A") -> KindTemplataType),
           Set(CodeRuneT("C"), CodeRuneT("A")),
           Map(CodeRuneT("A") -> KindTemplata(IntT.i32)),
-          List(),
+          Nil,
           None,
           true)
 
@@ -483,7 +483,7 @@ class InfererTests extends FunSuite with Matchers {
           Map(CodeRuneT("Z") -> CoordTemplataType),
           Set(CodeRuneT("Z")),
           Map(),
-          List(),
+          Nil,
           None,
           true)
 
@@ -507,12 +507,12 @@ class InfererTests extends FunSuite with Matchers {
           Map(CodeRuneT("__RetRune") -> CoordTemplataType),
           Set(CodeRuneT("__RetRune")),
           Map(),
-          List(),
+          Nil,
           None,
           true)
 
     conclusions.templatasByRune(CodeRuneT("__RetRune")) shouldEqual
-      CoordTemplata(CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List())))))
+      CoordTemplata(CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil)))))
   }
 
   test("Can infer from simple rules") {
@@ -528,7 +528,7 @@ class InfererTests extends FunSuite with Matchers {
           Map(CodeRuneT("Z") -> CoordTemplataType),
           Set(CodeRuneT("Z")),
           Map(),
-          List(),
+          Nil,
           None,
           true)
 
@@ -548,8 +548,8 @@ class InfererTests extends FunSuite with Matchers {
           RangeS.testZero,
           Map(CodeRuneT("X") -> KindTemplataType, CodeRuneT("T") -> CoordTemplataType),
           Set(CodeRuneT("X"), CodeRuneT("T")),
-          Map(CodeRuneT("X") -> KindTemplata(InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutTInterface",List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))))),
-          List(),
+          Map(CodeRuneT("X") -> KindTemplata(InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutTInterface",List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))))),
+          Nil,
           None,
           true)
 
@@ -592,10 +592,10 @@ class InfererTests extends FunSuite with Matchers {
           Set(CodeRuneT("1337"), CodeRuneT("0"), CodeRuneT("T")),
           Map(),
           List(AtomAP(RangeS.testZero,LocalA(CodeVarNameA("m"), NotUsed, Used, NotUsed, NotUsed, NotUsed, NotUsed),None,CodeRuneA("0"),None)),
-          Some(List(ParamFilter(CoordT(ConstraintT,ReadonlyT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutInterface", List())))),None))),
+          Some(List(ParamFilter(CoordT(ConstraintT,ReadonlyT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutInterface", Nil)))),None))),
           true)
 
-    vassert(inferences.templatasByRune(CodeRuneT("T")) == CoordTemplata(CoordT(OwnT,ReadwriteT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutInterface", List()))))))
+    vassert(inferences.templatasByRune(CodeRuneT("T")) == CoordTemplata(CoordT(OwnT,ReadwriteT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutInterface", Nil))))))
   }
 
   test("Rune 0 upcasts to right type, simple") {
@@ -614,10 +614,10 @@ class InfererTests extends FunSuite with Matchers {
           Set(CodeRuneT("__Let0_")),
           Map(),
           List(AtomAP(RangeS.testZero,LocalA(CodeVarNameA("x"), NotUsed, Used, NotUsed, NotUsed, NotUsed, NotUsed),None,CodeRuneA("__Let0_"),None)),
-          Some(List(ParamFilter(CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct",List())))),None))),
+          Some(List(ParamFilter(CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct",Nil)))),None))),
           true)
 
-    vassert(inferences.templatasByRune(CodeRuneT("__Let0_")) == CoordTemplata(CoordT(OwnT,ReadwriteT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutInterface", List()))))))
+    vassert(inferences.templatasByRune(CodeRuneT("__Let0_")) == CoordTemplata(CoordT(OwnT,ReadwriteT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutInterface", Nil))))))
   }
 
   test("Rune 0 upcasts to right type templated") {
@@ -644,12 +644,12 @@ class InfererTests extends FunSuite with Matchers {
           Set(CodeRuneT("__Let0_"), CodeRuneT("T")),
           Map(),
           List(AtomAP(RangeS.testZero,LocalA(CodeVarNameA("x"), NotUsed, Used, NotUsed, NotUsed, NotUsed, NotUsed),None,CodeRuneA("__Let0_"),None)),
-          Some(List(ParamFilter(CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutTStruct",List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32))))))),None))),
+          Some(List(ParamFilter(CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutTStruct",List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32))))))),None))),
           true)
 
     vassert(
       inferences.templatasByRune(CodeRuneT("__Let0_")) ==
-        CoordTemplata(CoordT(OwnT,ReadwriteT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutTInterface", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))))))
+        CoordTemplata(CoordT(OwnT,ReadwriteT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutTInterface", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))))))
     vassert(
       inferences.templatasByRune(CodeRuneT("T")) ==
         CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))
@@ -691,12 +691,12 @@ class InfererTests extends FunSuite with Matchers {
       }
 
     // Test that it does match a pack
-    val packCoord = CoordT(ShareT, ReadonlyT,PackTT(List(),StructRefT(FullNameT(PackageCoordinate.BUILTIN, List(), CitizenNameT("__Pack",List())))))
+    val packCoord = CoordT(ShareT, ReadonlyT,PackTT(Nil,StructRefT(FullNameT(PackageCoordinate.BUILTIN, Nil, CitizenNameT("__Pack",Nil)))))
     val (InferSolveSuccess(inferencesA)) = solve(ParamFilter(packCoord,None))
     vassert(inferencesA.templatasByRune(CodeRuneT("T")) == CoordTemplata(packCoord))
 
     // Test that it does match a struct
-    val structCoord = CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct",List()))))
+    val structCoord = CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct",Nil))))
     val (InferSolveSuccess(inferencesD)) = solve(ParamFilter(structCoord,None))
     vassert(inferencesD.templatasByRune(CodeRuneT("T")) == CoordTemplata(structCoord))
 
@@ -706,7 +706,7 @@ class InfererTests extends FunSuite with Matchers {
     vassert(isfE.toString.contains("Bad arguments to passThroughIfConcrete"))
 
     // Test that it doesn't match an interface
-    val interfaceCoord = CoordT(OwnT,ReadwriteT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutInterface",List()))))
+    val interfaceCoord = CoordT(OwnT,ReadwriteT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutInterface",Nil))))
     val (isfF @ InferSolveFailure(_, _, _,_,_, _, _)) = solve(ParamFilter(interfaceCoord,None))
     vassert(isfF.toString.contains("Bad arguments to passThroughIfConcrete"))
   }
@@ -749,7 +749,7 @@ class InfererTests extends FunSuite with Matchers {
       }
 
     // Test that it does match an interface
-    val interfaceCoord = CoordT(OwnT,ReadwriteT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutInterface",List()))))
+    val interfaceCoord = CoordT(OwnT,ReadwriteT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutInterface",Nil))))
     val (InferSolveSuccess(inferencesD)) = solve(ParamFilter(interfaceCoord,None))
     vassert(inferencesD.templatasByRune(CodeRuneT("T")) == CoordTemplata(interfaceCoord))
 
@@ -798,7 +798,7 @@ class InfererTests extends FunSuite with Matchers {
       }
 
     // Test that it does match a struct
-    val structCoord = CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct",List()))))
+    val structCoord = CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct",Nil))))
     val (InferSolveSuccess(inferencesD)) = solve(ParamFilter(structCoord,None))
     vassert(inferencesD.templatasByRune(CodeRuneT("T")) == CoordTemplata(structCoord))
 
@@ -808,12 +808,12 @@ class InfererTests extends FunSuite with Matchers {
     vassert(isfE.toString.contains("Bad arguments to passThroughIfStruct"))
 
     // Test that it doesn't match an interface
-    val interfaceCoord = CoordT(OwnT,ReadwriteT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutInterface",List()))))
+    val interfaceCoord = CoordT(OwnT,ReadwriteT, InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutInterface",Nil))))
     val (isfF @ InferSolveFailure(_, _, _,_,_, _, _)) = solve(ParamFilter(interfaceCoord,None))
     vassert(isfF.toString.contains("Bad arguments to passThroughIfStruct"))
 
     // Test that it doesn't match an pack
-    val packCoord = CoordT(ShareT, ReadonlyT,PackTT(List(),StructRefT(FullNameT(PackageCoordinate.BUILTIN, List(), CitizenNameT("__Pack",List())))))
+    val packCoord = CoordT(ShareT, ReadonlyT,PackTT(Nil,StructRefT(FullNameT(PackageCoordinate.BUILTIN, Nil, CitizenNameT("__Pack",Nil)))))
     val (isfG @ InferSolveFailure(_, _, _,_,_, _, _)) = solve(ParamFilter(packCoord,None))
     vassert(isfG.toString.contains("Bad arguments to passThroughIfStruct"))
   }
@@ -850,7 +850,7 @@ class InfererTests extends FunSuite with Matchers {
         true)
 
     inferencesD.templatasByRune(CodeRuneT("Z")) shouldEqual
-      CoordTemplata(CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutTStruct",List(CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32))))))))
+      CoordTemplata(CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutTStruct",List(CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32))))))))
   }
 
 
@@ -875,7 +875,7 @@ class InfererTests extends FunSuite with Matchers {
         None,
         true)
     inferencesD.templatasByRune(CodeRuneT("__Par0")) shouldEqual
-      CoordTemplata(CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct",List())))))
+      CoordTemplata(CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct",Nil)))))
   }
 
   test("Matching a CoordTemplataType onto a CallAT") {
@@ -900,10 +900,10 @@ class InfererTests extends FunSuite with Matchers {
         Set(CodeRuneT("0"), CodeRuneT("T")),
         Map(),
         List(AtomAP(RangeS.testZero,LocalA(CodeVarNameA("x"),NotUsed, Used, NotUsed, NotUsed, NotUsed, NotUsed),Some(AbstractAP),CodeRuneA("0"),None)),
-        Some(List(ParamFilter(CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutTStruct",List(CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32))))))),None))),
+        Some(List(ParamFilter(CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutTStruct",List(CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32))))))),None))),
         true)
     inferencesD.templatasByRune(CodeRuneT("0")) shouldEqual
-      CoordTemplata(CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutTStruct",List(CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32))))))))
+      CoordTemplata(CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutTStruct",List(CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32))))))))
   }
 
   test("Test destructuring") {
@@ -928,7 +928,7 @@ class InfererTests extends FunSuite with Matchers {
               List(
                 AtomAP(RangeS.testZero,LocalA(CodeVarNameA("x"), NotUsed, Used, NotUsed, NotUsed, NotUsed, NotUsed),None,CodeRuneA("__Let0__Mem_0"),None),
                 AtomAP(RangeS.testZero,LocalA(CodeVarNameA("y"), NotUsed, Used, NotUsed, NotUsed, NotUsed, NotUsed),None,CodeRuneA("__Let0__Mem_1"),None))))),
-        Some(List(ParamFilter(CoordT(ShareT, ReadonlyT,PackTT(List(CoordT(ShareT, ReadonlyT,IntT.i32), CoordT(ShareT, ReadonlyT,IntT.i32)),StructRefT(FullNameT(PackageCoordinate.BUILTIN, List(), CitizenNameT("__Pack",List(CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32)), CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32)))))))),None))),
+        Some(List(ParamFilter(CoordT(ShareT, ReadonlyT,PackTT(List(CoordT(ShareT, ReadonlyT,IntT.i32), CoordT(ShareT, ReadonlyT,IntT.i32)),StructRefT(FullNameT(PackageCoordinate.BUILTIN, Nil, CitizenNameT("__Pack",List(CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32)), CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32)))))))),None))),
         true)
     inferencesD.templatasByRune(CodeRuneT("__Let0_")) shouldEqual
       CoordTemplata(
@@ -937,7 +937,7 @@ class InfererTests extends FunSuite with Matchers {
           ReadonlyT,
           PackTT(
             List(CoordT(ShareT, ReadonlyT,IntT.i32), CoordT(ShareT, ReadonlyT,IntT.i32)),
-            StructRefT(FullNameT(PackageCoordinate.BUILTIN, List(), CitizenNameT("__Pack",List(CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32)), CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32)))))))))
+            StructRefT(FullNameT(PackageCoordinate.BUILTIN, Nil, CitizenNameT("__Pack",List(CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32)), CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32)))))))))
     inferencesD.templatasByRune(CodeRuneT("__Let0__Mem_0")) shouldEqual
       CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32))
     inferencesD.templatasByRune(CodeRuneT("__Let0__Mem_1")) shouldEqual
@@ -963,7 +963,7 @@ class InfererTests extends FunSuite with Matchers {
         Map(CodeRuneT("Z") -> CoordTemplataType),
         Set(CodeRuneT("Z")),
         Map(),
-        List(),
+        Nil,
         None,
         true)
     inferencesD.templatasByRune(CodeRuneT("Z")) shouldEqual
@@ -989,7 +989,7 @@ class InfererTests extends FunSuite with Matchers {
         Map(CodeRuneT("E") -> CoordTemplataType),
         Set(CodeRuneT("E"), CodeRuneT("M"), CodeRuneT("V"), CodeRuneT("N")),
         Map(),
-        List(),
+        Nil,
         None,
         true)
     inferencesD.templatasByRune(CodeRuneT("M")) shouldEqual MutabilityTemplata(MutableT)
@@ -1017,7 +1017,7 @@ class InfererTests extends FunSuite with Matchers {
         Map(CodeRuneT("E") -> CoordTemplataType),
         Set(CodeRuneT("E"), CodeRuneT("M"), CodeRuneT("V"), CodeRuneT("N")),
         Map(),
-        List(),
+        Nil,
         None,
         true)
     inferencesD.templatasByRune(CodeRuneT("M")) shouldEqual MutabilityTemplata(MutableT)
@@ -1044,7 +1044,7 @@ class InfererTests extends FunSuite with Matchers {
         Map(CodeRuneT("Z") -> CoordTemplataType),
         Set(CodeRuneT("Z")),
         Map(),
-        List(),
+        Nil,
         None,
         true)
     inferencesD.templatasByRune(CodeRuneT("Z")) shouldEqual
@@ -1054,7 +1054,7 @@ class InfererTests extends FunSuite with Matchers {
           ReadonlyT,
           TupleTT(
             List(CoordT(ShareT, ReadonlyT,IntT.i32), CoordT(ShareT, ReadonlyT,BoolT())),
-            StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(),CitizenNameT("ImmStruct",List()))))))
+            StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil,CitizenNameT("ImmStruct",Nil))))))
   }
 
   test("Test matching manual sequence as coord") {
@@ -1075,7 +1075,7 @@ class InfererTests extends FunSuite with Matchers {
         Map(),
         Set(CodeRuneT("A"), CodeRuneT("B")),
         Map(),
-        List(),
+        Nil,
         None,
         true)
     inferencesD.templatasByRune(CodeRuneT("A")) shouldEqual CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32))
@@ -1100,7 +1100,7 @@ class InfererTests extends FunSuite with Matchers {
         Map(),
         Set(CodeRuneT("A"), CodeRuneT("B")),
         Map(),
-        List(),
+        Nil,
         None,
         true)
     inferencesD.templatasByRune(CodeRuneT("A")) shouldEqual CoordTemplata(CoordT(ShareT, ReadonlyT,IntT.i32))
@@ -1138,7 +1138,7 @@ class InfererTests extends FunSuite with Matchers {
           CodeRuneT("K") -> KindTemplataType),
         Set(CodeRuneT("T"), CodeRuneT("M"), CodeRuneT("V"), CodeRuneT("K")),
         Map(),
-        List(),
+        Nil,
         None,
         true)
     inferencesD.templatasByRune(CodeRuneT("M")) shouldEqual MutabilityTemplata(MutableT)
@@ -1159,8 +1159,8 @@ class InfererTests extends FunSuite with Matchers {
           RangeS.testZero,
           Map(CodeRuneT("K") -> KindTemplataType),
           Set(CodeRuneT("K")),
-          Map(CodeRuneT("K") -> KindTemplata(StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))),
-          List(),
+          Map(CodeRuneT("K") -> KindTemplata(StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))),
+          Nil,
           None,
           true)
 
@@ -1176,8 +1176,8 @@ class InfererTests extends FunSuite with Matchers {
           RangeS.testZero,
           Map(CodeRuneT("K") -> KindTemplataType),
           Set(CodeRuneT("K")),
-          Map(CodeRuneT("K") -> KindTemplata(StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutSoloStruct", List()))))),
-          List(),
+          Map(CodeRuneT("K") -> KindTemplata(StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutSoloStruct", Nil))))),
+          Nil,
           None,
           true)
     vassert(isf.toString.contains("Isa failed"))
@@ -1198,8 +1198,8 @@ class InfererTests extends FunSuite with Matchers {
           RangeS.testZero,
           Map(CodeRuneT("K") -> KindTemplataType),
           Set(CodeRuneT("K"), CodeRuneT("Z")),
-          Map(CodeRuneT("K") -> KindTemplata(StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))),
-          List(),
+          Map(CodeRuneT("K") -> KindTemplata(StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))),
+          Nil,
           None,
           true)
 
@@ -1215,8 +1215,8 @@ class InfererTests extends FunSuite with Matchers {
           RangeS.testZero,
           Map(CodeRuneT("K") -> KindTemplataType),
           Set(CodeRuneT("K")),
-          Map(CodeRuneT("K") -> KindTemplata(StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutSoloStruct", List()))))),
-          List(),
+          Map(CodeRuneT("K") -> KindTemplata(StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutSoloStruct", Nil))))),
+          Nil,
           None,
           true)
     vassert(isf.toString.contains("Isa failed"))
@@ -1242,7 +1242,7 @@ class InfererTests extends FunSuite with Matchers {
           Map(CodeRuneT("F") -> PrototypeTemplataType),
           Set(CodeRuneT("F")),
           Map(),
-          List(),
+          Nil,
           None,
           true)
     conclusions.templatasByRune(CodeRuneT("F")) shouldEqual PrototypeTemplata(incrementPrototype)
@@ -1277,7 +1277,7 @@ class InfererTests extends FunSuite with Matchers {
           Map(CodeRuneT("T") -> CoordTemplataType, CodeRuneT("F") -> PrototypeTemplataType),
           Set(CodeRuneT("T"), CodeRuneT("F")),
           Map(),
-          List(),
+          Nil,
           None,
           true)
     conclusions.templatasByRune(CodeRuneT("F")) shouldEqual PrototypeTemplata(incrementPrototype)
@@ -1303,7 +1303,7 @@ class InfererTests extends FunSuite with Matchers {
           Map(CodeRuneT("X") -> StringTemplataType, CodeRuneT("Y") -> PackTemplataType(CoordTemplataType), CodeRuneT("T") -> CoordTemplataType, CodeRuneT("F") -> PrototypeTemplataType),
           Set(CodeRuneT("X"), CodeRuneT("Y"), CodeRuneT("T"), CodeRuneT("F")),
           Map(CodeRuneT("F") -> PrototypeTemplata(incrementPrototype)),
-          List(),
+          Nil,
           None,
           true)
     conclusions.templatasByRune(CodeRuneT("X")) shouldEqual StringTemplata("increment")
@@ -1352,43 +1352,43 @@ class InfererTests extends FunSuite with Matchers {
     expectSuccess(run("int", ShareP, ReadwriteP)) shouldEqual CoordT(ShareT, ReadonlyT, IntT.i32)
 
     vassert(expectFail(run("MutStruct", ShareP, ReadonlyP)).contains("Expected a share, but was an own"))
-    expectSuccess(run("MutStruct", OwnP, ReadwriteP)) shouldEqual CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
-    expectSuccess(run("MutStruct", ConstraintP, ReadonlyP)) shouldEqual CoordT(ConstraintT,ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
-    expectSuccess(run("MutStruct", ConstraintP, ReadwriteP)) shouldEqual CoordT(ConstraintT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
-    expectSuccess(run("MutStruct", WeakP, ReadonlyP)) shouldEqual CoordT(WeakT, ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
-    expectSuccess(run("MutStruct", WeakP, ReadwriteP)) shouldEqual CoordT(WeakT, ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
+    expectSuccess(run("MutStruct", OwnP, ReadwriteP)) shouldEqual CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
+    expectSuccess(run("MutStruct", ConstraintP, ReadonlyP)) shouldEqual CoordT(ConstraintT,ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
+    expectSuccess(run("MutStruct", ConstraintP, ReadwriteP)) shouldEqual CoordT(ConstraintT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
+    expectSuccess(run("MutStruct", WeakP, ReadonlyP)) shouldEqual CoordT(WeakT, ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
+    expectSuccess(run("MutStruct", WeakP, ReadwriteP)) shouldEqual CoordT(WeakT, ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
 
     vassert(expectFail(run("MutStructConstraint", ShareP, ReadonlyP)).contains("Expected a share, but was a borrow"))
-    expectSuccess(run("MutStructConstraint", OwnP, ReadwriteP)) shouldEqual CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
-    expectSuccess(run("MutStructConstraint", ConstraintP, ReadonlyP)) shouldEqual CoordT(ConstraintT,ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
+    expectSuccess(run("MutStructConstraint", OwnP, ReadwriteP)) shouldEqual CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
+    expectSuccess(run("MutStructConstraint", ConstraintP, ReadonlyP)) shouldEqual CoordT(ConstraintT,ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
     // &!T given a &Spaceship should give a &T, it should make the ro into a Readwrite.
-    expectSuccess(run("MutStructConstraint", ConstraintP, ReadwriteP)) shouldEqual CoordT(ConstraintT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
-    expectSuccess(run("MutStructConstraint", WeakP, ReadonlyP)) shouldEqual CoordT(WeakT, ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
+    expectSuccess(run("MutStructConstraint", ConstraintP, ReadwriteP)) shouldEqual CoordT(ConstraintT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
+    expectSuccess(run("MutStructConstraint", WeakP, ReadonlyP)) shouldEqual CoordT(WeakT, ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
     // &&!T given a &Spaceship should give a &T, it should make the ro into a Readwrite, and the borrow into a weak.
-    expectSuccess(run("MutStructConstraint", WeakP, ReadwriteP)) shouldEqual CoordT(WeakT, ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
+    expectSuccess(run("MutStructConstraint", WeakP, ReadwriteP)) shouldEqual CoordT(WeakT, ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
 
     vassert(expectFail(run("MutStructConstraintRW", ShareP, ReadonlyP)).contains("Expected a share, but was a borrow"))
-    expectSuccess(run("MutStructConstraintRW", OwnP, ReadwriteP)) shouldEqual CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
+    expectSuccess(run("MutStructConstraintRW", OwnP, ReadwriteP)) shouldEqual CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
     // &T given a &!Spaceship should give a &T, it should make the Readwrite into a Readonly.
-    expectSuccess(run("MutStructConstraintRW", ConstraintP, ReadonlyP)) shouldEqual CoordT(ConstraintT,ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
-    expectSuccess(run("MutStructConstraintRW", ConstraintP, ReadwriteP)) shouldEqual CoordT(ConstraintT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
-    expectSuccess(run("MutStructConstraintRW", WeakP, ReadonlyP)) shouldEqual CoordT(WeakT, ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
+    expectSuccess(run("MutStructConstraintRW", ConstraintP, ReadonlyP)) shouldEqual CoordT(ConstraintT,ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
+    expectSuccess(run("MutStructConstraintRW", ConstraintP, ReadwriteP)) shouldEqual CoordT(ConstraintT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
+    expectSuccess(run("MutStructConstraintRW", WeakP, ReadonlyP)) shouldEqual CoordT(WeakT, ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
     // &&T given a &!Spaceship should give a &T, it should make the Readwrite into a Readonly, and the borrow into a weak.
-    expectSuccess(run("MutStructConstraintRW", WeakP, ReadwriteP)) shouldEqual CoordT(WeakT, ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
+    expectSuccess(run("MutStructConstraintRW", WeakP, ReadwriteP)) shouldEqual CoordT(WeakT, ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
 
     vassert(expectFail(run("MutStructWeak", ShareP, ReadonlyP)).contains("Expected a share, but was a weak"))
     vassert(expectFail(run("MutStructWeak", OwnP, ReadwriteP)).contains("Expected a own, but was a weak"))
     vassert(expectFail(run("MutStructWeak", ConstraintP, ReadonlyP)).contains("Expected a borrow, but was a weak"))
     vassert(expectFail(run("MutStructWeak", ConstraintP, ReadwriteP)).contains("Expected a borrow, but was a weak"))
-    expectSuccess(run("MutStructWeak", WeakP, ReadonlyP)) shouldEqual CoordT(WeakT, ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
-    expectSuccess(run("MutStructWeak", WeakP, ReadwriteP)) shouldEqual CoordT(WeakT, ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
+    expectSuccess(run("MutStructWeak", WeakP, ReadonlyP)) shouldEqual CoordT(WeakT, ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
+    expectSuccess(run("MutStructWeak", WeakP, ReadwriteP)) shouldEqual CoordT(WeakT, ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
 
     vassert(expectFail(run("MutStructWeakRW", ShareP, ReadonlyP)).contains("Expected a share, but was a weak"))
     vassert(expectFail(run("MutStructWeakRW", OwnP, ReadwriteP)).contains("Expected a own, but was a weak"))
     vassert(expectFail(run("MutStructWeakRW", ConstraintP, ReadonlyP)).contains("Expected a borrow, but was a weak"))
     vassert(expectFail(run("MutStructWeakRW", ConstraintP, ReadwriteP)).contains("Expected a borrow, but was a weak"))
-    expectSuccess(run("MutStructWeakRW", WeakP, ReadonlyP)) shouldEqual CoordT(WeakT, ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
-    expectSuccess(run("MutStructWeakRW", WeakP, ReadwriteP)) shouldEqual CoordT(WeakT, ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
+    expectSuccess(run("MutStructWeakRW", WeakP, ReadonlyP)) shouldEqual CoordT(WeakT, ReadonlyT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
+    expectSuccess(run("MutStructWeakRW", WeakP, ReadwriteP)) shouldEqual CoordT(WeakT, ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
 
     expectSuccess(run("void", ShareP, ReadonlyP)) shouldEqual CoordT(ShareT, ReadonlyT, VoidT())
     expectSuccess(run("void", OwnP, ReadwriteP)) shouldEqual CoordT(ShareT, ReadonlyT, VoidT())
@@ -1412,7 +1412,7 @@ class InfererTests extends FunSuite with Matchers {
           Map(CodeRuneT("T") -> CoordTemplataType),
           Set(CodeRuneT("T")),
           Map(),
-          List(),
+          Nil,
           None,
           true)
       result
@@ -1445,7 +1445,7 @@ class InfererTests extends FunSuite with Matchers {
 
     vassert(expectFail(run("MutStruct", ShareP, ReadonlyP)).contains("Couldn't match incoming own against expected share"))
     // Takes the own off the incoming own coord, ends up as another own.
-    expectSuccess(run("MutStruct", OwnP, ReadwriteP)) shouldEqual CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
+    expectSuccess(run("MutStruct", OwnP, ReadwriteP)) shouldEqual CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
     // Tries to take the borrow off the incoming own coord... fails.
     vassert(expectFail(run("MutStruct", ConstraintP, ReadonlyP)).contains("Couldn't match incoming own against expected constraint"))
     vassert(expectFail(run("MutStruct", ConstraintP, ReadwriteP)).contains("Couldn't match incoming own against expected constraint"))
@@ -1455,7 +1455,7 @@ class InfererTests extends FunSuite with Matchers {
     // Tries to take the own off the incoming borrow coord... fails.
     vassert(expectFail(run("MutStructConstraint", OwnP, ReadwriteP)).contains("Couldn't match incoming constraint against expected own"))
     // Takes the borrow off the incoming borrow coord, succeeds and gives us an own.
-    expectSuccess(run("MutStructConstraint", ConstraintP, ReadonlyP)) shouldEqual CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
+    expectSuccess(run("MutStructConstraint", ConstraintP, ReadonlyP)) shouldEqual CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
     vassert(expectFail(run("MutStructConstraint", ConstraintP, ReadwriteP)).contains("Couldn't match incoming ro against expected rw"))
     // Takes the weak off the incoming borrow coord... fails.
     vassert(expectFail(run("MutStructConstraint", WeakP, ReadonlyP)).contains("Couldn't match incoming constraint against expected weak"))
@@ -1466,7 +1466,7 @@ class InfererTests extends FunSuite with Matchers {
     vassert(expectFail(run("MutStructConstraintRW", OwnP, ReadwriteP)).contains("Couldn't match incoming constraint against expected own"))
     vassert(expectFail(run("MutStructConstraintRW", ConstraintP, ReadonlyP)).contains("Couldn't match incoming rw against expected ro"))
     // Takes the borrow off the incoming borrow coord, succeeds and gives us an own.
-    expectSuccess(run("MutStructConstraintRW", ConstraintP, ReadwriteP)) shouldEqual CoordT(OwnT,ReadwriteT,StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(),CitizenNameT("MutStruct",List()))))
+    expectSuccess(run("MutStructConstraintRW", ConstraintP, ReadwriteP)) shouldEqual CoordT(OwnT,ReadwriteT,StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil,CitizenNameT("MutStruct",Nil))))
     // Takes the weak off the incoming borrow coord... fails.
     vassert(expectFail(run("MutStructConstraintRW", WeakP, ReadonlyP)).contains("Couldn't match incoming constraint against expected weak"))
     vassert(expectFail(run("MutStructConstraintRW", WeakP, ReadwriteP)).contains("Couldn't match incoming constraint against expected weak"))
@@ -1478,7 +1478,7 @@ class InfererTests extends FunSuite with Matchers {
     vassert(expectFail(run("MutStructWeak", ConstraintP, ReadonlyP)).contains("Couldn't match incoming weak against expected constraint"))
     vassert(expectFail(run("MutStructWeak", ConstraintP, ReadwriteP)).contains("Couldn't match incoming weak against expected constraint"))
     // Takes the weak off the incoming weak coord, succeeds and gives us an own.
-    expectSuccess(run("MutStructWeak", WeakP, ReadonlyP)) shouldEqual CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
+    expectSuccess(run("MutStructWeak", WeakP, ReadonlyP)) shouldEqual CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
     vassert(expectFail(run("MutStructWeak", WeakP, ReadwriteP)).contains("Couldn't match incoming ro against expected rw"))
     vassert(expectFail(run("MutStructWeak", ShareP, ReadonlyP)).contains("Couldn't match incoming weak against expected share"))
 
@@ -1489,7 +1489,7 @@ class InfererTests extends FunSuite with Matchers {
     vassert(expectFail(run("MutStructWeakRW", ConstraintP, ReadwriteP)).contains("Couldn't match incoming weak against expected constraint"))
     vassert(expectFail(run("MutStructWeakRW", WeakP, ReadonlyP)).contains("Couldn't match incoming rw against expected ro"))
     // Takes the weak off the incoming weak coord, succeeds and gives us an own.
-    expectSuccess(run("MutStructWeakRW", WeakP, ReadwriteP)) shouldEqual CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MutStruct", List()))))
+    expectSuccess(run("MutStructWeakRW", WeakP, ReadwriteP)) shouldEqual CoordT(OwnT,ReadwriteT, StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MutStruct", Nil))))
     vassert(expectFail(run("MutStructWeakRW", ShareP, ReadonlyP)).contains("Couldn't match incoming weak against expected share"))
   }
 }

--- a/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarMutateTests.scala
+++ b/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarMutateTests.scala
@@ -116,7 +116,7 @@ class TemplarMutateTests extends FunSuite with Matchers {
     compile.getTemputs() match {
       case Err(CantMutateFinalMember(_, structRef2, memberName)) => {
         structRef2.last match {
-          case CitizenNameT("Vec3", List()) =>
+          case CitizenNameT("Vec3", Nil) =>
         }
         memberName.last match {
           case CodeVarNameT("x") =>
@@ -137,7 +137,7 @@ class TemplarMutateTests extends FunSuite with Matchers {
     compile.getTemputs() match {
       case Err(CantMutateFinalMember(_, structRef2, memberName)) => {
         structRef2.last match {
-          case CitizenNameT("Vec3", List()) =>
+          case CitizenNameT("Vec3", Nil) =>
         }
         memberName.last match {
           case CodeVarNameT("x") =>
@@ -197,9 +197,9 @@ class TemplarMutateTests extends FunSuite with Matchers {
   }
 
   test("Humanize errors") {
-    val fireflyKind = StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("Firefly", List())))
+    val fireflyKind = StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List.empty, CitizenNameT("Firefly", List.empty)))
     val fireflyCoord = CoordT(OwnT,ReadwriteT,fireflyKind)
-    val serenityKind = StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("Serenity", List())))
+    val serenityKind = StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List.empty, CitizenNameT("Serenity", List.empty)))
     val serenityCoord = CoordT(OwnT,ReadwriteT,serenityKind)
 
     val filenamesAndSources = FileCoordinateMap.test("blah blah blah\nblah blah blah")
@@ -209,7 +209,7 @@ class TemplarMutateTests extends FunSuite with Matchers {
     vassert(TemplarErrorHumanizer.humanize(false, filenamesAndSources,
       CouldntFindFunctionToCallT(
         RangeS.testZero,
-        ScoutExpectedFunctionFailure(GlobalFunctionFamilyNameA(""), List(), Map(), Map(), Map())))
+        ScoutExpectedFunctionFailure(GlobalFunctionFamilyNameA(""), List.empty, Map(), Map(), Map())))
       .nonEmpty)
     vassert(TemplarErrorHumanizer.humanize(false, filenamesAndSources,
       CannotSubscriptT(
@@ -260,13 +260,13 @@ class TemplarMutateTests extends FunSuite with Matchers {
       FunctionAlreadyExists(
         RangeS.testZero,
         RangeS.testZero,
-        SignatureT(FullNameT(PackageCoordinate.TEST_TLD, List(), FunctionNameT("myFunc", List(), List())))))
+        SignatureT(FullNameT(PackageCoordinate.TEST_TLD, List.empty, FunctionNameT("myFunc", List.empty, List.empty)))))
       .nonEmpty)
     vassert(TemplarErrorHumanizer.humanize(false, filenamesAndSources,
       CantMutateFinalMember(
         RangeS.testZero,
         serenityKind.fullName,
-        FullNameT(PackageCoordinate.TEST_TLD, List(), CodeVarNameT("bork"))))
+        FullNameT(PackageCoordinate.TEST_TLD, List.empty, CodeVarNameT("bork"))))
       .nonEmpty)
     vassert(TemplarErrorHumanizer.humanize(false, filenamesAndSources,
       LambdaReturnDoesntMatchInterfaceConstructor(

--- a/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarProjectTests.scala
+++ b/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarProjectTests.scala
@@ -14,7 +14,7 @@ class TemplarProjectTests extends FunSuite with Matchers {
       TemplarTestCompilation.test("fn main() export { }")
     val temputs = compile.expectTemputs()
 
-    val fullName = FullNameT(PackageCoordinate.TEST_TLD, List(), FunctionNameT("main", List(), List()))
+    val fullName = FullNameT(PackageCoordinate.TEST_TLD, Nil, FunctionNameT("main", Nil, Nil))
     vassertSome(temputs.lookupFunction(SignatureT(fullName)))
   }
 
@@ -23,14 +23,14 @@ class TemplarProjectTests extends FunSuite with Matchers {
       TemplarTestCompilation.test("fn main() export { {}!() }")
     val temputs = compile.expectTemputs()
 
-//    val fullName = FullName2(PackageCoordinate.TEST_TLD, List(), FunctionName2("lamb", List(), List()))
+//    val fullName = FullName2(PackageCoordinate.TEST_TLD, Nil, FunctionName2("lamb", Nil, Nil))
 
     val lamFunc = temputs.lookupFunction("__call")
     lamFunc.header.fullName match {
       case FullNameT(
         PackageCoordinate.TEST_TLD,
-        List(FunctionNameT("main",List(),List()), LambdaCitizenNameT(_)),
-        FunctionNameT("__call",List(),List(CoordT(ShareT,ReadonlyT,_)))) =>
+        List(FunctionNameT("main",Nil,Nil), LambdaCitizenNameT(_)),
+        FunctionNameT("__call",Nil,List(CoordT(ShareT,ReadonlyT,_)))) =>
     }
   }
 
@@ -41,7 +41,7 @@ class TemplarProjectTests extends FunSuite with Matchers {
 
     val struct = temputs.lookupStruct("MyStruct")
     struct.fullName match {
-      case FullNameT(PackageCoordinate.TEST_TLD,List(),CitizenNameT("MyStruct",List())) =>
+      case FullNameT(PackageCoordinate.TEST_TLD,Nil,CitizenNameT("MyStruct",Nil)) =>
     }
   }
 }

--- a/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarTests.scala
+++ b/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarTests.scala
@@ -32,7 +32,7 @@ class TemplarTests extends FunSuite with Matchers {
 
     val main = temputs.lookupFunction("main")
     main.only({
-      case FunctionHeaderT(simpleName("main"),List(UserFunction2),List(), CoordT(ShareT, ReadonlyT, IntT.i32), _) => true
+      case FunctionHeaderT(simpleName("main"),List(UserFunction2),Nil, CoordT(ShareT, ReadonlyT, IntT.i32), _) => true
     })
     main.only({ case ConstantIntTE(3, _) => true })
   }
@@ -400,7 +400,7 @@ class TemplarTests extends FunSuite with Matchers {
 
     val interfaceDef =
       temputs.interfaces.collectFirst({
-        case id @ InterfaceDefinitionT(simpleName("MyInterface"), _, false, MutableT, List()) => id
+        case id @ InterfaceDefinitionT(simpleName("MyInterface"), _, false, MutableT, Nil) => id
       }).get
 
     val structDef =
@@ -423,9 +423,9 @@ class TemplarTests extends FunSuite with Matchers {
 
     temputs.lookupInterface(
       InterfaceRefT(
-        FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MyOption", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))))
+        FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MyOption", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))))
     vassert(temputs.lookupFunction("main").header.params.head.tyype ==
-        CoordT(OwnT,ReadwriteT,InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MyOption", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32))))))))
+        CoordT(OwnT,ReadwriteT,InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MyOption", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32))))))))
 
     // Can't run it because there's nothing implementing that interface >_>
   }
@@ -473,9 +473,9 @@ class TemplarTests extends FunSuite with Matchers {
     val interface =
       temputs.lookupInterface(
         InterfaceRefT(
-          FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MyOption", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))))
+          FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MyOption", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))))
 
-    val struct = temputs.lookupStruct(StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MySome", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))));
+    val struct = temputs.lookupStruct(StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MySome", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))));
 
     temputs.lookupImpl(struct.getRef, interface.getRef)
   }
@@ -511,7 +511,7 @@ class TemplarTests extends FunSuite with Matchers {
 
     val temputs = compile.expectTemputs()
 
-    temputs.lookupStruct(StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MySome", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))));
+    temputs.lookupStruct(StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MySome", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32)))))));
 
     val constructor = temputs.lookupFunction("MySome")
     constructor.header match {
@@ -520,7 +520,7 @@ class TemplarTests extends FunSuite with Matchers {
         simpleName("MySome"),
         _,
         _,
-        CoordT(OwnT,ReadwriteT,StructRefT(FullNameT(_, List(), CitizenNameT("MySome", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32))))))),
+        CoordT(OwnT,ReadwriteT,StructRefT(FullNameT(_, Nil, CitizenNameT("MySome", List(CoordTemplata(CoordT(ShareT, ReadonlyT, IntT.i32))))))),
         _) =>
     }
 
@@ -538,8 +538,8 @@ class TemplarTests extends FunSuite with Matchers {
     main.only({ case ReferenceLocalVariableT(FullNameT(_,_,CodeVarNameT("x")),FinalT,CoordT(OwnT,ReadwriteT,InterfaceRefT(simpleName("MyInterface")))) => })
 
     val upcast = main.onlyOf(classOf[StructToInterfaceUpcastTE])
-    vassert(upcast.resultRegister.reference == CoordT(OwnT,ReadwriteT,InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MyInterface", List())))))
-    vassert(upcast.innerExpr.resultRegister.reference == CoordT(OwnT,ReadwriteT,StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("MyStruct", List())))))
+    vassert(upcast.resultRegister.reference == CoordT(OwnT,ReadwriteT,InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MyInterface", Nil)))))
+    vassert(upcast.innerExpr.resultRegister.reference == CoordT(OwnT,ReadwriteT,StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("MyStruct", Nil)))))
   }
 
   test("Tests calling a virtual function") {
@@ -552,7 +552,7 @@ class TemplarTests extends FunSuite with Matchers {
         innerExpr.resultRegister.only({
           case StructRefT(simpleName("Toyota")) =>
         })
-        vassert(up.resultRegister.reference.kind == InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("Car", List()))))
+        vassert(up.resultRegister.reference.kind == InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("Car", Nil))))
       }
     })
   }
@@ -638,7 +638,7 @@ class TemplarTests extends FunSuite with Matchers {
     main.only({
       case ReferenceMemberLookupT(_,
         SoftLoadTE(LocalLookupT(_, _, CoordT(_,_,StructRefT(_)), FinalT), ConstraintT, ReadonlyT),
-        FullNameT(_, List(CitizenNameT("Vec3i",List())),CodeVarNameT("x")),CoordT(ShareT,ReadonlyT,IntT.i32),ReadonlyT,FinalT) =>
+        FullNameT(_, List(CitizenNameT("Vec3i",Nil)),CodeVarNameT("x")),CoordT(ShareT,ReadonlyT,IntT.i32),ReadonlyT,FinalT) =>
     })
   }
 
@@ -787,7 +787,7 @@ class TemplarTests extends FunSuite with Matchers {
     val temputs = compile.expectTemputs()
     val main = temputs.lookupFunction("main")
     val destructorCalls =
-      main.all({ case fpc @ FunctionCallTE(PrototypeT(FullNameT(_, List(), FunctionNameT("destructor",List(CoordTemplata(CoordT(OwnT,ReadwriteT,StructRefT(simpleName("Marine"))))), _)), _),_) => fpc })
+      main.all({ case fpc @ FunctionCallTE(PrototypeT(FullNameT(_, Nil, FunctionNameT("destructor",List(CoordTemplata(CoordT(OwnT,ReadwriteT,StructRefT(simpleName("Marine"))))), _)), _),_) => fpc })
     destructorCalls.size shouldEqual 2
   }
 
@@ -943,7 +943,7 @@ class TemplarTests extends FunSuite with Matchers {
         |}
         |""".stripMargin)
     compile.getTemputs() match {
-      case Err(CannotSubscriptT(_, StructRefT(FullNameT(_, _, CitizenNameT("Weapon", List()))))) =>
+      case Err(CannotSubscriptT(_, StructRefT(FullNameT(_, _, CitizenNameT("Weapon", Nil))))) =>
     }
   }
 
@@ -954,7 +954,7 @@ class TemplarTests extends FunSuite with Matchers {
         |fn moo() int export { 1448 }
         |""".stripMargin)
     compile.getTemputs() match {
-      case Err(FunctionAlreadyExists(_, _, SignatureT(FullNameT(_, List(), FunctionNameT("moo", List(), List()))))) =>
+      case Err(FunctionAlreadyExists(_, _, SignatureT(FullNameT(_, Nil, FunctionNameT("moo", Nil, Nil))))) =>
     }
   }
 
@@ -1030,13 +1030,13 @@ class TemplarTests extends FunSuite with Matchers {
   }
 
   test("Humanize errors") {
-    val fireflyKind = StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("Firefly", List())))
+    val fireflyKind = StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("Firefly", Nil)))
     val fireflyCoord = CoordT(OwnT,ReadwriteT,fireflyKind)
-    val serenityKind = StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("Serenity", List())))
+    val serenityKind = StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("Serenity", Nil)))
     val serenityCoord = CoordT(OwnT,ReadwriteT,serenityKind)
-    val ispaceshipKind = InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("ISpaceship", List())))
+    val ispaceshipKind = InterfaceRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("ISpaceship", Nil)))
     val ispaceshipCoord = CoordT(OwnT,ReadwriteT,ispaceshipKind)
-    val unrelatedKind = StructRefT(FullNameT(PackageCoordinate.TEST_TLD, List(), CitizenNameT("Spoon", List())))
+    val unrelatedKind = StructRefT(FullNameT(PackageCoordinate.TEST_TLD, Nil, CitizenNameT("Spoon", Nil)))
     val unrelatedCoord = CoordT(OwnT,ReadwriteT,unrelatedKind)
 
     val filenamesAndSources = FileCoordinateMap.test("blah blah blah\nblah blah blah")
@@ -1048,14 +1048,14 @@ class TemplarTests extends FunSuite with Matchers {
         RangeS.testZero,
         ScoutExpectedFunctionFailure(
           CodeTypeNameA("someFunc"),
-          List(),
+          Nil,
           Map(),
           Map(),
           Map()))).nonEmpty)
     vassert(TemplarErrorHumanizer.humanize(false, filenamesAndSources,
       CouldntFindFunctionToCallT(
         RangeS.testZero,
-        ScoutExpectedFunctionFailure(GlobalFunctionFamilyNameA(""), List(), Map(), Map(), Map())))
+        ScoutExpectedFunctionFailure(GlobalFunctionFamilyNameA(""), Nil, Map(), Map(), Map())))
       .nonEmpty)
     vassert(TemplarErrorHumanizer.humanize(false, filenamesAndSources,
       CannotSubscriptT(
@@ -1111,13 +1111,13 @@ class TemplarTests extends FunSuite with Matchers {
       FunctionAlreadyExists(
         RangeS.testZero,
         RangeS.testZero,
-        SignatureT(FullNameT(PackageCoordinate.TEST_TLD, List(), FunctionNameT("myFunc", List(), List())))))
+        SignatureT(FullNameT(PackageCoordinate.TEST_TLD, Nil, FunctionNameT("myFunc", Nil, Nil)))))
       .nonEmpty)
     vassert(TemplarErrorHumanizer.humanize(false, filenamesAndSources,
       CantMutateFinalMember(
         RangeS.testZero,
         serenityKind.fullName,
-        FullNameT(PackageCoordinate.TEST_TLD, List(), CodeVarNameT("bork"))))
+        FullNameT(PackageCoordinate.TEST_TLD, Nil, CodeVarNameT("bork"))))
       .nonEmpty)
     vassert(TemplarErrorHumanizer.humanize(false, filenamesAndSources,
       LambdaReturnDoesntMatchInterfaceConstructor(

--- a/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarVirtualTests.scala
+++ b/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarVirtualTests.scala
@@ -29,10 +29,10 @@ class TemplarVirtualTests extends FunSuite with Matchers {
     temputs.lookupFunction("as").only({
       case as @ AsSubtypeTE(sourceExpr, targetSubtype, resultOptType, okConstructor, errConstructor) => {
         sourceExpr.resultRegister.reference match {
-          case CoordT(ConstraintT,ReadonlyT,InterfaceRefT(FullNameT(_, List(),CitizenNameT("IShip",List())))) =>
+          case CoordT(ConstraintT,ReadonlyT,InterfaceRefT(FullNameT(_, Nil,CitizenNameT("IShip",Nil)))) =>
         }
         targetSubtype match {
-          case StructRefT(FullNameT(_, List(),CitizenNameT("Raza",List()))) =>
+          case StructRefT(FullNameT(_, Nil,CitizenNameT("Raza",Nil))) =>
         }
         val (firstGenericArg, secondGenericArg) =
           resultOptType match {
@@ -40,7 +40,7 @@ class TemplarVirtualTests extends FunSuite with Matchers {
               OwnT,ReadwriteT,
               InterfaceRefT(
                 FullNameT(
-                  _, List(),
+                  _, Nil,
                   CitizenNameT(
                     "Result",
                     List(firstGenericArg, secondGenericArg))))) => (firstGenericArg, secondGenericArg)
@@ -49,13 +49,13 @@ class TemplarVirtualTests extends FunSuite with Matchers {
           case CoordTemplata(
             CoordT(
               ConstraintT,ReadonlyT,
-              StructRefT(FullNameT(_, List(),CitizenNameT("Raza",List()))))) =>
+              StructRefT(FullNameT(_, Nil,CitizenNameT("Raza",Nil))))) =>
         }
         secondGenericArg match {
           case CoordTemplata(
             CoordT(
               ConstraintT,ReadonlyT,
-              InterfaceRefT(FullNameT(_, List(),CitizenNameT("IShip",List()))))) =>
+              InterfaceRefT(FullNameT(_, Nil,CitizenNameT("IShip",Nil))))) =>
         }
         vassert(okConstructor.paramTypes.head.kind == targetSubtype)
         vassert(errConstructor.paramTypes.head == sourceExpr.resultRegister.reference)

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/TemplataUtils.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/TemplataUtils.scala
@@ -4,7 +4,7 @@ import net.verdagon.vale.templar.templata.{FunctionHeaderT, PrototypeT}
 
 object simpleName {
 //  def apply(name: String): FullName2 = {
-//    FullName2(List(FunctionNamePart2(name, Some(List()), None, None)))
+//    FullName2(List(FunctionNamePart2(name, Some(List.empty), None, None)))
 //  }
   def unapply(fullName: FullNameT[INameT]): Option[String] = {
     fullName.last match {

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/ast.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/ast.scala
@@ -78,10 +78,10 @@ case class EdgeT(
   methods: List[PrototypeT])
 
 object Program2 {
-  val emptyTupleStructRef = StructRefT(FullNameT(PackageCoordinate.BUILTIN, List(), TupleNameT(List())))
-  val emptyTupleType: PackTT = PackTT(List(), Program2.emptyTupleStructRef)
+  val emptyTupleStructRef = StructRefT(FullNameT(PackageCoordinate.BUILTIN, List.empty, TupleNameT(List.empty)))
+  val emptyTupleType: PackTT = PackTT(List.empty, Program2.emptyTupleStructRef)
   val emptyTupleReference: CoordT = CoordT(ShareT, ReadonlyT, emptyTupleType)
-  val emptyPackExpression: PackTE = PackTE(List(), CoordT(ShareT, ReadonlyT, Program2.emptyTupleType), Program2.emptyTupleType)
+  val emptyPackExpression: PackTE = PackTE(List.empty, CoordT(ShareT, ReadonlyT, Program2.emptyTupleType), Program2.emptyTupleType)
 
   val intType = CoordT(ShareT, ReadonlyT, IntT.i32)
   val boolType = CoordT(ShareT, ReadonlyT, BoolT())

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/env/Environment.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/env/Environment.scala
@@ -113,7 +113,7 @@ case class TemplatasStore(
   //  private var entriesByHumanName = Map[String, List[IEnvEntry]]()
 
   def entryToTemplata(env: IEnvironment, entry: IEnvEntry): ITemplata = {
-//    vassert(env.fullName != FullName2(PackageCoordinate.BUILTIN, List(), PackageTopLevelName2()))
+//    vassert(env.fullName != FullName2(PackageCoordinate.BUILTIN, List.empty, PackageTopLevelName2()))
     entry match {
       case FunctionEnvEntry(func) => FunctionTemplata.make(env, func)
       case StructEnvEntry(struct) => StructTemplata.make(env, struct)
@@ -325,7 +325,7 @@ case class TemplatasStore(
       .flatten
       .filter(entryMatchesFilter(_, lookupFilter)) match {
       case List(entry) => Some(entryToTemplata(from, entry))
-      case List() => from.getParentEnv().flatMap(_.getNearestTemplataWithAbsoluteName2(name, lookupFilter))
+      case Nil => from.getParentEnv().flatMap(_.getNearestTemplataWithAbsoluteName2(name, lookupFilter))
       case multiple => vfail("Too many things named " + name + ":" + multiple);
     }
   }
@@ -338,7 +338,7 @@ case class TemplatasStore(
   List[ITemplata] = {
     profiler.childFrame("getAllTemplatasWithName", () => {
       entriesByImpreciseNameA
-        .getOrElse(name, List())
+        .getOrElse(name, List.empty)
         .filter(entryMatchesFilter(_, lookupFilter))
         .map(x => entryToTemplata(from, x))
         .toList ++
@@ -352,10 +352,10 @@ case class TemplatasStore(
     lookupFilter: Set[ILookupContext]):
   Option[ITemplata] = {
     entriesByImpreciseNameA
-      .getOrElse(name, List())
+      .getOrElse(name, List.empty)
       .filter(entryMatchesFilter(_, lookupFilter)) match {
       case List(entry) => Some(entryToTemplata(from, entry))
-      case List() => from.getParentEnv().flatMap(_.getNearestTemplataWithName(name, lookupFilter))
+      case Nil => from.getParentEnv().flatMap(_.getNearestTemplataWithName(name, lookupFilter))
       case multiple => vfail("Too many things named " + name + ":" + multiple);
     }
   }

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/env/FunctionEnvironment.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/env/FunctionEnvironment.scala
@@ -162,10 +162,10 @@ case class FunctionEnvironment(
       if (includeAncestorEnvs) {
         parentEnv match {
           case parentFuncEnv@FunctionEnvironment(_, _, _, _, _, _, _, _) => parentFuncEnv.getAllLocals(includeAncestorEnvs)
-          case _ => List()
+          case _ => List.empty
         }
       } else {
-        List()
+        List.empty
       }
     val liveLocals = locals.collect({ case i : ILocalVariableT => i })
     parentLiveLocals ++ liveLocals
@@ -176,10 +176,10 @@ case class FunctionEnvironment(
       if (includeAncestorEnvs) {
         parentEnv match {
           case parentFuncEnv@FunctionEnvironment(_, _, _, _, _, _, _, _) => parentFuncEnv.getAllUnstackifiedLocals(includeAncestorEnvs)
-          case _ => List()
+          case _ => List.empty
         }
       } else {
-        List()
+        List.empty
       }
     parentUnstackifiedLocals ++ unstackifieds
   }
@@ -192,7 +192,7 @@ case class FunctionEnvironment(
       newTemplataStore(),
       maybeReturnType,
       varCounter,
-      List(),
+      List.empty,
       Set())
   }
 

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/names.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/names.scala
@@ -20,7 +20,7 @@ case class FullNameT[+T <: INameT](
   vassert(!initSteps.contains(PackageTopLevelNameT()))
 
   this match {
-    case FullNameT(PackageCoordinate.TEST_TLD, List(), FunctionNameT("main", List(), List())) =>
+    case FullNameT(PackageCoordinate.TEST_TLD, Nil, FunctionNameT("main", Nil, Nil)) =>
     case _ =>
   }
 
@@ -153,7 +153,7 @@ case class ExternFunctionNameT(
   humanName: String,
   parameters: List[CoordT]
 ) extends IFunctionNameT {
-  override def templateArgs: List[ITemplata] = List()
+  override def templateArgs: List[ITemplata] = List.empty
 
   def order = 46;
   def all[T](func: PartialFunction[QueriableT, T]): List[T] = {
@@ -221,7 +221,7 @@ case class ConstructorNameT(
   parameters: List[CoordT]
 ) extends IFunctionNameT {
   def order = 21;
-  def templateArgs: List[ITemplata] = List()
+  def templateArgs: List[ITemplata] = List.empty
   def all[T](func: PartialFunction[QueriableT, T]): List[T] = {
     List(this).collect(func)
   }
@@ -272,7 +272,7 @@ case class LambdaCitizenNameT(
 ) extends ICitizenNameT {
   vpass()
 
-  def templateArgs: List[ITemplata] = List()
+  def templateArgs: List[ITemplata] = List.empty
   def order = 17;
   def all[T](func: PartialFunction[QueriableT, T]): List[T] = {
     List(this).collect(func) ++ templateArgs.toList.flatMap(_.all(func))

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/templata/TemplataTemplarInner.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/templata/TemplataTemplarInner.scala
@@ -211,10 +211,10 @@ class TemplataTemplarInner[Env, State](delegate: ITemplataTemplarInnerDelegate[E
               case (Some(distance)) => (distance)
             }
           }
-          case (PackTT(List(), _), VoidT()) => vfail("figure out void<->emptypack")
-          case (VoidT(), PackTT(List(), _)) => vfail("figure out void<->emptypack")
-          case (PackTT(List(), _), _) => return (None)
-          case (_, PackTT(List(), _)) => return (None)
+          case (PackTT(Nil, _), VoidT()) => vfail("figure out void<->emptypack")
+          case (VoidT(), PackTT(Nil, _)) => vfail("figure out void<->emptypack")
+          case (PackTT(Nil, _), _) => return (None)
+          case (_, PackTT(Nil, _)) => return (None)
           case (_ : CitizenRefT, IntT(_) | BoolT() | StrT() | FloatT()) => return (None)
           case (IntT(_) | BoolT() | StrT() | FloatT(), _ : CitizenRefT) => return (None)
           case _ => {
@@ -301,10 +301,10 @@ class TemplataTemplarInner[Env, State](delegate: ITemplataTemplarInnerDelegate[E
             case (Some(_)) =>
           }
         }
-        case (PackTT(List(), _), VoidT()) => vfail("figure out void<->emptypack")
-        case (VoidT(), PackTT(List(), _)) => vfail("figure out void<->emptypack")
-        case (PackTT(List(), _), _) => return (false)
-        case (_, PackTT(List(), _)) => return (false)
+        case (PackTT(Nil, _), VoidT()) => vfail("figure out void<->emptypack")
+        case (VoidT(), PackTT(Nil, _)) => vfail("figure out void<->emptypack")
+        case (PackTT(Nil, _), _) => return (false)
+        case (_, PackTT(Nil, _)) => return (false)
         case (_ : CitizenRefT, IntT(_) | BoolT() | StrT() | FloatT()) => return (false)
         case (IntT(_) | BoolT() | StrT() | FloatT(), _ : CitizenRefT) => return (false)
         case _ => {
@@ -507,7 +507,7 @@ class TemplataTemplarInner[Env, State](delegate: ITemplataTemplarInnerDelegate[E
           vfail("Can't coerce " + structA.name + " to be a kind, is a template!")
         }
         val kind =
-          delegate.evaluateStructTemplata(state, range, st, List())
+          delegate.evaluateStructTemplata(state, range, st, List.empty)
         (KindTemplata(kind))
       }
       case (it @ InterfaceTemplata(_, interfaceA), KindTemplataType) => {
@@ -515,7 +515,7 @@ class TemplataTemplarInner[Env, State](delegate: ITemplataTemplarInnerDelegate[E
           vfail("Can't coerce " + interfaceA.name + " to be a kind, is a template!")
         }
         val kind =
-          delegate.evaluateInterfaceTemplata(state, range, it, List())
+          delegate.evaluateInterfaceTemplata(state, range, it, List.empty)
         (KindTemplata(kind))
       }
       case (st @ StructTemplata(_, structA), ttt @ TemplateTemplataType(_, _)) => {
@@ -528,7 +528,7 @@ class TemplataTemplarInner[Env, State](delegate: ITemplataTemplarInnerDelegate[E
           vfail("Can't coerce " + structA.name + " to be a coord, is a template!")
         }
         val kind =
-          delegate.evaluateStructTemplata(state, range, st, List())
+          delegate.evaluateStructTemplata(state, range, st, List.empty)
         val mutability = delegate.getMutability(state, kind)
 
         // Default ownership is own for mutables, share for imms
@@ -543,7 +543,7 @@ class TemplataTemplarInner[Env, State](delegate: ITemplataTemplarInnerDelegate[E
           vfail("Can't coerce " + interfaceA.name + " to be a coord, is a template!")
         }
         val kind =
-          delegate.evaluateInterfaceTemplata(state, range, it, List())
+          delegate.evaluateInterfaceTemplata(state, range, it, List.empty)
         val mutability = delegate.getMutability(state, kind)
         val coerced =
           CoordTemplata(
@@ -591,25 +591,25 @@ class TemplataTemplarInner[Env, State](delegate: ITemplataTemplarInnerDelegate[E
       }
       case (KindTemplata(actualStructRef @ StructRefT(_)), expectedStructTemplata @ StructTemplata(_, _)) => {
         vassert(bExpectedType == KindTemplataType)
-        citizenMatchesTemplata(actualStructRef, expectedStructTemplata, List())
+        citizenMatchesTemplata(actualStructRef, expectedStructTemplata, List.empty)
       }
       case (CoordTemplata(CoordT(ShareT | OwnT, actualPermission, actualStructRef @ StructRefT(_))), expectedStructTemplata @ StructTemplata(_, _)) => {
         vassert(bExpectedType == CoordTemplataType)
         val mutability = delegate.getMutability(state, actualStructRef)
         val expectedPermission = if (mutability == MutableT) ReadwriteT else ReadonlyT
         val permissionMatches = expectedPermission == actualPermission
-        permissionMatches && citizenMatchesTemplata(actualStructRef, expectedStructTemplata, List())
+        permissionMatches && citizenMatchesTemplata(actualStructRef, expectedStructTemplata, List.empty)
       }
       case (KindTemplata(actualInterfaceRef @ InterfaceRefT(_)), expectedInterfaceTemplata @ InterfaceTemplata(_, _)) => {
         vassert(bExpectedType == KindTemplataType)
-        citizenMatchesTemplata(actualInterfaceRef, expectedInterfaceTemplata, List())
+        citizenMatchesTemplata(actualInterfaceRef, expectedInterfaceTemplata, List.empty)
       }
       case (CoordTemplata(CoordT(ShareT | OwnT, actualPermission, actualInterfaceRef @ InterfaceRefT(_))), expectedInterfaceTemplata @ InterfaceTemplata(_, _)) => {
         vassert(bExpectedType == CoordTemplataType)
         val mutability = delegate.getMutability(state, actualInterfaceRef)
         val expectedPermission = if (mutability == MutableT) ReadwriteT else ReadonlyT
         val permissionMatches = expectedPermission == actualPermission
-        permissionMatches && citizenMatchesTemplata(actualInterfaceRef, expectedInterfaceTemplata, List())
+        permissionMatches && citizenMatchesTemplata(actualInterfaceRef, expectedInterfaceTemplata, List.empty)
       }
       case (ArrayTemplateTemplata(), ArrayTemplateTemplata()) => true
       case (KindTemplata(RuntimeSizedArrayTT(_)), ArrayTemplateTemplata()) => true

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/templata/ast.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/templata/ast.scala
@@ -223,6 +223,6 @@ object CodeLocationT {
   val zero = CodeLocationT.internal(-1)
   def internal(internalNum: Int): CodeLocationT = {
     vassert(internalNum < 0)
-    CodeLocationT(FileCoordinate("", List(), "internal"), internalNum)
+    CodeLocationT(FileCoordinate("", List.empty, "internal"), internalNum)
   }
 }

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/templata/templata.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/templata/templata.scala
@@ -65,12 +65,12 @@ case class FunctionTemplata(
 //  this match {
 //    case FunctionTemplata(
 //      env,
-//      FunctionA(_, ImmConcreteDestructorNameA(PackageCoordinate(_,List())),_, _, _, _, _, _, _, _, _, _))
-//    if env.fullName == FullName2(PackageCoordinate.TEST_TLD,List(),PackageTopLevelName2()) => vfail()
+//      FunctionA(_, ImmConcreteDestructorNameA(PackageCoordinate(_,List.empty)),_, _, _, _, _, _, _, _, _, _))
+//    if env.fullName == FullName2(PackageCoordinate.TEST_TLD,List.empty,PackageTopLevelName2()) => vfail()
 //    case _ =>
 //  }
 //  this match {
-//    case FunctionTemplata(env, _) if env.fullName == FullName2(PackageCoordinate.TEST_TLD,List(),PackageTopLevelName2()) => vfail()
+//    case FunctionTemplata(env, _) if env.fullName == FullName2(PackageCoordinate.TEST_TLD,List.empty,PackageTopLevelName2()) => vfail()
 //    case _ =>
 //  }
 

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/types/types.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/types/types.scala
@@ -252,7 +252,7 @@ case class RawArrayTT(
 case class StaticSizedArrayTT(size: Int, array: RawArrayTT) extends KindT {
   override def order: Int = 12;
 
-  def name: FullNameT[StaticSizedArrayNameT] = FullNameT(PackageCoordinate.BUILTIN, List(), StaticSizedArrayNameT(size, RawArrayNameT(array.mutability, array.memberType)))
+  def name: FullNameT[StaticSizedArrayNameT] = FullNameT(PackageCoordinate.BUILTIN, List.empty, StaticSizedArrayNameT(size, RawArrayNameT(array.mutability, array.memberType)))
 
   def all[T](func: PartialFunction[QueriableT, T]): List[T] = {
     List(this).collect(func) ++ array.all(func)
@@ -262,7 +262,7 @@ case class StaticSizedArrayTT(size: Int, array: RawArrayTT) extends KindT {
 case class RuntimeSizedArrayTT(array: RawArrayTT) extends KindT {
   override def order: Int = 19;
 
-  def name: FullNameT[RuntimeSizedArrayNameT] = FullNameT(PackageCoordinate.BUILTIN, List(), RuntimeSizedArrayNameT(RawArrayNameT(array.mutability, array.memberType)))
+  def name: FullNameT[RuntimeSizedArrayNameT] = FullNameT(PackageCoordinate.BUILTIN, List.empty, RuntimeSizedArrayNameT(RawArrayNameT(array.mutability, array.memberType)))
 
   def all[T](func: PartialFunction[QueriableT, T]): List[T] = {
     List(this).collect(func) ++ array.all(func)

--- a/Valestrom/Tests/test/main/resources/programs/scratch.vale
+++ b/Valestrom/Tests/test/main/resources/programs/scratch.vale
@@ -446,7 +446,7 @@ struct FunctionHeaderP {
   // attributes List<IFunctionAttributeP>;
 
   // If this is None, then the function had no identifying runes.
-  // If it's Some(List()) it might represent the <> in `fn moo<>(a int, b bool) { ... }`
+  // If it's Some(List.empty) it might represent the <> in `fn moo<>(a int, b bool) { ... }`
   // If it's Some(List(...)) then it's the <T, Y> in `fn moo<T, Y>(a T, b Y) { ... }`
   maybeUserSpecifiedIdentifyingRunes Opt<IdentifyingRunesP>;
 

--- a/Valestrom/Utils/src/net/verdagon/vale/CodeHierarchy.scala
+++ b/Valestrom/Utils/src/net/verdagon/vale/CodeHierarchy.scala
@@ -11,7 +11,7 @@ case class FileCoordinate(module: String, packages: List[String], filepath: Stri
 }
 
 object FileCoordinate extends Ordering[FileCoordinate] {
-  val test = FileCoordinate("test", List(), "test.vale")
+  val test = FileCoordinate("test", List.empty, "test.vale")
 
   override def compare(a: FileCoordinate, b: FileCoordinate):Int = {
     val diff = a.packageCoordinate.compareTo(b.packageCoordinate)
@@ -30,11 +30,11 @@ case class PackageCoordinate(module: String, packages: List[String]) {
 }
 
 object PackageCoordinate extends Ordering[PackageCoordinate] {
-  val TEST_TLD = PackageCoordinate("test", List())
+  val TEST_TLD = PackageCoordinate("test", List.empty)
 
-  val BUILTIN = PackageCoordinate("", List())
+  val BUILTIN = PackageCoordinate("", List.empty)
 
-  val internal = PackageCoordinate("", List())
+  val internal = PackageCoordinate("", List.empty)
 
   override def compare(a: PackageCoordinate, b: PackageCoordinate):Int = {
     val lenDiff = a.packages.length - b.packages.length
@@ -56,14 +56,14 @@ object PackageCoordinate extends Ordering[PackageCoordinate] {
 object FileCoordinateMap {
   val TEST_MODULE = "test"
   def test[T](contents: T): FileCoordinateMap[T] = {
-    FileCoordinateMap(Map()).add(TEST_MODULE, List(), "test.vale", contents)
+    FileCoordinateMap(Map()).add(TEST_MODULE, List.empty, "test.vale", contents)
   }
   def test[T](contents: List[T]): FileCoordinateMap[T] = {
     test(contents.zipWithIndex.map({ case (code, index) => (index + ".vale", code) }).toMap)
   }
   def test[T](contents: Map[String, T]): FileCoordinateMap[T] = {
     contents.foldLeft(FileCoordinateMap[T](Map()))({
-      case (prev, (filename, c)) => prev.add(TEST_MODULE, List(), filename, c)
+      case (prev, (filename, c)) => prev.add(TEST_MODULE, List.empty, filename, c)
     })
   }
 }
@@ -216,7 +216,7 @@ case class PackageCoordinateMap[Contents](
   }
 
   def test[T](contents: T): PackageCoordinateMap[T] = {
-    PackageCoordinateMap(Map()).add("test", List(), contents)
+    PackageCoordinateMap(Map()).add("test", List.empty, contents)
   }
 
   def expectOne(): Contents = {

--- a/Valestrom/Utils/src/net/verdagon/vale/Profiler.scala
+++ b/Valestrom/Utils/src/net/verdagon/vale/Profiler.scala
@@ -103,7 +103,7 @@ class Profiler extends IProfiler {
         FinishedFrame(newProfile.currentFrame.timer.nanosecondsSoFar, newProfile.currentFrame.children.toMap))
 
     // Don't add it to the parent frame's children, instead add it to the profiles list
-    var profilesWithThisName = profiles.getOrElse(profileName, List())
+    var profilesWithThisName = profiles.getOrElse(profileName, List.empty)
     profilesWithThisName = finishedProfileRootFrame :: profilesWithThisName
     profiles += (profileName -> profilesWithThisName)
 
@@ -126,7 +126,7 @@ class Profiler extends IProfiler {
     val finishedFrame = FinishedFrame(newFrame.timer.nanosecondsSoFar, newFrame.children.toMap)
 
     // Add it to the parent frame's children
-    var childFramesWithThisName = parentFrame.children.getOrElse(frameName, List())
+    var childFramesWithThisName = parentFrame.children.getOrElse(frameName, List.empty)
     childFramesWithThisName = finishedFrame :: childFramesWithThisName
     parentFrame.children += (frameName -> childFramesWithThisName)
 

--- a/Valestrom/Vivem/src/net/verdagon/vale/vivem/ExpressionVivem.scala
+++ b/Valestrom/Vivem/src/net/verdagon/vale/vivem/ExpressionVivem.scala
@@ -17,7 +17,7 @@ object ExpressionVivem {
   def makeVoid(programH: ProgramH, heap: Heap, callId: CallId) = {
     val emptyPackStructRefH = ProgramH.emptyTupleStructRef
     val emptyPackStructDefH = programH.lookupStruct(emptyPackStructRefH)
-    val void = heap.newStruct(emptyPackStructDefH, ReferenceH(ShareH, InlineH, ReadonlyH, emptyPackStructRefH), List())
+    val void = heap.newStruct(emptyPackStructDefH, ReferenceH(ShareH, InlineH, ReadonlyH, emptyPackStructRefH), List.empty)
     heap.incrementReferenceRefCount(RegisterToObjectReferrer(callId, ShareH), void)
     void
   }

--- a/Valestrom/Vivem/src/net/verdagon/vale/vivem/FunctionVivem.scala
+++ b/Valestrom/Vivem/src/net/verdagon/vale/vivem/FunctionVivem.scala
@@ -31,7 +31,7 @@ object FunctionVivem {
 
     heap.vivemDout.println()
 
-    val rootExpressionId = ExpressionId(callId, List())
+    val rootExpressionId = ExpressionId(callId, List.empty)
     val returnRef =
       ExpressionVivem.executeNode(programH, stdin, stdout, heap, rootExpressionId, functionH.body) match {
         case NodeReturn(r) => NodeReturn(r)

--- a/Valestrom/Vivem/src/net/verdagon/vale/vivem/Heap.scala
+++ b/Valestrom/Vivem/src/net/verdagon/vale/vivem/Heap.scala
@@ -35,7 +35,7 @@ class AdapterForExterns(
   def makeVoid(): ReferenceV = {
     val emptyPackStructRefH = ProgramH.emptyTupleStructRef
     val emptyPackStructDefH = programH.lookupStruct(emptyPackStructRefH)
-    heap.newStruct(emptyPackStructDefH, ReferenceH(ShareH, InlineH, ReadonlyH, emptyPackStructRefH), List())
+    heap.newStruct(emptyPackStructDefH, ReferenceH(ShareH, InlineH, ReadonlyH, emptyPackStructRefH), List.empty)
   }
 }
 

--- a/Valestrom/Vivem/src/net/verdagon/vale/vivem/Vivem.scala
+++ b/Valestrom/Vivem/src/net/verdagon/vale/vivem/Vivem.scala
@@ -75,7 +75,7 @@ object Vivem {
       programH.packages.flatMap({ case (packageCoord, paackage) =>
         paackage.exportNameToFunction.get("main").map(prototype => paackage.functions.find(_.prototype == prototype).get).toList
       }).flatten match {
-        case List() => vfail()
+        case Nil=> vfail()
         case List(m) => m
         case _ => vfail()
       }

--- a/Valestrom/Vivem/test/net/verdagon/vale/vivem/VivemTests.scala
+++ b/Valestrom/Vivem/test/net/verdagon/vale/vivem/VivemTests.scala
@@ -14,7 +14,7 @@ class VivemTests extends FunSuite with Matchers {
             "main",
             0,
             PackageCoordinate.TEST_TLD,
-            List(VonObject("F",None,Vector(VonMember("humanName",VonStr("main")), VonMember("templateArgs",VonArray(None,Vector())), VonMember("parameters",VonArray(None,Vector())))))),List(),ReferenceH(m.ShareH,InlineH,ReadonlyH,IntH.i32)),
+            List(VonObject("F",None,Vector(VonMember("humanName",VonStr("main")), VonMember("templateArgs",VonArray(None,Vector())), VonMember("parameters",VonArray(None,Vector())))))),List.empty,ReferenceH(m.ShareH,InlineH,ReadonlyH,IntH.i32)),
         true,
         false,
         false,
@@ -23,7 +23,7 @@ class VivemTests extends FunSuite with Matchers {
     val programH =
       ProgramH(
         PackageCoordinateMap(Map())
-          .add(PackageCoordinate.TEST_TLD, PackageH(List(), List(), List(main), List(), List(), Map(), Map("main" -> main.prototype), Map(), Map(), Map())))
+          .add(PackageCoordinate.TEST_TLD, PackageH(List.empty, List.empty, List(main), List.empty, List.empty, Map(), Map("main" -> main.prototype), Map(), Map(), Map())))
     val result =
       Vivem.executeWithPrimitiveArgs(programH, Vector(), System.out, Vivem.emptyStdin, Vivem.nullStdout)
     result shouldEqual VonInt(7)
@@ -49,7 +49,7 @@ class VivemTests extends FunSuite with Matchers {
             "main",
             0,
             PackageCoordinate.TEST_TLD,
-            List(VonObject("F",None,Vector(VonMember("humanName",VonStr("main")), VonMember("templateArgs",VonArray(None,Vector())), VonMember("parameters",VonArray(None,Vector())))))),List(),ReferenceH(m.ShareH,InlineH,ReadonlyH,IntH.i32)),
+            List(VonObject("F",None,Vector(VonMember("humanName",VonStr("main")), VonMember("templateArgs",VonArray(None,Vector())), VonMember("parameters",VonArray(None,Vector())))))),List.empty,ReferenceH(m.ShareH,InlineH,ReadonlyH,IntH.i32)),
         true,
         false,
         false,
@@ -70,13 +70,13 @@ class VivemTests extends FunSuite with Matchers {
         false,
         false,
         true,
-        List(),
+        List.empty,
         BlockH(ConstantIntH(133337, 32)))
     val programH =
       ProgramH(
         PackageCoordinateMap(Map())
-          .add(PackageCoordinate.BUILTIN, PackageH(List(), List(), List(addExtern), List(), List(), Map(), Map(), Map(), Map("__addI32" -> addPrototype), Map()))
-          .add(PackageCoordinate.TEST_TLD, PackageH(List(), List(), List(main), List(), List(), Map(), Map("main" -> main.prototype), Map(), Map(), Map())))
+          .add(PackageCoordinate.BUILTIN, PackageH(List.empty, List.empty, List(addExtern), List.empty, List.empty, Map(), Map(), Map(), Map("__addI32" -> addPrototype), Map()))
+          .add(PackageCoordinate.TEST_TLD, PackageH(List.empty, List.empty, List(main), List.empty, List.empty, Map(), Map("main" -> main.prototype), Map(), Map(), Map())))
     val result =
       Vivem.executeWithPrimitiveArgs(programH, Vector(), System.out, Vivem.emptyStdin, Vivem.nullStdout)
     result shouldEqual VonInt(159)


### PR DESCRIPTION
Replaced all List() construction with List.empty as a small speedup. Also empty list match clauses were transformed from List() to Nil, for same reasons. This PR should make the codebase more idiomatic and hopefully a tiny tiny tiny tiny bit faster