### PR TITLE
.github/ci.yml: add in CI for Ubuntu

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -27,7 +27,12 @@ jobs:
 
   build_and_test_ubuntu:
     runs-on: ubuntu-latest
-    steps: *steps
+    steps: 
+      - uses: actions/checkout@v2
+      - name: install prereqs
+        run: ./install-compiler-prereqs-linux.sh ~/ValeLLVM ~/ValeCompiler-0.1.3.3-Ubuntu
+      - name: build compiler 
+        run: ./build-compiler-linux.sh ~/ValeLLVM/clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-20.10 ~/ValeCompiler-0.1.3.3-Ubuntu
 
   build_and_test_mac:
     runs-on: macos-latest

--- a/.github/gwp.py
+++ b/.github/gwp.py
@@ -53,13 +53,13 @@ def main():
         if not args.dry_run:
             for workflow_file, outfile in zip(workflow_files, outfiles):
                 os.system(
-                    "yq e \""
-                    "explode(.) | "
-                    "del(.anchors) | "
-                    ". headComment="
-                    "\"\"Do_not_edit_directly."
-                    "_See_readme_section_editing_github_workflows\"\""
-                    "\""
+                    r'yq e "'
+                    r"explode(.) | "
+                    r"del(.anchors) | "
+                    r". headComment="
+                    r'\"Do_not_edit_directly.'
+                    r'_See_readme_section_editing_github_workflows\"'
+                    r'"'
                     f" {workflow_file} > {github_dir}\\workflows\\{outfile}")
 
 

--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -21,8 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: stub
-        run: echo stubbed out for now
+      - name: install prereqs
+        run: ./install-compiler-prereqs-linux.sh ~/ValeLLVM ~/ValeCompiler-0.1.3.3-Ubuntu
+      - name: build compiler
+        run: ./build-compiler-linux.sh ~/ValeLLVM/clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-20.10 ~/ValeCompiler-0.1.3.3-Ubuntu
   build_and_test_mac:
     runs-on: macos-latest
     steps:

--- a/install-compiler-prereqs-linux.sh
+++ b/install-compiler-prereqs-linux.sh
@@ -19,7 +19,9 @@ fi
 
 # Install misc dependencies
 echo "Installing dependencies..."
-sudo apt install -y curl git clang cmake zlib1g-dev
+apt install sudo
+sudo apt update -y
+sudo apt install -y software-properties-common curl git clang cmake zlib1g-dev zip unzip wget
 
 # Install Java
 echo "Installing java..."
@@ -38,7 +40,7 @@ sudo apt install -y sbt
 
 echo "Downloading and unzipping stable bootstrapping valec to $BOOTSTRAPPING_VALEC_DIR..."
 # Install stable valec, for the .vale parts of the compiler
-curl -L https://vale.dev/releases/ValeCompiler-0.1.3.3-Ubuntu.zip
+curl -L https://vale.dev/releases/ValeCompiler-0.1.3.3-Ubuntu.zip -o ValeCompiler-0.1.3.3-Ubuntu.zip
 unzip ValeCompiler-0.1.3.3-Ubuntu.zip -d $BOOTSTRAPPING_VALEC_DIR
 # Doesnt work, see https://github.com/ValeLang/Vale/issues/306
 # echo 'export PATH=$PATH:~/ValeCompiler-0.1.3.3-Ubuntu' >> ~/.bashrc


### PR DESCRIPTION
- install-compiler-prereqs-linux.sh: deps and minor fixes
	- Make sure some deps are installed. Turns out that ubuntu:20.04
	  docker image, at least, is really bare:
		- sudo
		- software-properties-common
		- zip
		- unzip
		- wget
- install-compiler-prereqs-linux.sh: add -o when doing curl for vale
  compiler
- .github/gwp.py: fix for yq lexer error on ubuntu. Failed to escape
  some things correctly the first time when generating yq command